### PR TITLE
Add regression tests for question pages

### DIFF
--- a/lib/smart_answer_test_helper.rb
+++ b/lib/smart_answer_test_helper.rb
@@ -76,8 +76,8 @@ class SmartAnswerTestHelper
     artefacts_path.join(@flow_name)
   end
 
-  def save_output(responses, response)
-    filename = responses.pop + '.txt'
+  def save_output(responses, response, extension: 'txt')
+    filename = "#{responses.pop}.#{extension}"
     path_to_output_directory = path_to_outputs_for_flow.join(*responses)
     FileUtils.mkdir_p(path_to_output_directory)
     path_to_output_file = path_to_output_directory.join(filename)

--- a/test/artefacts/additional-commodity-code/0.html
+++ b/test/artefacts/additional-commodity-code/0.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much sucrose, invert sugar or isoglucose does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0 - 4.99
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="5" />
+          5 - 29.99
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="30" />
+          30 - 49.99
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="50" />
+          50 - 69.99
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="70" />
+          70 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/0/0.html
+++ b/test/artefacts/additional-commodity-code/0/0.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/0/0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much milk fat does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0 - 1.49
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="1" />
+          1.5 - 2.99
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="3" />
+          3 - 5.99
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="6" />
+          6 - 8.99
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="9" />
+          9 - 11.99
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="12" />
+          12 - 17.99
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="18" />
+          18 - 25.99
+        </label>
+    </li>
+    <li>
+        <label for="response_7" class="selectable">
+          <input type="radio" name="response" id="response_7" value="26" />
+          26 - 39.99
+        </label>
+    </li>
+    <li>
+        <label for="response_8" class="selectable">
+          <input type="radio" name="response" id="response_8" value="40" />
+          40 - 54.99
+        </label>
+    </li>
+    <li>
+        <label for="response_9" class="selectable">
+          <input type="radio" name="response" id="response_9" value="55" />
+          55 - 69.99
+        </label>
+    </li>
+    <li>
+        <label for="response_10" class="selectable">
+          <input type="radio" name="response" id="response_10" value="70" />
+          70 - 84.99
+        </label>
+    </li>
+    <li>
+        <label for="response_11" class="selectable">
+          <input type="radio" name="response" id="response_11" value="85" />
+          85 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much sucrose, invert sugar or isoglucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much sucrose, invert sugar or isoglucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/0/0/0.html
+++ b/test/artefacts/additional-commodity-code/0/0/0.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/0/0/0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much milk proteins does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0 - 2.49
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="2" />
+          2.5 - 5.99
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="6" />
+          6 - 17.99
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="18" />
+          18 - 29.99
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="30" />
+          30 - 59.99
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="60" />
+          60 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much sucrose, invert sugar or isoglucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much sucrose, invert sugar or isoglucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much milk fat does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 1.49</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0/0?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much milk fat does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/0/0/18.html
+++ b/test/artefacts/additional-commodity-code/0/0/18.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/0/0/18" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much milk proteins does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0-5.99
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="6" />
+          6 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much sucrose, invert sugar or isoglucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much sucrose, invert sugar or isoglucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much milk fat does the product contain?</td>
+      <td class="previous-question-body">
+      18 - 25.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0/0?previous_response=18">
+            Change<span class="visuallyhidden"> answer to "How much milk fat does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/0/0/3.html
+++ b/test/artefacts/additional-commodity-code/0/0/3.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/0/0/3" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much milk proteins does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0-2.49
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="2" />
+          2.5-11.99
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="12" />
+          12 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much sucrose, invert sugar or isoglucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much sucrose, invert sugar or isoglucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much milk fat does the product contain?</td>
+      <td class="previous-question-body">
+      3 - 5.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0/0?previous_response=3">
+            Change<span class="visuallyhidden"> answer to "How much milk fat does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/0/0/6.html
+++ b/test/artefacts/additional-commodity-code/0/0/6.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/0/0/6" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much milk proteins does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0-3.99
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="4" />
+          4-14.99
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="15" />
+          15 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much sucrose, invert sugar or isoglucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much sucrose, invert sugar or isoglucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much milk fat does the product contain?</td>
+      <td class="previous-question-body">
+      6 - 8.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0/0?previous_response=6">
+            Change<span class="visuallyhidden"> answer to "How much milk fat does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/0/0/9.html
+++ b/test/artefacts/additional-commodity-code/0/0/9.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/0/0/9" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much milk proteins does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0-5.99
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="6" />
+          6-17.99
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="18" />
+          18 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much sucrose, invert sugar or isoglucose does the product contain?</td>
+      <td class="previous-question-body">
+      0 - 4.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "How much sucrose, invert sugar or isoglucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much milk fat does the product contain?</td>
+      <td class="previous-question-body">
+      9 - 11.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y/0/0?previous_response=9">
+            Change<span class="visuallyhidden"> answer to "How much milk fat does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/25.html
+++ b/test/artefacts/additional-commodity-code/25.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/25" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much sucrose, invert sugar or isoglucose does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0 - 4.99
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="5" />
+          5 - 29.99
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="30" />
+          30 - 49.99
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="50" />
+          50 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      25 - 49.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/50.html
+++ b/test/artefacts/additional-commodity-code/50.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/50" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much sucrose, invert sugar or isoglucose does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0 - 4.99
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="5" />
+          5 - 29.99
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="30" />
+          30 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      50 - 74.99</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=50">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/75.html
+++ b/test/artefacts/additional-commodity-code/75.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y/75" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much sucrose, invert sugar or isoglucose does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0 - 4.99
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="5" />
+          5 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/additional-commodity-code">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">How much starch or glucose does the product contain?</td>
+      <td class="previous-question-body">
+      75 or more</td>
+
+      <td class="link-right">
+          <a href="/additional-commodity-code/y?previous_response=75">
+            Change<span class="visuallyhidden"> answer to "How much starch or glucose does the product contain?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/additional-commodity-code/y.html
+++ b/test/artefacts/additional-commodity-code/y.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Look up Meursing code - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Look up Meursing code
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/additional-commodity-code/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much starch or glucose does the product contain?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The values represent % by weight</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          0 - 4.99
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="5" />
+          5 - 24.99
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="25" />
+          25 - 49.99
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="50" />
+          50 - 74.99
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="75" />
+          75 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you an apprentice?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you’re 19 or over and past your first year you don’t count as an apprentice for minimum wage purposes.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="not_an_apprentice" />
+          Not an apprentice
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="apprentice_under_19" />
+          Apprentice under 19
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="apprentice_over_19_first_year" />
+          Apprentice aged 19 and over in your first year
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="apprentice_over_19_second_year_onwards" />
+          Apprentice 19 and over in your second year or onwards
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old are you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years old</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Are you an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you get paid?
+  </h2>
+  <div class="question-body">
+      <p>This is your pay period.</p>
+
+
+      <p class="hint">You get paid every
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />days</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Are you an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old are you?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old are you?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours do you work during the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Don’t include any overtime or other extra hours you might work.
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />hours</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Are you an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old are you?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you get paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much does your employer charge for accommodation per day?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Are you an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old are you?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours do you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you get paid before tax in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you get paid before tax in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime do you work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employer provide you with accommodation?</td>
+      <td class="previous-question-body">
+      Yes, the accommodation is charged for</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0?previous_response=yes_charged">
+            Change<span class="visuallyhidden"> answer to "Does your employer provide you with accommodation?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many days per week do you live in the accommodation?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />days per week</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Are you an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old are you?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours do you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you get paid before tax in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you get paid before tax in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime do you work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employer provide you with accommodation?</td>
+      <td class="previous-question-body">
+      Yes, the accommodation is free</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0?previous_response=yes_free">
+            Change<span class="visuallyhidden"> answer to "Does your employer provide you with accommodation?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does your employer provide you with accommodation?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="no" />
+          No
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="yes_free" />
+          Yes, the accommodation is free
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="yes_charged" />
+          Yes, the accommodation is charged for
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Are you an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old are you?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours do you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you get paid before tax in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you get paid before tax in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime do you work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0/8.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you get paid for overtime per hour?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Are you an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old are you?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours do you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you get paid before tax in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you get paid before tax in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime do you work during the pay period?</td>
+      <td class="previous-question-body">
+      8.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0?previous_response=8.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0/100.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours of overtime do you work during the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you don’t work overtime enter 0</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />hours</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Are you an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old are you?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours do you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you get paid before tax in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you get paid before tax in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1/16.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you get paid before tax in the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Don’t include payments for overtime or anything extra to your pay, eg money for clothes or goods.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you&#39;re getting the National Minimum Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Are you an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old are you?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours do you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours do you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which year would you like to check past payments for?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You can go back up to 6 years</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="2013-10-01" />
+          Oct 2013 - Sep 2014
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="2012-10-01" />
+          Oct 2012 - Sep 2013
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="2011-10-01" />
+          Oct 2011 - Sep 2012
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="2010-10-01" />
+          Oct 2010 - Sep 2011
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="2009-10-01" />
+          Oct 2009 - Sep 2010
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="2008-10-01" />
+          Oct 2008 - Sep 2009
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Were you an apprentice at the time?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="no" />
+          No
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="apprentice_under_19" />
+          Apprentice under 19
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="apprentice_over_19" />
+          Apprentice aged 19 and over and in your first year
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old were you at the time?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years old</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often did you get paid?
+  </h2>
+  <div class="question-body">
+      <p>This is your pay period.</p>
+
+
+      <p class="hint">You get paid every
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />days</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old were you at the time?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours did you work during the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Don’t include any overtime or other extra hours you worked.
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />hours</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old were you at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you get paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_charged" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much did your employer charge for accommodation per day?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old were you at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much were you paid in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much were you paid in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime did you work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employer provide you with accommodation?</td>
+      <td class="previous-question-body">
+      Yes, the accommodation was charged for</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0?previous_response=yes_charged">
+            Change<span class="visuallyhidden"> answer to "Did your employer provide you with accommodation?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_free.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_free.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_free" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many days per week did you live in the accommodation?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />days per week</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old were you at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much were you paid in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much were you paid in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime did you work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employer provide you with accommodation?</td>
+      <td class="previous-question-body">
+      Yes, the accommodation was free</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0?previous_response=yes_free">
+            Change<span class="visuallyhidden"> answer to "Did your employer provide you with accommodation?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.0/0.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.0/0.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did your employer provide you with accommodation?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="no" />
+          No
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="yes_free" />
+          Yes, the accommodation was free
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="yes_charged" />
+          Yes, the accommodation was charged for
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old were you at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much were you paid in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much were you paid in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime did you work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.0/8.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.0/8.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0/8.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much did you get paid for overtime per hour?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old were you at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much were you paid in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much were you paid in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime did you work during the pay period?</td>
+      <td class="previous-question-body">
+      8.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0?previous_response=8.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.0/100.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0/100.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours of overtime did you work during the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you didn’t work overtime enter 0</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />hours</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old were you at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much were you paid in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much were you paid in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2013-10-01/no/25/1/16.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1/16.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much were you paid in the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Don’t include payments for overtime or anything extra to your pay, eg money for clothes or goods.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If an employer owes you past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old were you at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you get paid?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you get paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did you work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/am-i-getting-minimum-wage/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did you work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/am-i-getting-minimum-wage/y.html
+++ b/test/artefacts/am-i-getting-minimum-wage/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for workers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for workers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/am-i-getting-minimum-wage/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What would you like to check?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="current_payment" />
+          If you&#39;re getting the National Minimum Wage (from October 2014)
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="past_payment" />
+          If an employer owes you past payments (before October 2014)
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/apply-tier-4-visa/extend_general.html
+++ b/test/artefacts/apply-tier-4-visa/extend_general.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Apply to extend or switch to a Tier 4 visa - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Apply to extend or switch to a Tier 4 visa
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/apply-tier-4-visa/y/extend_general" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your Tier 4 sponsor number?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You can find your sponsor number on your certificate of acceptance for studies (CAS).</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/apply-tier-4-visa">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you:</td>
+      <td class="previous-question-body">
+      extending your Tier 4 (General) student visa</td>
+
+      <td class="link-right">
+          <a href="/apply-tier-4-visa/y?previous_response=extend_general">
+            Change<span class="visuallyhidden"> answer to "Are you:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/apply-tier-4-visa/y.html
+++ b/test/artefacts/apply-tier-4-visa/y.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Apply to extend or switch to a Tier 4 visa - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Apply to extend or switch to a Tier 4 visa
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/apply-tier-4-visa/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="extend_general" />
+          extending your Tier 4 (General) student visa
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="switch_general" />
+          switching to the Tier 4 (General) student visa
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="extend_child" />
+          extending your Tier 4 (Child) student visa
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="switch_child" />
+          switching to the Tier 4 (Child) student visa
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/y.html
+++ b/test/artefacts/benefit-cap-calculator/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you receive Housing Benefit?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes.html
+++ b/test/artefacts/benefit-cap-calculator/yes.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you qualify for Working Tax Credit?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You don&#39;t need to be getting Working Tax Credit, only qualify for it.</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you or someone in your household get any of the following benefits:
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>Attendance Allowance</li>
+  <li>Disability Living Allowance</li>
+  <li>Industrial Injuries Benefit</li>
+  <li>Personal Independence Payment</li>
+  <li>Employment and Support Allowance (support component)</li>
+  <li>War Widow’s or War Widower’s Pension</li>
+  <li>Armed Forces Compensation Scheme</li>
+  <li>Armed Forces Independence Payment</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you or someone in your household get any of the following benefits:
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you do not receive any of these click Next step.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="bereavement" />
+        Bereavement Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="carers" />
+        Carer&#39;s Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="child_benefit" />
+        Child Benefit
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="child_tax" />
+        Child Tax Credit
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="esa" />
+        Employment and Support Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_5">
+        <input type="checkbox" name="response[]" id="response_5" value="guardian" />
+        Guardian&#39;s Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_6">
+        <input type="checkbox" name="response[]" id="response_6" value="incapacity" />
+        Incapacity Benefit
+      </label>
+    </li>
+    <li>
+      <label for="response_7">
+        <input type="checkbox" name="response[]" id="response_7" value="income_support" />
+        Income Support
+      </label>
+    </li>
+    <li>
+      <label for="response_8">
+        <input type="checkbox" name="response[]" id="response_8" value="jsa" />
+        Jobseeker’s Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_9">
+        <input type="checkbox" name="response[]" id="response_9" value="maternity" />
+        Maternity Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_10">
+        <input type="checkbox" name="response[]" id="response_10" value="sda" />
+        Severe Disablement Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_11">
+        <input type="checkbox" name="response[]" id="response_11" value="widowed_mother" />
+        Widowed Mother&#39;s Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_12">
+        <input type="checkbox" name="response[]" id="response_12" value="widowed_parent" />
+        Widowed Parent&#39;s Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_13">
+        <input type="checkbox" name="response[]" id="response_13" value="widow_pension" />
+        Widow&#39;s Pension
+      </label>
+    </li>
+    <li>
+      <label for="response_14">
+        <input type="checkbox" name="response[]" id="response_14" value="widows_aged" />
+        Widow&#39;s Pension (age related)
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Widow&#39;s Pension (age related)?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Guardian&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Guardian&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Incapacity Benefit?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Incapacity Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Income Support?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Income Support?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Jobseeker’s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Jobseeker’s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Maternity Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Maternity Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Severe Disability Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Severe Disability Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Widow&#39;s Pension?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Widow&#39;s Pension?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Widowed Mother&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Widowed Mother&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Widowed Parent&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Widowed Parent&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Widowed Parent&#39;s Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Guardian&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Guardian&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Incapacity Benefit?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Incapacity Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Income Support?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Income Support?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Jobseeker’s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Jobseeker’s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Maternity Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Maternity Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Severe Disability Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Severe Disability Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Widow&#39;s Pension?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Widow&#39;s Pension?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Widowed Mother&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Widowed Mother&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Widowed Mother&#39;s Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Guardian&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Guardian&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Incapacity Benefit?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Incapacity Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Income Support?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Income Support?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Jobseeker’s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Jobseeker’s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Maternity Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Maternity Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Severe Disability Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Severe Disability Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Widow&#39;s Pension?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Widow&#39;s Pension?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Widow&#39;s Pension?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Guardian&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Guardian&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Incapacity Benefit?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Incapacity Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Income Support?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Income Support?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Jobseeker’s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Jobseeker’s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Maternity Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Maternity Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Severe Disability Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Severe Disability Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Severe Disability Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Guardian&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Guardian&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Incapacity Benefit?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Incapacity Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Income Support?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Income Support?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Jobseeker’s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Jobseeker’s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Maternity Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Maternity Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Maternity Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Guardian&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Guardian&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Incapacity Benefit?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Incapacity Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Income Support?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Income Support?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Jobseeker’s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Jobseeker’s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Jobseeker’s Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Guardian&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Guardian&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Incapacity Benefit?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Incapacity Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Income Support?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Income Support?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Income Support?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Guardian&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Guardian&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Incapacity Benefit?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Incapacity Benefit?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Incapacity Benefit?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Guardian&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Guardian&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Guardian&#39;s Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Employment and Support Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Employment and Support Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Employment and Support Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Tax Credits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Tax Credits?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Child Tax Credits?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Child Benefits?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Child Benefits?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Child Benefits?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Carer&#39;s Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Carer&#39;s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Carer&#39;s Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+        <li>Carer&#39;s Allowance</li>
+        <li>Child Benefit</li>
+        <li>Child Tax Credit</li>
+        <li>Employment and Support Allowance</li>
+        <li>Guardian&#39;s Allowance</li>
+        <li>Incapacity Benefit</li>
+        <li>Income Support</li>
+        <li>Jobseeker’s Allowance</li>
+        <li>Maternity Allowance</li>
+        <li>Severe Disablement Allowance</li>
+        <li>Widow&#39;s Pension</li>
+        <li>Widowed Mother&#39;s Allowance</li>
+        <li>Widowed Parent&#39;s Allowance</li>
+        <li>Widow&#39;s Pension (age related)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement%2Ccarers%2Cchild_benefit%2Cchild_tax%2Cesa%2Cguardian%2Cincapacity%2Cincome_support%2Cjsa%2Cmaternity%2Csda%2Cwidow_pension%2Cwidowed_mother%2Cwidowed_parent%2Cwidows_aged">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Bereavement Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement/50.0/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="single" />
+          Single
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="couple" />
+          Living as a couple (with or without children)
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="parent" />
+          A lone parent with 1 or more dependent children
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Housing Benefit?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement/50.0?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Benefit cap calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Benefit cap calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/benefit-cap-calculator/y/yes/no/no/bereavement/50.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you or someone in your household get for Housing Benefit?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/benefit-cap-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you receive Housing Benefit?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you receive Housing Benefit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you qualify for Working Tax Credit?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you qualify for Working Tax Credit?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you or someone in your household get any of the following benefits:</td>
+      <td class="previous-question-body"><ul>
+        <li>Bereavement Allowance</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no?previous_response=bereavement">
+            Change<span class="visuallyhidden"> answer to "Do you or someone in your household get any of the following benefits:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you or someone in your household get for Bereavement Allowance?</td>
+      <td class="previous-question-body">
+      £50</td>
+
+      <td class="link-right">
+          <a href="/benefit-cap-calculator/y/yes/no/no/bereavement?previous_response=50.0">
+            Change<span class="visuallyhidden"> answer to "How much do you or someone in your household get for Bereavement Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/different-number-of-days.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/different-number-of-days.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your agricultural worker holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your agricultural worker holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-agricultural-holiday-entitlement/y/different-number-of-days" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What date will your holiday start?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This is the first day that you will take off work as leave</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-agricultural-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you work the same number of days each week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-agricultural-holiday-entitlement/y?previous_response=different-number-of-days">
+            Change<span class="visuallyhidden"> answer to "Do you work the same number of days each week?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/different-number-of-days/2015-02-01.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/different-number-of-days/2015-02-01.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your agricultural worker holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your agricultural worker holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-agricultural-holiday-entitlement/y/different-number-of-days/2015-02-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many days will you have worked between 1 October (the start of the leave year) and the start of your holiday?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This includes any days that you worked basic hours, took annual leave or were off sick (whether paid or not).
+</p>
+
+    <div class="">
+
+      <label for="response">Total days worked for current employer<input type="text" name="response" id="response" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-agricultural-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you work the same number of days each week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-agricultural-holiday-entitlement/y?previous_response=different-number-of-days">
+            Change<span class="visuallyhidden"> answer to "Do you work the same number of days each week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What date will your holiday start?</td>
+      <td class="previous-question-body">
+       1 February 2015</td>
+
+      <td class="link-right">
+          <a href="/calculate-agricultural-holiday-entitlement/y/different-number-of-days?previous_response=2015-02-01">
+            Change<span class="visuallyhidden"> answer to "What date will your holiday start?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your agricultural worker holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your agricultural worker holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-agricultural-holiday-entitlement/y/same-number-of-days" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many days do you work per week?
+  </h2>
+  <div class="question-body">
+      <p>Include guaranteed overtime hours if:</p>
+
+<ul>
+  <li>you have to work them as part of your contract</li>
+  <li>you&rsquo;re paid for the time even if there’s no work for you to do</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="7-days" />
+          7 days per week
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="6-days" />
+          6 days per week
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="5-days" />
+          5 days per week
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="4-days" />
+          4 days per week
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="3-days" />
+          3 days per week
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="2-days" />
+          2 days per week
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="1-day" />
+          1 day per week
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-agricultural-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you work the same number of days each week?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-agricultural-holiday-entitlement/y?previous_response=same-number-of-days">
+            Change<span class="visuallyhidden"> answer to "Do you work the same number of days each week?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days/7-days.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days/7-days.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your agricultural worker holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your agricultural worker holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-agricultural-holiday-entitlement/y/same-number-of-days/7-days" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Have you worked for the same employer for a full year?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="same-employer" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="multiple-employers" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-agricultural-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you work the same number of days each week?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-agricultural-holiday-entitlement/y?previous_response=same-number-of-days">
+            Change<span class="visuallyhidden"> answer to "Do you work the same number of days each week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many days do you work per week?</td>
+      <td class="previous-question-body">
+      7 days per week</td>
+
+      <td class="link-right">
+          <a href="/calculate-agricultural-holiday-entitlement/y/same-number-of-days?previous_response=7-days">
+            Change<span class="visuallyhidden"> answer to "How many days do you work per week?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days/7-days/multiple-employers.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days/7-days/multiple-employers.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your agricultural worker holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your agricultural worker holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-agricultural-holiday-entitlement/y/same-number-of-days/7-days/multiple-employers" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many weeks have you worked continuously for your current employer?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response">Weeks worked at current employer<input type="text" name="response" id="response" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-agricultural-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you work the same number of days each week?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-agricultural-holiday-entitlement/y?previous_response=same-number-of-days">
+            Change<span class="visuallyhidden"> answer to "Do you work the same number of days each week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many days do you work per week?</td>
+      <td class="previous-question-body">
+      7 days per week</td>
+
+      <td class="link-right">
+          <a href="/calculate-agricultural-holiday-entitlement/y/same-number-of-days?previous_response=7-days">
+            Change<span class="visuallyhidden"> answer to "How many days do you work per week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you worked for the same employer for a full year?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-agricultural-holiday-entitlement/y/same-number-of-days/7-days?previous_response=multiple-employers">
+            Change<span class="visuallyhidden"> answer to "Have you worked for the same employer for a full year?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/y.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your agricultural worker holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your agricultural worker holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-agricultural-holiday-entitlement/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you work the same number of days each week?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="same-number-of-days" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="different-number-of-days" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory redundancy pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory redundancy pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-employee-redundancy-pay/y/2012-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old was your employee on the date they were made redundant?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years old</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-employee-redundancy-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What date was your employee made redundant?</td>
+      <td class="previous-question-body">
+       1 January 2012</td>
+
+      <td class="link-right">
+          <a href="/calculate-employee-redundancy-pay/y?previous_response=2012-01-01">
+            Change<span class="visuallyhidden"> answer to "What date was your employee made redundant?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory redundancy pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory redundancy pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-employee-redundancy-pay/y/2012-01-01/21" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Number of years they’ve worked for you
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Only count full years of service. For example, 3 years and 9 months count as 3 years.
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />full years worked</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-employee-redundancy-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What date was your employee made redundant?</td>
+      <td class="previous-question-body">
+       1 January 2012</td>
+
+      <td class="link-right">
+          <a href="/calculate-employee-redundancy-pay/y?previous_response=2012-01-01">
+            Change<span class="visuallyhidden"> answer to "What date was your employee made redundant?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was your employee on the date they were made redundant?</td>
+      <td class="previous-question-body">
+      21</td>
+
+      <td class="link-right">
+          <a href="/calculate-employee-redundancy-pay/y/2012-01-01?previous_response=21">
+            Change<span class="visuallyhidden"> answer to "How old was your employee on the date they were made redundant?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21/3.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21/3.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory redundancy pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory redundancy pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-employee-redundancy-pay/y/2012-01-01/21/3.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is their weekly pay before tax and any other deductions?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Examples of other deductions include student loans and child maintenance.
+</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per week</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-employee-redundancy-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What date was your employee made redundant?</td>
+      <td class="previous-question-body">
+       1 January 2012</td>
+
+      <td class="link-right">
+          <a href="/calculate-employee-redundancy-pay/y?previous_response=2012-01-01">
+            Change<span class="visuallyhidden"> answer to "What date was your employee made redundant?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was your employee on the date they were made redundant?</td>
+      <td class="previous-question-body">
+      21</td>
+
+      <td class="link-right">
+          <a href="/calculate-employee-redundancy-pay/y/2012-01-01?previous_response=21">
+            Change<span class="visuallyhidden"> answer to "How old was your employee on the date they were made redundant?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Number of years they’ve worked for you</td>
+      <td class="previous-question-body">
+      3.0</td>
+
+      <td class="link-right">
+          <a href="/calculate-employee-redundancy-pay/y/2012-01-01/21?previous_response=3.0">
+            Change<span class="visuallyhidden"> answer to "Number of years they’ve worked for you"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-employee-redundancy-pay/y.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/y.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory redundancy pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory redundancy pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-employee-redundancy-pay/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What date was your employee made redundant?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Use the original redundancy date even if their notice is brought forward, they’re paid in lieu of notice or made redundant after trialing a new job.
+</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/y.html
+++ b/test/artefacts/calculate-married-couples-allowance/y.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Were you or your partner born before 6 April 1935?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You must be married or in a civil partnership to qualify.</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did you marry before 5 December 2005?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Before this date the husband&#39;s income is used to work out your allowance, after this date it&#39;s the income of the highest earner.</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-married-couples-allowance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you or your partner born before 6 April 1935?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you or your partner born before 6 April 1935?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/yes/no.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/no.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y/yes/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What&#39;s the highest earner&#39;s date of birth?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">We need your date of birth to work out your personal allowance (how much of your income is tax-free).</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2015">2015</option>
+<option value="2014">2014</option>
+<option value="2013">2013</option>
+<option value="2012">2012</option>
+<option value="2011">2011</option>
+<option value="2010">2010</option>
+<option value="2009">2009</option>
+<option value="2008">2008</option>
+<option value="2007">2007</option>
+<option value="2006">2006</option>
+<option value="2005">2005</option>
+<option value="2004">2004</option>
+<option value="2003">2003</option>
+<option value="2002">2002</option>
+<option value="2001">2001</option>
+<option value="2000">2000</option>
+<option value="1999">1999</option>
+<option value="1998">1998</option>
+<option value="1997">1997</option>
+<option value="1996">1996</option>
+<option value="1995">1995</option>
+<option value="1994">1994</option>
+<option value="1993">1993</option>
+<option value="1992">1992</option>
+<option value="1991">1991</option>
+<option value="1990">1990</option>
+<option value="1989">1989</option>
+<option value="1988">1988</option>
+<option value="1987">1987</option>
+<option value="1986">1986</option>
+<option value="1985">1985</option>
+<option value="1984">1984</option>
+<option value="1983">1983</option>
+<option value="1982">1982</option>
+<option value="1981">1981</option>
+<option value="1980">1980</option>
+<option value="1979">1979</option>
+<option value="1978">1978</option>
+<option value="1977">1977</option>
+<option value="1976">1976</option>
+<option value="1975">1975</option>
+<option value="1974">1974</option>
+<option value="1973">1973</option>
+<option value="1972">1972</option>
+<option value="1971">1971</option>
+<option value="1970">1970</option>
+<option value="1969">1969</option>
+<option value="1968">1968</option>
+<option value="1967">1967</option>
+<option value="1966">1966</option>
+<option value="1965">1965</option>
+<option value="1964">1964</option>
+<option value="1963">1963</option>
+<option value="1962">1962</option>
+<option value="1961">1961</option>
+<option value="1960">1960</option>
+<option value="1959">1959</option>
+<option value="1958">1958</option>
+<option value="1957">1957</option>
+<option value="1956">1956</option>
+<option value="1955">1955</option>
+<option value="1954">1954</option>
+<option value="1953">1953</option>
+<option value="1952">1952</option>
+<option value="1951">1951</option>
+<option value="1950">1950</option>
+<option value="1949">1949</option>
+<option value="1948">1948</option>
+<option value="1947">1947</option>
+<option value="1946">1946</option>
+<option value="1945">1945</option>
+<option value="1944">1944</option>
+<option value="1943">1943</option>
+<option value="1942">1942</option>
+<option value="1941">1941</option>
+<option value="1940">1940</option>
+<option value="1939">1939</option>
+<option value="1938">1938</option>
+<option value="1937">1937</option>
+<option value="1936">1936</option>
+<option value="1935">1935</option>
+<option value="1934">1934</option>
+<option value="1933">1933</option>
+<option value="1932">1932</option>
+<option value="1931">1931</option>
+<option value="1930">1930</option>
+<option value="1929">1929</option>
+<option value="1928">1928</option>
+<option value="1927">1927</option>
+<option value="1926">1926</option>
+<option value="1925">1925</option>
+<option value="1924">1924</option>
+<option value="1923">1923</option>
+<option value="1922">1922</option>
+<option value="1921">1921</option>
+<option value="1920">1920</option>
+<option value="1919">1919</option>
+<option value="1918">1918</option>
+<option value="1917">1917</option>
+<option value="1916">1916</option>
+<option value="1915">1915</option>
+<option value="1914">1914</option>
+<option value="1913">1913</option>
+<option value="1912">1912</option>
+<option value="1911">1911</option>
+<option value="1910">1910</option>
+<option value="1909">1909</option>
+<option value="1908">1908</option>
+<option value="1907">1907</option>
+<option value="1906">1906</option>
+<option value="1905">1905</option>
+<option value="1904">1904</option>
+<option value="1903">1903</option>
+<option value="1902">1902</option>
+<option value="1901">1901</option>
+<option value="1900">1900</option>
+<option value="1899">1899</option>
+<option value="1898">1898</option>
+<option value="1897">1897</option>
+<option value="1896">1896</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-married-couples-allowance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you or your partner born before 6 April 1935?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you or your partner born before 6 April 1935?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you marry before 5 December 2005?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did you marry before 5 December 2005?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/yes/no/1955-01-01.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/no/1955-01-01.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y/yes/no/1955-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What&#39;s the highest earner&#39;s yearly income?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Add up your taxable income, eg earnings, pensions and any taxable benefits, eg Carer&#39;s Allowance.
+</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-married-couples-allowance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you or your partner born before 6 April 1935?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you or your partner born before 6 April 1935?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you marry before 5 December 2005?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did you marry before 5 December 2005?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the highest earner&#39;s date of birth?</td>
+      <td class="previous-question-body">
+       1 January 1955</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/no?previous_response=1955-01-01">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the highest earner&#39;s date of birth?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What&#39;s the husband&#39;s date of birth?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">We need your date of birth to work out your personal allowance (how much of your income is tax-free).</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2015">2015</option>
+<option value="2014">2014</option>
+<option value="2013">2013</option>
+<option value="2012">2012</option>
+<option value="2011">2011</option>
+<option value="2010">2010</option>
+<option value="2009">2009</option>
+<option value="2008">2008</option>
+<option value="2007">2007</option>
+<option value="2006">2006</option>
+<option value="2005">2005</option>
+<option value="2004">2004</option>
+<option value="2003">2003</option>
+<option value="2002">2002</option>
+<option value="2001">2001</option>
+<option value="2000">2000</option>
+<option value="1999">1999</option>
+<option value="1998">1998</option>
+<option value="1997">1997</option>
+<option value="1996">1996</option>
+<option value="1995">1995</option>
+<option value="1994">1994</option>
+<option value="1993">1993</option>
+<option value="1992">1992</option>
+<option value="1991">1991</option>
+<option value="1990">1990</option>
+<option value="1989">1989</option>
+<option value="1988">1988</option>
+<option value="1987">1987</option>
+<option value="1986">1986</option>
+<option value="1985">1985</option>
+<option value="1984">1984</option>
+<option value="1983">1983</option>
+<option value="1982">1982</option>
+<option value="1981">1981</option>
+<option value="1980">1980</option>
+<option value="1979">1979</option>
+<option value="1978">1978</option>
+<option value="1977">1977</option>
+<option value="1976">1976</option>
+<option value="1975">1975</option>
+<option value="1974">1974</option>
+<option value="1973">1973</option>
+<option value="1972">1972</option>
+<option value="1971">1971</option>
+<option value="1970">1970</option>
+<option value="1969">1969</option>
+<option value="1968">1968</option>
+<option value="1967">1967</option>
+<option value="1966">1966</option>
+<option value="1965">1965</option>
+<option value="1964">1964</option>
+<option value="1963">1963</option>
+<option value="1962">1962</option>
+<option value="1961">1961</option>
+<option value="1960">1960</option>
+<option value="1959">1959</option>
+<option value="1958">1958</option>
+<option value="1957">1957</option>
+<option value="1956">1956</option>
+<option value="1955">1955</option>
+<option value="1954">1954</option>
+<option value="1953">1953</option>
+<option value="1952">1952</option>
+<option value="1951">1951</option>
+<option value="1950">1950</option>
+<option value="1949">1949</option>
+<option value="1948">1948</option>
+<option value="1947">1947</option>
+<option value="1946">1946</option>
+<option value="1945">1945</option>
+<option value="1944">1944</option>
+<option value="1943">1943</option>
+<option value="1942">1942</option>
+<option value="1941">1941</option>
+<option value="1940">1940</option>
+<option value="1939">1939</option>
+<option value="1938">1938</option>
+<option value="1937">1937</option>
+<option value="1936">1936</option>
+<option value="1935">1935</option>
+<option value="1934">1934</option>
+<option value="1933">1933</option>
+<option value="1932">1932</option>
+<option value="1931">1931</option>
+<option value="1930">1930</option>
+<option value="1929">1929</option>
+<option value="1928">1928</option>
+<option value="1927">1927</option>
+<option value="1926">1926</option>
+<option value="1925">1925</option>
+<option value="1924">1924</option>
+<option value="1923">1923</option>
+<option value="1922">1922</option>
+<option value="1921">1921</option>
+<option value="1920">1920</option>
+<option value="1919">1919</option>
+<option value="1918">1918</option>
+<option value="1917">1917</option>
+<option value="1916">1916</option>
+<option value="1915">1915</option>
+<option value="1914">1914</option>
+<option value="1913">1913</option>
+<option value="1912">1912</option>
+<option value="1911">1911</option>
+<option value="1910">1910</option>
+<option value="1909">1909</option>
+<option value="1908">1908</option>
+<option value="1907">1907</option>
+<option value="1906">1906</option>
+<option value="1905">1905</option>
+<option value="1904">1904</option>
+<option value="1903">1903</option>
+<option value="1902">1902</option>
+<option value="1901">1901</option>
+<option value="1900">1900</option>
+<option value="1899">1899</option>
+<option value="1898">1898</option>
+<option value="1897">1897</option>
+<option value="1896">1896</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-married-couples-allowance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you or your partner born before 6 April 1935?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you or your partner born before 6 April 1935?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you marry before 5 December 2005?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did you marry before 5 December 2005?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y/yes/yes/1950-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What&#39;s the husband&#39;s yearly income?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Add up your taxable income, eg earnings, pensions and any taxable benefits, eg Carer’s Allowance.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-married-couples-allowance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you or your partner born before 6 April 1935?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you or your partner born before 6 April 1935?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you marry before 5 December 2005?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did you marry before 5 December 2005?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the husband&#39;s date of birth?</td>
+      <td class="previous-question-body">
+       1 January 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes?previous_response=1950-01-01">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the husband&#39;s date of birth?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you expect to pay into a pension where your contributions are made before tax is taken away?
+  </h2>
+  <div class="question-body">
+      <p>Enter the total you expect to pay for the whole tax year into:</p>
+
+<ul>
+  <li>pension schemes where your contributions are paid before your income is taxed (called ‘net pay arrangements’)</li>
+  <li>retirement annuity contracts (called ‘gross contributions’)</li>
+</ul>
+
+
+      <p class="hint">If none, please enter 0.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-married-couples-allowance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you or your partner born before 6 April 1935?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you or your partner born before 6 April 1935?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you marry before 5 December 2005?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did you marry before 5 December 2005?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the husband&#39;s date of birth?</td>
+      <td class="previous-question-body">
+       1 January 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes?previous_response=1950-01-01">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the husband&#39;s date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the husband&#39;s yearly income?</td>
+      <td class="previous-question-body">
+      £27,001</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01?previous_response=27001.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the husband&#39;s yearly income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you paying into a pension?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you paying into a pension?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.0/5000.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.0/5000.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0/yes/10000.0/5000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you expect to donate to charity through Gift Aid during the entire tax year?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Only enter what you pay - don’t include any tax relief. If none, please enter 0.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-married-couples-allowance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you or your partner born before 6 April 1935?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you or your partner born before 6 April 1935?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you marry before 5 December 2005?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did you marry before 5 December 2005?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the husband&#39;s date of birth?</td>
+      <td class="previous-question-body">
+       1 January 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes?previous_response=1950-01-01">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the husband&#39;s date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the husband&#39;s yearly income?</td>
+      <td class="previous-question-body">
+      £27,001</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01?previous_response=27001.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the husband&#39;s yearly income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you paying into a pension?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you paying into a pension?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you expect to pay into a pension where your contributions are made before tax is taken away?</td>
+      <td class="previous-question-body">
+      £10,000</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0/yes?previous_response=10000.0">
+            Change<span class="visuallyhidden"> answer to "How much do you expect to pay into a pension where your contributions are made before tax is taken away?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you expect to pay into a pension this tax year where your pension provider claims tax relief for you?</td>
+      <td class="previous-question-body">
+      £5,000</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0/yes/10000.0?previous_response=5000.0">
+            Change<span class="visuallyhidden"> answer to "How much do you expect to pay into a pension this tax year where your pension provider claims tax relief for you?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0/yes/10000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you expect to pay into a pension this tax year where your pension provider claims tax relief for you?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Only enter what you pay - don’t include the tax relief. If none, please enter 0.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-married-couples-allowance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you or your partner born before 6 April 1935?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you or your partner born before 6 April 1935?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you marry before 5 December 2005?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did you marry before 5 December 2005?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the husband&#39;s date of birth?</td>
+      <td class="previous-question-body">
+       1 January 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes?previous_response=1950-01-01">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the husband&#39;s date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the husband&#39;s yearly income?</td>
+      <td class="previous-question-body">
+      £27,001</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01?previous_response=27001.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the husband&#39;s yearly income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you paying into a pension?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you paying into a pension?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you expect to pay into a pension where your contributions are made before tax is taken away?</td>
+      <td class="previous-question-body">
+      £10,000</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0/yes?previous_response=10000.0">
+            Change<span class="visuallyhidden"> answer to "How much do you expect to pay into a pension where your contributions are made before tax is taken away?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your Married Couple&#39;s Allowance
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-married-couples-allowance/y/yes/yes/1950-01-01/27001.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you paying into a pension?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-married-couples-allowance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you or your partner born before 6 April 1935?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you or your partner born before 6 April 1935?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you marry before 5 December 2005?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did you marry before 5 December 2005?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the husband&#39;s date of birth?</td>
+      <td class="previous-question-body">
+       1 January 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes?previous_response=1950-01-01">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the husband&#39;s date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the husband&#39;s yearly income?</td>
+      <td class="previous-question-body">
+      £27,001</td>
+
+      <td class="link-right">
+          <a href="/calculate-married-couples-allowance/y/yes/yes/1950-01-01?previous_response=27001.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the husband&#39;s yearly income?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/age.html
+++ b/test/artefacts/calculate-state-pension/age.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/age" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you a man or a woman?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="male" />
+          Man
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="female" />
+          Woman
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      State Pension age - including pension credit age</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=age">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/age/male.html
+++ b/test/artefacts/calculate-state-pension/age/male.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/age/male" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your date of birth?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="1893">1893</option>
+<option value="1894">1894</option>
+<option value="1895">1895</option>
+<option value="1896">1896</option>
+<option value="1897">1897</option>
+<option value="1898">1898</option>
+<option value="1899">1899</option>
+<option value="1900">1900</option>
+<option value="1901">1901</option>
+<option value="1902">1902</option>
+<option value="1903">1903</option>
+<option value="1904">1904</option>
+<option value="1905">1905</option>
+<option value="1906">1906</option>
+<option value="1907">1907</option>
+<option value="1908">1908</option>
+<option value="1909">1909</option>
+<option value="1910">1910</option>
+<option value="1911">1911</option>
+<option value="1912">1912</option>
+<option value="1913">1913</option>
+<option value="1914">1914</option>
+<option value="1915">1915</option>
+<option value="1916">1916</option>
+<option value="1917">1917</option>
+<option value="1918">1918</option>
+<option value="1919">1919</option>
+<option value="1920">1920</option>
+<option value="1921">1921</option>
+<option value="1922">1922</option>
+<option value="1923">1923</option>
+<option value="1924">1924</option>
+<option value="1925">1925</option>
+<option value="1926">1926</option>
+<option value="1927">1927</option>
+<option value="1928">1928</option>
+<option value="1929">1929</option>
+<option value="1930">1930</option>
+<option value="1931">1931</option>
+<option value="1932">1932</option>
+<option value="1933">1933</option>
+<option value="1934">1934</option>
+<option value="1935">1935</option>
+<option value="1936">1936</option>
+<option value="1937">1937</option>
+<option value="1938">1938</option>
+<option value="1939">1939</option>
+<option value="1940">1940</option>
+<option value="1941">1941</option>
+<option value="1942">1942</option>
+<option value="1943">1943</option>
+<option value="1944">1944</option>
+<option value="1945">1945</option>
+<option value="1946">1946</option>
+<option value="1947">1947</option>
+<option value="1948">1948</option>
+<option value="1949">1949</option>
+<option value="1950">1950</option>
+<option value="1951">1951</option>
+<option value="1952">1952</option>
+<option value="1953">1953</option>
+<option value="1954">1954</option>
+<option value="1955">1955</option>
+<option value="1956">1956</option>
+<option value="1957">1957</option>
+<option value="1958">1958</option>
+<option value="1959">1959</option>
+<option value="1960">1960</option>
+<option value="1961">1961</option>
+<option value="1962">1962</option>
+<option value="1963">1963</option>
+<option value="1964">1964</option>
+<option value="1965">1965</option>
+<option value="1966">1966</option>
+<option value="1967">1967</option>
+<option value="1968">1968</option>
+<option value="1969">1969</option>
+<option value="1970">1970</option>
+<option value="1971">1971</option>
+<option value="1972">1972</option>
+<option value="1973">1973</option>
+<option value="1974">1974</option>
+<option value="1975">1975</option>
+<option value="1976">1976</option>
+<option value="1977">1977</option>
+<option value="1978">1978</option>
+<option value="1979">1979</option>
+<option value="1980">1980</option>
+<option value="1981">1981</option>
+<option value="1982">1982</option>
+<option value="1983">1983</option>
+<option value="1984">1984</option>
+<option value="1985">1985</option>
+<option value="1986">1986</option>
+<option value="1987">1987</option>
+<option value="1988">1988</option>
+<option value="1989">1989</option>
+<option value="1990">1990</option>
+<option value="1991">1991</option>
+<option value="1992">1992</option>
+<option value="1993">1993</option>
+<option value="1994">1994</option>
+<option value="1995">1995</option>
+<option value="1996">1996</option>
+<option value="1997">1997</option>
+<option value="1998">1998</option>
+<option value="1999">1999</option>
+<option value="2000">2000</option>
+<option value="2001">2001</option>
+<option value="2002">2002</option>
+<option value="2003">2003</option>
+<option value="2004">2004</option>
+<option value="2005">2005</option>
+<option value="2006">2006</option>
+<option value="2007">2007</option>
+<option value="2008">2008</option>
+<option value="2009">2009</option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      State Pension age - including pension credit age</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=age">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/age?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/female/1961-04-04.html
+++ b/test/artefacts/calculate-state-pension/amount/female/1961-04-04.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/female/1961-04-04" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Have you ever opted to pay the reduced National Insurance rate for married women and widows (also known as the married woman’s stamp)?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Opting to pay the reduced rate means you chose to pay a lower rate of National Insurance while you were employed or you chose not to pay Class 2 contributions while you were self-employed.
+</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Woman</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=female">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+       4 April 1961</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/female?previous_response=1961-04-04">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/male.html
+++ b/test/artefacts/calculate-state-pension/amount/male.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/male" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your date of birth?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="1893">1893</option>
+<option value="1894">1894</option>
+<option value="1895">1895</option>
+<option value="1896">1896</option>
+<option value="1897">1897</option>
+<option value="1898">1898</option>
+<option value="1899">1899</option>
+<option value="1900">1900</option>
+<option value="1901">1901</option>
+<option value="1902">1902</option>
+<option value="1903">1903</option>
+<option value="1904">1904</option>
+<option value="1905">1905</option>
+<option value="1906">1906</option>
+<option value="1907">1907</option>
+<option value="1908">1908</option>
+<option value="1909">1909</option>
+<option value="1910">1910</option>
+<option value="1911">1911</option>
+<option value="1912">1912</option>
+<option value="1913">1913</option>
+<option value="1914">1914</option>
+<option value="1915">1915</option>
+<option value="1916">1916</option>
+<option value="1917">1917</option>
+<option value="1918">1918</option>
+<option value="1919">1919</option>
+<option value="1920">1920</option>
+<option value="1921">1921</option>
+<option value="1922">1922</option>
+<option value="1923">1923</option>
+<option value="1924">1924</option>
+<option value="1925">1925</option>
+<option value="1926">1926</option>
+<option value="1927">1927</option>
+<option value="1928">1928</option>
+<option value="1929">1929</option>
+<option value="1930">1930</option>
+<option value="1931">1931</option>
+<option value="1932">1932</option>
+<option value="1933">1933</option>
+<option value="1934">1934</option>
+<option value="1935">1935</option>
+<option value="1936">1936</option>
+<option value="1937">1937</option>
+<option value="1938">1938</option>
+<option value="1939">1939</option>
+<option value="1940">1940</option>
+<option value="1941">1941</option>
+<option value="1942">1942</option>
+<option value="1943">1943</option>
+<option value="1944">1944</option>
+<option value="1945">1945</option>
+<option value="1946">1946</option>
+<option value="1947">1947</option>
+<option value="1948">1948</option>
+<option value="1949">1949</option>
+<option value="1950">1950</option>
+<option value="1951">1951</option>
+<option value="1952">1952</option>
+<option value="1953">1953</option>
+<option value="1954">1954</option>
+<option value="1955">1955</option>
+<option value="1956">1956</option>
+<option value="1957">1957</option>
+<option value="1958">1958</option>
+<option value="1959">1959</option>
+<option value="1960">1960</option>
+<option value="1961">1961</option>
+<option value="1962">1962</option>
+<option value="1963">1963</option>
+<option value="1964">1964</option>
+<option value="1965">1965</option>
+<option value="1966">1966</option>
+<option value="1967">1967</option>
+<option value="1968">1968</option>
+<option value="1969">1969</option>
+<option value="1970">1970</option>
+<option value="1971">1971</option>
+<option value="1972">1972</option>
+<option value="1973">1973</option>
+<option value="1974">1974</option>
+<option value="1975">1975</option>
+<option value="1976">1976</option>
+<option value="1977">1977</option>
+<option value="1978">1978</option>
+<option value="1979">1979</option>
+<option value="1980">1980</option>
+<option value="1981">1981</option>
+<option value="1982">1982</option>
+<option value="1983">1983</option>
+<option value="1984">1984</option>
+<option value="1985">1985</option>
+<option value="1986">1986</option>
+<option value="1987">1987</option>
+<option value="1988">1988</option>
+<option value="1989">1989</option>
+<option value="1990">1990</option>
+<option value="1991">1991</option>
+<option value="1992">1992</option>
+<option value="1993">1993</option>
+<option value="1994">1994</option>
+<option value="1995">1995</option>
+<option value="1996">1996</option>
+<option value="1997">1997</option>
+<option value="1998">1998</option>
+<option value="1999">1999</option>
+<option value="2000">2000</option>
+<option value="2001">2001</option>
+<option value="2002">2002</option>
+<option value="2003">2003</option>
+<option value="2004">2004</option>
+<option value="2005">2005</option>
+<option value="2006">2006</option>
+<option value="2007">2007</option>
+<option value="2008">2008</option>
+<option value="2009">2009</option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/male/1950-02-01.html
+++ b/test/artefacts/calculate-state-pension/amount/male/1950-02-01.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/male/1950-02-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many years have you worked and paid National Insurance contributions from the age of 19?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">These are the years when you paid Class 1 with your wages, Class 2 if you were self employed or Class 3 if you paid voluntary contributions.  Enter 0 if you haven’t paid National Insurance contributions. National Insurance credits will be automatically added for ages between 16 and 19 years old (if you’re eligible) - you don’t have to count them.
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+       1 February 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male?previous_response=1950-02-01">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1.html
+++ b/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/male/1950-02-01/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">These are years you may have received credits towards your State Pension. Don’t count years you’ve entered already. Enter 0 if you’ve never claimed benefits. </p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+       1 February 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male?previous_response=1950-02-01">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you worked and paid National Insurance contributions from the age of 19?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years have you worked and paid National Insurance contributions from the age of 19?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1.html
+++ b/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/male/1950-02-01/1/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+       1 February 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male?previous_response=1950-02-01">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you worked and paid National Insurance contributions from the age of 19?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years have you worked and paid National Insurance contributions from the age of 19?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1/yes.html
+++ b/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1/yes.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Before 6 April 2010 how many years did any of the following apply:
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>you claimed Child Benefit for a child under 16</li>
+  <li>you cared for someone sick or disabled</li>
+  <li>you worked as a registered foster carer (from 2003 to 2010)</li>
+</ul>
+
+
+      <p class="hint">These are years when you were getting Home Responsibility Protection. Enter 0 if none of these apply. Don’t count any years you’ve entered in the previous questions. </p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+       1 February 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male?previous_response=1950-02-01">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you worked and paid National Insurance contributions from the age of 19?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years have you worked and paid National Insurance contributions from the age of 19?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1/yes/1.html
+++ b/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1/yes/1.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    From 6 April 2010 how many years did any of the following apply:
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>you claimed Child Benefit for a child under 12</li>
+  <li>you cared for someone sick or disabled for at least 20 hours a week</li>
+  <li>you were a registered foster carer</li>
+</ul>
+
+
+      <p class="hint">Enter 0 if none of these apply. Don’t count any years you’ve entered in the previous questions.</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+       1 February 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male?previous_response=1950-02-01">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you worked and paid National Insurance contributions from the age of 19?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years have you worked and paid National Insurance contributions from the age of 19?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Before 6 April 2010 how many years did any of the following apply:</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "Before 6 April 2010 how many years did any of the following apply:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1/yes/1/1.html
+++ b/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1/yes/1/1.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes/1/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many years have you received Carer’s Allowance?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Enter 0 if you didn’t get any. Don’t count any years you’ve entered in the previous questions. </p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+       1 February 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male?previous_response=1950-02-01">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you worked and paid National Insurance contributions from the age of 19?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years have you worked and paid National Insurance contributions from the age of 19?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Before 6 April 2010 how many years did any of the following apply:</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "Before 6 April 2010 how many years did any of the following apply:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">From 6 April 2010 how many years did any of the following apply:</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "From 6 April 2010 how many years did any of the following apply:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1/yes/1/1/1.html
+++ b/test/artefacts/calculate-state-pension/amount/male/1950-02-01/1/1/yes/1/1/1.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes/1/1/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many years between age 16 and 19 were you working and paying National Insurance Contributions, or receiving National Insurance credits?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You might have been eligible for credits if you were getting unemployment, sickness, or disability benefits. You may have got credits if you were in full time education (not higher education) or approved training and you were born before 6 April 1959.</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+       1 February 1950</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male?previous_response=1950-02-01">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you worked and paid National Insurance contributions from the age of 19?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years have you worked and paid National Insurance contributions from the age of 19?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Before 6 April 2010 how many years did any of the following apply:</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "Before 6 April 2010 how many years did any of the following apply:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">From 6 April 2010 how many years did any of the following apply:</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "From 6 April 2010 how many years did any of the following apply:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you received Carer’s Allowance?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1950-02-01/1/1/yes/1/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years have you received Carer’s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/amount/male/1961-04-04/1/1/yes/1/1/1.html
+++ b/test/artefacts/calculate-state-pension/amount/male/1961-04-04/1/1/yes/1/1/1.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/amount/male/1961-04-04/1/1/yes/1/1/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Have you lived or worked outside the UK?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Amount - estimate of your basic State Pension amount</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=amount">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a man or a woman?</td>
+      <td class="previous-question-body">
+      Man</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "Are you a man or a woman?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+       4 April 1961</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male?previous_response=1961-04-04">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you worked and paid National Insurance contributions from the age of 19?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1961-04-04?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years have you worked and paid National Insurance contributions from the age of 19?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1961-04-04/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years from the age of 19 have you claimed unemployment, sickness or disability benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1961-04-04/1/1?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Before 6 April 2010 how many years did any of the following apply:</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1961-04-04/1/1/yes?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "Before 6 April 2010 how many years did any of the following apply:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">From 6 April 2010 how many years did any of the following apply:</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1961-04-04/1/1/yes/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "From 6 April 2010 how many years did any of the following apply:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you received Carer’s Allowance?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y/amount/male/1961-04-04/1/1/yes/1/1?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How many years have you received Carer’s Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/bus_pass.html
+++ b/test/artefacts/calculate-state-pension/bus_pass.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y/bus_pass" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your date of birth?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="1893">1893</option>
+<option value="1894">1894</option>
+<option value="1895">1895</option>
+<option value="1896">1896</option>
+<option value="1897">1897</option>
+<option value="1898">1898</option>
+<option value="1899">1899</option>
+<option value="1900">1900</option>
+<option value="1901">1901</option>
+<option value="1902">1902</option>
+<option value="1903">1903</option>
+<option value="1904">1904</option>
+<option value="1905">1905</option>
+<option value="1906">1906</option>
+<option value="1907">1907</option>
+<option value="1908">1908</option>
+<option value="1909">1909</option>
+<option value="1910">1910</option>
+<option value="1911">1911</option>
+<option value="1912">1912</option>
+<option value="1913">1913</option>
+<option value="1914">1914</option>
+<option value="1915">1915</option>
+<option value="1916">1916</option>
+<option value="1917">1917</option>
+<option value="1918">1918</option>
+<option value="1919">1919</option>
+<option value="1920">1920</option>
+<option value="1921">1921</option>
+<option value="1922">1922</option>
+<option value="1923">1923</option>
+<option value="1924">1924</option>
+<option value="1925">1925</option>
+<option value="1926">1926</option>
+<option value="1927">1927</option>
+<option value="1928">1928</option>
+<option value="1929">1929</option>
+<option value="1930">1930</option>
+<option value="1931">1931</option>
+<option value="1932">1932</option>
+<option value="1933">1933</option>
+<option value="1934">1934</option>
+<option value="1935">1935</option>
+<option value="1936">1936</option>
+<option value="1937">1937</option>
+<option value="1938">1938</option>
+<option value="1939">1939</option>
+<option value="1940">1940</option>
+<option value="1941">1941</option>
+<option value="1942">1942</option>
+<option value="1943">1943</option>
+<option value="1944">1944</option>
+<option value="1945">1945</option>
+<option value="1946">1946</option>
+<option value="1947">1947</option>
+<option value="1948">1948</option>
+<option value="1949">1949</option>
+<option value="1950">1950</option>
+<option value="1951">1951</option>
+<option value="1952">1952</option>
+<option value="1953">1953</option>
+<option value="1954">1954</option>
+<option value="1955">1955</option>
+<option value="1956">1956</option>
+<option value="1957">1957</option>
+<option value="1958">1958</option>
+<option value="1959">1959</option>
+<option value="1960">1960</option>
+<option value="1961">1961</option>
+<option value="1962">1962</option>
+<option value="1963">1963</option>
+<option value="1964">1964</option>
+<option value="1965">1965</option>
+<option value="1966">1966</option>
+<option value="1967">1967</option>
+<option value="1968">1968</option>
+<option value="1969">1969</option>
+<option value="1970">1970</option>
+<option value="1971">1971</option>
+<option value="1972">1972</option>
+<option value="1973">1973</option>
+<option value="1974">1974</option>
+<option value="1975">1975</option>
+<option value="1976">1976</option>
+<option value="1977">1977</option>
+<option value="1978">1978</option>
+<option value="1979">1979</option>
+<option value="1980">1980</option>
+<option value="1981">1981</option>
+<option value="1982">1982</option>
+<option value="1983">1983</option>
+<option value="1984">1984</option>
+<option value="1985">1985</option>
+<option value="1986">1986</option>
+<option value="1987">1987</option>
+<option value="1988">1988</option>
+<option value="1989">1989</option>
+<option value="1990">1990</option>
+<option value="1991">1991</option>
+<option value="1992">1992</option>
+<option value="1993">1993</option>
+<option value="1994">1994</option>
+<option value="1995">1995</option>
+<option value="1996">1996</option>
+<option value="1997">1997</option>
+<option value="1998">1998</option>
+<option value="1999">1999</option>
+<option value="2000">2000</option>
+<option value="2001">2001</option>
+<option value="2002">2002</option>
+<option value="2003">2003</option>
+<option value="2004">2004</option>
+<option value="2005">2005</option>
+<option value="2006">2006</option>
+<option value="2007">2007</option>
+<option value="2008">2008</option>
+<option value="2009">2009</option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-state-pension">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to calculate?</td>
+      <td class="previous-question-body">
+      Bus pass age - find out when you’ll get free bus travel</td>
+
+      <td class="link-right">
+          <a href="/calculate-state-pension/y?previous_response=bus_pass">
+            Change<span class="visuallyhidden"> answer to "What would you like to calculate?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-state-pension/y.html
+++ b/test/artefacts/calculate-state-pension/y.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-state-pension/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What would you like to calculate?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="age" />
+          State Pension age - including pension credit age
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="amount" />
+          Amount - estimate of your basic State Pension amount
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="bus_pass" />
+          Bus pass age - find out when you’ll get free bus travel
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does your employee routinely work different days of the week?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    During their most recent period of sickness, when did your employee first become sick?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This includes non-working days and bank holidays.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Enter the last day of sickness
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This can include non-working days and bank holidays</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?
+  </h2>
+  <div class="question-body">
+      <p>These are called ‘linked Periods of Incapacity for Work (<abbr title="Period of Incapacity for Work">PIW</abbr>)’. Check if an employee’s <a href="/government/publications/statutory-sick-pay-tables-for-linking-periods-of-incapacity-for-work"><abbr title="Period of Incapacity for Work">PIW</abbr> links to a previous one.</a></p>
+
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Enter the start date for this linked period of sickness.
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Enter the end date for this linked period of sickness.
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    On  1 February 2013 had you paid your employee at least 8 weeks of earnings?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="eight_weeks_more" />
+          Yes, paid at least 8 weeks earnings
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="eight_weeks_less" />
+          No, paid less than 8 weeks earnings
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="before_payday" />
+          No, employee is new and fell sick before their first payday
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Enter how much you would have paid the employee on their first payday if they hadn’t been sick.
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On  1 February 2013 had you paid your employee at least 8 weeks of earnings?</td>
+      <td class="previous-question-body">
+      No, employee is new and fell sick before their first payday</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15?previous_response=before_payday">
+            Change<span class="visuallyhidden"> answer to "On  1 February 2013 had you paid your employee at least 8 weeks of earnings?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many days does the period represented by these earnings cover?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If it’s 2 weeks and 3 days enter ‘17’.</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On  1 February 2013 had you paid your employee at least 8 weeks of earnings?</td>
+      <td class="previous-question-body">
+      No, employee is new and fell sick before their first payday</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15?previous_response=before_payday">
+            Change<span class="visuallyhidden"> answer to "On  1 February 2013 had you paid your employee at least 8 weeks of earnings?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter how much you would have paid the employee on their first payday if they hadn’t been sick.</td>
+      <td class="previous-question-body">
+      £2,000</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly?previous_response=2000.0">
+            Change<span class="visuallyhidden"> answer to "Enter how much you would have paid the employee on their first payday if they hadn’t been sick."</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Enter the total earnings paid before  1 February 2013.
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On  1 February 2013 had you paid your employee at least 8 weeks of earnings?</td>
+      <td class="previous-question-body">
+      No, paid less than 8 weeks earnings</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15?previous_response=eight_weeks_less">
+            Change<span class="visuallyhidden"> answer to "On  1 February 2013 had you paid your employee at least 8 weeks of earnings?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many days does the period represented by these earnings cover?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If it’s 2 weeks and 3 days enter ‘17’.</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On  1 February 2013 had you paid your employee at least 8 weeks of earnings?</td>
+      <td class="previous-question-body">
+      No, paid less than 8 weeks earnings</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15?previous_response=eight_weeks_less">
+            Change<span class="visuallyhidden"> answer to "On  1 February 2013 had you paid your employee at least 8 weeks of earnings?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the total earnings paid before  1 February 2013.</td>
+      <td class="previous-question-body">
+      £3,000</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less?previous_response=3000.0">
+            Change<span class="visuallyhidden"> answer to "Enter the total earnings paid before  1 February 2013."</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you pay the employee?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly" />
+          Weekly
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="fortnightly" />
+          Every 2 weeks
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="every_4_weeks" />
+          Every 4 weeks
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="monthly" />
+          Monthly - eg last day or Friday of a month
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="irregularly" />
+          Irregularly
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On  1 February 2013 had you paid your employee at least 8 weeks of earnings?</td>
+      <td class="previous-question-body">
+      Yes, paid at least 8 weeks earnings</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15?previous_response=eight_weeks_more">
+            Change<span class="visuallyhidden"> answer to "On  1 February 2013 had you paid your employee at least 8 weeks of earnings?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the last normal payday before  1 February 2013?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On  1 February 2013 had you paid your employee at least 8 weeks of earnings?</td>
+      <td class="previous-question-body">
+      Yes, paid at least 8 weeks earnings</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15?previous_response=eight_weeks_more">
+            Change<span class="visuallyhidden"> answer to "On  1 February 2013 had you paid your employee at least 8 weeks of earnings?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the last normal payday on or before  3 February 2013?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On  1 February 2013 had you paid your employee at least 8 weeks of earnings?</td>
+      <td class="previous-question-body">
+      Yes, paid at least 8 weeks earnings</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15?previous_response=eight_weeks_more">
+            Change<span class="visuallyhidden"> answer to "On  1 February 2013 had you paid your employee at least 8 weeks of earnings?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before  1 February 2013?</td>
+      <td class="previous-question-body">
+      31 March 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly?previous_response=2013-03-31">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before  1 February 2013?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between  1 February 2013 and 31 March 2013.
+  </h2>
+  <div class="question-body">
+      <p>Different rules apply for <a href="/statutory-sick-pay-how-different-employment-types-affect-what-you-pay">directors of limited companies incorporated before 1 October 2009</a></p>
+
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On  1 February 2013 had you paid your employee at least 8 weeks of earnings?</td>
+      <td class="previous-question-body">
+      Yes, paid at least 8 weeks earnings</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15?previous_response=eight_weeks_more">
+            Change<span class="visuallyhidden"> answer to "On  1 February 2013 had you paid your employee at least 8 weeks of earnings?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before  1 February 2013?</td>
+      <td class="previous-question-body">
+      31 March 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly?previous_response=2013-03-31">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before  1 February 2013?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before  3 February 2013?</td>
+      <td class="previous-question-body">
+      31 January 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31?previous_response=2013-01-31">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before  3 February 2013?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/200.html
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/200.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/200.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which days of the week do they usually work?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="1" />
+        Monday
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="2" />
+        Tuesday
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="3" />
+        Wednesday
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="4" />
+        Thursday
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="5" />
+        Friday
+      </label>
+    </li>
+    <li>
+      <label for="response_5">
+        <input type="checkbox" name="response[]" id="response_5" value="6" />
+        Saturday
+      </label>
+    </li>
+    <li>
+      <label for="response_6">
+        <input type="checkbox" name="response[]" id="response_6" value="0" />
+        Sunday
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-statutory-sick-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employee getting any of the following?</td>
+      <td class="previous-question-body"><ul>
+        <li>Ordinary Statutory Paternity Pay</li>
+        <li>Statutory Adoption Pay</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y?previous_response=ordinary_statutory_paternity_pay%2Cstatutory_adoption_pay">
+            Change<span class="visuallyhidden"> answer to "Is your employee getting any of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does your employee routinely work different days of the week?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does your employee routinely work different days of the week?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">During their most recent period of sickness, when did your employee first become sick?</td>
+      <td class="previous-question-body">
+       2 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no?previous_response=2013-04-02">
+            Change<span class="visuallyhidden"> answer to "During their most recent period of sickness, when did your employee first become sick?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the last day of sickness</td>
+      <td class="previous-question-body">
+      10 April 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02?previous_response=2013-04-10">
+            Change<span class="visuallyhidden"> answer to "Enter the last day of sickness"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the start date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+       1 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes?previous_response=2013-02-01">
+            Change<span class="visuallyhidden"> answer to "Enter the start date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the end date for this linked period of sickness.</td>
+      <td class="previous-question-body">
+      15 February 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01?previous_response=2013-02-15">
+            Change<span class="visuallyhidden"> answer to "Enter the end date for this linked period of sickness."</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On  1 February 2013 had you paid your employee at least 8 weeks of earnings?</td>
+      <td class="previous-question-body">
+      Yes, paid at least 8 weeks earnings</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15?previous_response=eight_weeks_more">
+            Change<span class="visuallyhidden"> answer to "On  1 February 2013 had you paid your employee at least 8 weeks of earnings?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before  1 February 2013?</td>
+      <td class="previous-question-body">
+      31 March 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly?previous_response=2013-03-31">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before  1 February 2013?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before  3 February 2013?</td>
+      <td class="previous-question-body">
+      31 January 2013</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31?previous_response=2013-01-31">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before  3 February 2013?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between  1 February 2013 and 31 March 2013.</td>
+      <td class="previous-question-body">
+      £200</td>
+
+      <td class="link-right">
+          <a href="/calculate-statutory-sick-pay/y/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31?previous_response=200.0">
+            Change<span class="visuallyhidden"> answer to "Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between  1 February 2013 and 31 March 2013."</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-statutory-sick-pay/y.html
+++ b/test/artefacts/calculate-statutory-sick-pay/y.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your employee&#39;s statutory sick pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-statutory-sick-pay/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is your employee getting any of the following?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If none apply just click ‘Next step’</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="statutory_maternity_pay" />
+        Statutory Maternity Pay
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="maternity_allowance" />
+        Maternity Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="ordinary_statutory_paternity_pay" />
+        Ordinary Statutory Paternity Pay
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="statutory_adoption_pay" />
+        Statutory Adoption Pay
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="additional_statutory_paternity_pay" />
+        Additional Statutory Paternity Pay
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-child-maintenance/pay.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Child maintenance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Child maintenance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-child-maintenance/y/pay" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many children are you paying child maintenance for?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Enter the total number of children - including children that you have family based arrangements for. They will be included in the calculation and you&#39;ll need to supply information about them when arranging Child Maintenance.
+
+</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="1_child" />
+          1
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="2_children" />
+          2
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="3_children" />
+          3 or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-child-maintenance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Will you be paying or receiving child maintenance payments?</td>
+      <td class="previous-question-body">
+      paying</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y?previous_response=pay">
+            Change<span class="visuallyhidden"> answer to "Will you be paying or receiving child maintenance payments?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Child maintenance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Child maintenance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-child-maintenance/y/pay/1_child" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you get any of these benefits?
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>Income Support</li>
+  <li>income-based Jobseeker’s Allowance</li>
+  <li>income-related Employment and Support Allowance</li>
+  <li>Pension Credit</li>
+  <li>contribution-based Jobseeker’s Allowance</li>
+  <li>contribution-based Employment and Support Allowance</li>
+  <li>State Pension</li>
+  <li>Incapacity Benefit</li>
+  <li>Training Allowance</li>
+  <li>Armed Forces Compensation Scheme payments</li>
+  <li>War Disablement Pension</li>
+  <li>Bereavement Allowance</li>
+  <li>Carer’s Allowance</li>
+  <li>Maternity Allowance</li>
+  <li>Severe Disablement Allowance</li>
+  <li>Industrial Injuries Disablement Benefit</li>
+  <li>Widowed Parent’s Allowance</li>
+  <li>Widow’s pension</li>
+  <li>Universal Credit with no earned income</li>
+</ul>
+
+
+      <p class="hint">In Scotland, this also includes: Skillseekers training, War Widow’s, Widower’s or Surviving Civil Partner’s Pension</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-child-maintenance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Will you be paying or receiving child maintenance payments?</td>
+      <td class="previous-question-body">
+      paying</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y?previous_response=pay">
+            Change<span class="visuallyhidden"> answer to "Will you be paying or receiving child maintenance payments?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many children are you paying child maintenance for?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y/pay?previous_response=1_child">
+            Change<span class="visuallyhidden"> answer to "How many children are you paying child maintenance for?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Child maintenance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Child maintenance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-child-maintenance/y/pay/1_child/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your weekly gross income?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This is income before tax and National Insurance but after pension contributions.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per week</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-child-maintenance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Will you be paying or receiving child maintenance payments?</td>
+      <td class="previous-question-body">
+      paying</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y?previous_response=pay">
+            Change<span class="visuallyhidden"> answer to "Will you be paying or receiving child maintenance payments?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many children are you paying child maintenance for?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y/pay?previous_response=1_child">
+            Change<span class="visuallyhidden"> answer to "How many children are you paying child maintenance for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you get any of these benefits?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y/pay/1_child?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you get any of these benefits?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Child maintenance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Child maintenance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-child-maintenance/y/pay/1_child/no/150.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many other children live in your household?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Enter 0 if no children live there. Don’t count the children child maintenance has to be paid for.</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-child-maintenance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Will you be paying or receiving child maintenance payments?</td>
+      <td class="previous-question-body">
+      paying</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y?previous_response=pay">
+            Change<span class="visuallyhidden"> answer to "Will you be paying or receiving child maintenance payments?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many children are you paying child maintenance for?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y/pay?previous_response=1_child">
+            Change<span class="visuallyhidden"> answer to "How many children are you paying child maintenance for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you get any of these benefits?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y/pay/1_child?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you get any of these benefits?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your weekly gross income?</td>
+      <td class="previous-question-body">
+      £150</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y/pay/1_child/no?previous_response=150.0">
+            Change<span class="visuallyhidden"> answer to "What is your weekly gross income?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Child maintenance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Child maintenance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-child-maintenance/y/pay/1_child/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    On average, how many nights a year do the children stay over with you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          Less than 52 (less than once a week)
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="1" />
+          52 to 103 (1 to 2 nights a week)
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="2" />
+          104 to 155 (2 to 3 nights a week)
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="3" />
+          156 to 174 (approx. 3 nights a week)
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="4" />
+          175 or more (more than 3 nights a week)
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-child-maintenance">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Will you be paying or receiving child maintenance payments?</td>
+      <td class="previous-question-body">
+      paying</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y?previous_response=pay">
+            Change<span class="visuallyhidden"> answer to "Will you be paying or receiving child maintenance payments?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many children are you paying child maintenance for?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y/pay?previous_response=1_child">
+            Change<span class="visuallyhidden"> answer to "How many children are you paying child maintenance for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you get any of these benefits?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-child-maintenance/y/pay/1_child?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you get any of these benefits?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-child-maintenance/y.html
+++ b/test/artefacts/calculate-your-child-maintenance/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Child maintenance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Child maintenance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-child-maintenance/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Will you be paying or receiving child maintenance payments?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="pay" />
+          paying
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="receive" />
+          receiving
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/annualised-hours.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/annualised-hours.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/annualised-hours" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours will be worked a year?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This is calculated by excluding statutory entitlement. This calculation isn&#39;t suitable for term-time workers.</p>
+
+    <div class="">
+
+      <label for="response">Hours per year<input type="text" name="response" id="response" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      annualised hours</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=annualised-hours">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/casual-or-irregular-hours.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/casual-or-irregular-hours.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/casual-or-irregular-hours" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours have been worked in this leave year?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The holiday entitlement may be calculated as the leave builds up (&#39;accrues&#39;) for each hour worked.</p>
+
+    <div class="">
+
+      <label for="response">Hours worked<input type="text" name="response" id="response" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      casual or irregular hours</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=casual-or-irregular-hours">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/compressed-hours.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/compressed-hours.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/compressed-hours" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours are worked per week?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response">Hours per week<input type="text" name="response" id="response" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      compressed hours</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=compressed-hours">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/compressed-hours/8.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/compressed-hours/8.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/compressed-hours/8.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Number of days per week worked?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response">Days per week<input type="text" name="response" id="response" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      compressed hours</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=compressed-hours">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours are worked per week?</td>
+      <td class="previous-question-body">
+      8.0</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/compressed-hours?previous_response=8.0">
+            Change<span class="visuallyhidden"> answer to "How many hours are worked per week?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/days-worked-per-week" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you want to work out holiday:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="full-year" />
+          for a full leave year
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="starting" />
+          for someone starting part way through a leave year
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="leaving" />
+          for someone leaving part way through a leave year
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="starting-and-leaving" />
+          for someone starting and leaving part way through a leave year
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      days worked per week</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=days-worked-per-week">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/full-year.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/full-year.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/days-worked-per-week/full-year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Number of days worked per week?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you work half-days enter .5 for a half, eg 3.5 for three and a half days.</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      days worked per week</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=days-worked-per-week">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you want to work out holiday:</td>
+      <td class="previous-question-body">
+      for a full leave year</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/days-worked-per-week?previous_response=full-year">
+            Change<span class="visuallyhidden"> answer to "Do you want to work out holiday:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/leaving.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/leaving.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/days-worked-per-week/leaving" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the employment end date?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      days worked per week</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=days-worked-per-week">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you want to work out holiday:</td>
+      <td class="previous-question-body">
+      for someone leaving part way through a leave year</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/days-worked-per-week?previous_response=leaving">
+            Change<span class="visuallyhidden"> answer to "Do you want to work out holiday:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/starting.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/starting.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/days-worked-per-week/starting" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the employment start date?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      days worked per week</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=days-worked-per-week">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you want to work out holiday:</td>
+      <td class="previous-question-body">
+      for someone starting part way through a leave year</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/days-worked-per-week?previous_response=starting">
+            Change<span class="visuallyhidden"> answer to "Do you want to work out holiday:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/starting/2012-01-01.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/starting/2012-01-01.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/days-worked-per-week/starting/2012-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When does the leave year start?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This is usually in the employment contract. If it isn’t and the job was started after 1 October 1998, the leave year will start on the 1st day of the job. If the job was started on or before 1 October 1998, the leave year will start on 1 October.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      days worked per week</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=days-worked-per-week">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you want to work out holiday:</td>
+      <td class="previous-question-body">
+      for someone starting part way through a leave year</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/days-worked-per-week?previous_response=starting">
+            Change<span class="visuallyhidden"> answer to "Do you want to work out holiday:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the employment start date?</td>
+      <td class="previous-question-body">
+       1 January 2012</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/days-worked-per-week/starting?previous_response=2012-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the employment start date?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/hours-worked-per-week/full-year.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/hours-worked-per-week/full-year.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/hours-worked-per-week/full-year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Number of hours worked per week?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you work half-hours enter .5 for a half, eg 40.5.</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      hours worked per week</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=hours-worked-per-week">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you want to work out holiday:</td>
+      <td class="previous-question-body">
+      for a full leave year</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/hours-worked-per-week?previous_response=full-year">
+            Change<span class="visuallyhidden"> answer to "Do you want to work out holiday:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/shift-worker.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/shift-worker.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/shift-worker" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you want to calculate the holiday:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="full-year" />
+          for a full leave year
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="starting" />
+          for someone starting part way through a leave year
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="leaving" />
+          for someone leaving part way through a leave year
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="starting-and-leaving" />
+          for someone starting and leaving part way through a leave year
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      shifts</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=shift-worker">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/shift-worker/full-year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours in each shift?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response">Hours per shift<input type="text" name="response" id="response" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      shifts</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=shift-worker">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you want to calculate the holiday:</td>
+      <td class="previous-question-body">
+      for a full leave year</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/shift-worker?previous_response=full-year">
+            Change<span class="visuallyhidden"> answer to "Do you want to calculate the holiday:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year/8.0/3.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year/8.0/3.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/shift-worker/full-year/8.0/3" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many days in the shift pattern?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The shift pattern includes non-working days.</p>
+
+    <div class="">
+
+      <label for="response">Days per pattern<input type="text" name="response" id="response" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      shifts</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=shift-worker">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you want to calculate the holiday:</td>
+      <td class="previous-question-body">
+      for a full leave year</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/shift-worker?previous_response=full-year">
+            Change<span class="visuallyhidden"> answer to "Do you want to calculate the holiday:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours in each shift?</td>
+      <td class="previous-question-body">
+      8.0</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/shift-worker/full-year?previous_response=8.0">
+            Change<span class="visuallyhidden"> answer to "How many hours in each shift?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many shifts will be worked per shift pattern?</td>
+      <td class="previous-question-body">
+      3</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/shift-worker/full-year/8.0?previous_response=3">
+            Change<span class="visuallyhidden"> answer to "How many shifts will be worked per shift pattern?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year/8.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year/8.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y/shift-worker/full-year/8.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many shifts will be worked per shift pattern?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response">Shifts per pattern<input type="text" name="response" id="response" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-holiday-entitlement">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the holiday entitlement based on:</td>
+      <td class="previous-question-body">
+      shifts</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y?previous_response=shift-worker">
+            Change<span class="visuallyhidden"> answer to "Is the holiday entitlement based on:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you want to calculate the holiday:</td>
+      <td class="previous-question-body">
+      for a full leave year</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/shift-worker?previous_response=full-year">
+            Change<span class="visuallyhidden"> answer to "Do you want to calculate the holiday:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours in each shift?</td>
+      <td class="previous-question-body">
+      8.0</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-holiday-entitlement/y/shift-worker/full-year?previous_response=8.0">
+            Change<span class="visuallyhidden"> answer to "How many hours in each shift?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-holiday-entitlement/y.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/y.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate holiday entitlement - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate holiday entitlement
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-holiday-entitlement/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the holiday entitlement based on:
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Check the employment contract if you’re not sure about the holiday entitlement.
+</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="days-worked-per-week" />
+          days worked per week
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="hours-worked-per-week" />
+          hours worked per week
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="casual-or-irregular-hours" />
+          casual or irregular hours
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="annualised-hours" />
+          annualised hours
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="compressed-hours" />
+          compressed hours
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="shift-worker" />
+          shifts
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-redundancy-pay/2012-01-01.html
+++ b/test/artefacts/calculate-your-redundancy-pay/2012-01-01.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your statutory redundancy pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your statutory redundancy pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-redundancy-pay/y/2012-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old were you on the date you were made redundant?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years old</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-redundancy-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What date were you made redundant?</td>
+      <td class="previous-question-body">
+       1 January 2012</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-redundancy-pay/y?previous_response=2012-01-01">
+            Change<span class="visuallyhidden"> answer to "What date were you made redundant?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21.html
+++ b/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your statutory redundancy pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your statutory redundancy pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-redundancy-pay/y/2012-01-01/21" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many years have you worked for your employer?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Only count full years of service. For example, 3 years and 9 months count as 3 years.
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />full years worked</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-redundancy-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What date were you made redundant?</td>
+      <td class="previous-question-body">
+       1 January 2012</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-redundancy-pay/y?previous_response=2012-01-01">
+            Change<span class="visuallyhidden"> answer to "What date were you made redundant?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you on the date you were made redundant?</td>
+      <td class="previous-question-body">
+      21</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-redundancy-pay/y/2012-01-01?previous_response=21">
+            Change<span class="visuallyhidden"> answer to "How old were you on the date you were made redundant?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21/3.html
+++ b/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21/3.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your statutory redundancy pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your statutory redundancy pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-redundancy-pay/y/2012-01-01/21/3.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your weekly pay before tax and any other deductions?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Examples of other deductions include student loans and child maintenance.
+</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per week</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/calculate-your-redundancy-pay">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What date were you made redundant?</td>
+      <td class="previous-question-body">
+       1 January 2012</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-redundancy-pay/y?previous_response=2012-01-01">
+            Change<span class="visuallyhidden"> answer to "What date were you made redundant?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old were you on the date you were made redundant?</td>
+      <td class="previous-question-body">
+      21</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-redundancy-pay/y/2012-01-01?previous_response=21">
+            Change<span class="visuallyhidden"> answer to "How old were you on the date you were made redundant?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many years have you worked for your employer?</td>
+      <td class="previous-question-body">
+      3.0</td>
+
+      <td class="link-right">
+          <a href="/calculate-your-redundancy-pay/y/2012-01-01/21?previous_response=3.0">
+            Change<span class="visuallyhidden"> answer to "How many years have you worked for your employer?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/calculate-your-redundancy-pay/y.html
+++ b/test/artefacts/calculate-your-redundancy-pay/y.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Calculate your statutory redundancy pay - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Calculate your statutory redundancy pay
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/calculate-your-redundancy-pay/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What date were you made redundant?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Use the original redundancy date even if your notice is brought forward, you’re paid in lieu of notice or made redundant after trialing a new job.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/check-uk-visa/afghanistan.html
+++ b/test/artefacts/check-uk-visa/afghanistan.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if you need a UK visa - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if you need a UK visa
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/check-uk-visa/y/afghanistan" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What are you coming to the UK to do?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="tourism" />
+          Tourism, including visiting friends or family
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="work" />
+          Work, academic visit or business
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="study" />
+          Study
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="transit" />
+          Transit (on your way to somewhere else)
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="family" />
+          Join partner or family for a long stay
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="marriage" />
+          Get married or enter into a civil partnership
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="school" />
+          Visit your child at school
+        </label>
+    </li>
+    <li>
+        <label for="response_7" class="selectable">
+          <input type="radio" name="response" id="response_7" value="medical" />
+          Get private medical treatment
+        </label>
+    </li>
+    <li>
+        <label for="response_8" class="selectable">
+          <input type="radio" name="response" id="response_8" value="diplomatic" />
+          For official diplomatic or government business (including transit through the UK)
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/check-uk-visa">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What passport or travel document do you have?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/check-uk-visa/y?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "What passport or travel document do you have?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/check-uk-visa/afghanistan/transit.html
+++ b/test/artefacts/check-uk-visa/afghanistan/transit.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if you need a UK visa - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if you need a UK visa
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/check-uk-visa/y/afghanistan/transit" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Will you pass through UK Border Control?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You might pass through UK Border Control even if you don&#39;t leave the airport - eg your bags aren&#39;t checked through and you need to collect them before transferring to your outbound flight.</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/check-uk-visa">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What passport or travel document do you have?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/check-uk-visa/y?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "What passport or travel document do you have?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are you coming to the UK to do?</td>
+      <td class="previous-question-body">
+      Transit (on your way to somewhere else)</td>
+
+      <td class="link-right">
+          <a href="/check-uk-visa/y/afghanistan?previous_response=transit">
+            Change<span class="visuallyhidden"> answer to "What are you coming to the UK to do?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/check-uk-visa/afghanistan/work.html
+++ b/test/artefacts/check-uk-visa/afghanistan/work.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if you need a UK visa - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if you need a UK visa
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/check-uk-visa/y/afghanistan/work" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How long are you planning to work in the UK for?
+
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="six_months_or_less" />
+          6 months or less
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="longer_than_six_months" />
+          longer than 6 months
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/check-uk-visa">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What passport or travel document do you have?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/check-uk-visa/y?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "What passport or travel document do you have?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are you coming to the UK to do?</td>
+      <td class="previous-question-body">
+      Work, academic visit or business</td>
+
+      <td class="link-right">
+          <a href="/check-uk-visa/y/afghanistan?previous_response=work">
+            Change<span class="visuallyhidden"> answer to "What are you coming to the UK to do?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/check-uk-visa/y.html
+++ b/test/artefacts/check-uk-visa/y.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if you need a UK visa - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if you need a UK visa
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/check-uk-visa/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What passport or travel document do you have?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you&#39;re a refugee or don&#39;t have a passport or travel document, select stateless or refugee.</p>
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="british-dependent-territories-citizen">British dependent territories citizen</option>
+<option value="british-national-overseas">British national overseas</option>
+<option value="british-overseas-citizen">British overseas citizen</option>
+<option value="british-protected-person">British protected person</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="cyprus-north">Cyprus (northern part of Cyprus)</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hong-kong-(british-national-overseas)">Hong Kong (British national overseas)</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="palestinian-territories">Palestinian Territories</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="stateless-or-refugee">Stateless or Refugee</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="vatican-city">Vatican City</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you use childcare?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="regularly_less_than_year" />
+          I’ve been using childcare regularly for less than a year
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="regularly_more_than_year" />
+          I&#39;ve been using childcare regularly for a year or more
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="only_short_while" />
+          I only use childcare for short periods once in a while
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_less_than_year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you pay your childcare provider(s)?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly_same_amount" />
+          Weekly, and I always pay the same amount
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="weekly_diff_amount" />
+          Weekly, and the amount I pay varies
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="monthly_same_amount" />
+          Monthly, and I always pay the same amount
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="monthly_diff_amount" />
+          Monthly, and the amount I pay varies
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="other" />
+          Other
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I’ve been using childcare regularly for less than a year</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_less_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_diff_amount.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_less_than_year/monthly_diff_amount" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you expect to pay in total for childcare for the next 12 months?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Add up the amounts you expect to pay in total for the next 12 months - start from the day you’re doing the calculation</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I’ve been using childcare regularly for less than a year</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_less_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Monthly, and the amount I pay varies</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_less_than_year?previous_response=monthly_diff_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_same_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_same_amount.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_less_than_year/monthly_same_amount" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you pay each month?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I’ve been using childcare regularly for less than a year</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_less_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Monthly, and I always pay the same amount</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_less_than_year?previous_response=monthly_same_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/weekly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/weekly_diff_amount.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_less_than_year/weekly_diff_amount" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you expect to pay in total for childcare for the next 52 weeks?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Add up the amounts you expect to pay in total for the next 52 weeks - start from the day you’re doing the calculation</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I’ve been using childcare regularly for less than a year</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_less_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Weekly, and the amount I pay varies</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_less_than_year?previous_response=weekly_diff_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you pay the same each time?
+  </h2>
+  <div class="question-body">
+      <p>Sometimes you may pay - or expect to pay - different amounts for childcare (known as ‘variable costs’), for example:</p>
+
+<ul>
+  <li>you regularly use childcare, but pay more during school holidays than you do at term time</li>
+  <li>the hours you use childcare change from week to week or month to month</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I&#39;ve been using childcare regularly for a year or more</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_more_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/no.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/no.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much have you spent on childcare in the last 12 months?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Add up how much you have spent in total over the last 12 months - start backwards from the date you’re doing the calculation.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I&#39;ve been using childcare regularly for a year or more</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_more_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you pay the same each time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you pay the same each time?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you pay your childcare provider(s)?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly" />
+          Weekly
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="fortnightly" />
+          Fortnightly
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="every_4_weeks" />
+          Every 4 weeks
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="every_month" />
+          Every calendar month
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="termly" />
+          Termly
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="yearly" />
+          Yearly
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="other" />
+          Other
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I&#39;ve been using childcare regularly for a year or more</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_more_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you pay the same each time?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you pay the same each time?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/every_4_weeks.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/every_4_weeks.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year/yes/every_4_weeks" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you pay every 4 weeks?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I&#39;ve been using childcare regularly for a year or more</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_more_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you pay the same each time?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you pay the same each time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Every 4 weeks</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year/yes?previous_response=every_4_weeks">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/fortnightly.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/fortnightly.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year/yes/fortnightly" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you pay each fortnight?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I&#39;ve been using childcare regularly for a year or more</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_more_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you pay the same each time?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you pay the same each time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Fortnightly</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year/yes?previous_response=fortnightly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/yearly.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/yearly.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year/yes/yearly" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you pay every year?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you use childcare?</td>
+      <td class="previous-question-body">
+      I&#39;ve been using childcare regularly for a year or more</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no?previous_response=regularly_more_than_year">
+            Change<span class="visuallyhidden"> answer to "How often do you use childcare?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you pay the same each time?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you pay the same each time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Yearly</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/no/regularly_more_than_year/yes?previous_response=yearly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/y.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you currently claiming tax credits for childcare costs?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/yes.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Have the costs of your childcare changed since you last made your claim?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you pay your childcare provider(s)?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly_same_amount" />
+          Weekly, and I always pay the same amount
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="weekly_diff_amount" />
+          Weekly, and the amount I pay varies
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="monthly_same_amount" />
+          Monthly, and I always pay the same amount
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="monthly_diff_amount" />
+          Monthly, and the amount I pay varies
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="other" />
+          Other
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have the costs of your childcare changed since you last made your claim?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have the costs of your childcare changed since you last made your claim?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_diff_amount.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/yes/yes/monthly_diff_amount" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you expect to pay in total for childcare for the next 12 months?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have the costs of your childcare changed since you last made your claim?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have the costs of your childcare changed since you last made your claim?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Monthly, and the amount I pay varies</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes?previous_response=monthly_diff_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/yes/yes/monthly_same_amount" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What&#39;s the new monthly cost of your childcare?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have the costs of your childcare changed since you last made your claim?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have the costs of your childcare changed since you last made your claim?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Monthly, and I always pay the same amount</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes?previous_response=monthly_same_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount/43.3.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount/43.3.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/yes/yes/monthly_same_amount/43.3" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the old average weekly amount you gave the Tax Credit Office?
+  </h2>
+  <div class="question-body">
+      <p>If you don’t know what your previous childcare costs were, check your award or renewal notice.</p>
+
+<p>Round the total up to the nearest pound.</p>
+
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have the costs of your childcare changed since you last made your claim?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have the costs of your childcare changed since you last made your claim?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Monthly, and I always pay the same amount</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes?previous_response=monthly_same_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s the new monthly cost of your childcare?</td>
+      <td class="previous-question-body">
+      £43.30</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes/monthly_same_amount?previous_response=43.3">
+            Change<span class="visuallyhidden"> answer to "What&#39;s the new monthly cost of your childcare?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/yes/yes/weekly_diff_amount" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you expect to pay in total for childcare for the next 52 weeks?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have the costs of your childcare changed since you last made your claim?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have the costs of your childcare changed since you last made your claim?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Weekly, and the amount I pay varies</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes?previous_response=weekly_diff_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount/520.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount/520.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/yes/yes/weekly_diff_amount/520.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the old average weekly amount you gave the Tax Credit Office?
+  </h2>
+  <div class="question-body">
+      <p>If you don’t know what your previous childcare costs were, check your award or renewal notice.</p>
+
+<p>Round the total up to the nearest pound.</p>
+
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have the costs of your childcare changed since you last made your claim?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have the costs of your childcare changed since you last made your claim?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Weekly, and the amount I pay varies</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes?previous_response=weekly_diff_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you expect to pay in total for childcare for the next 52 weeks?</td>
+      <td class="previous-question-body">
+      £520</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes/weekly_diff_amount?previous_response=520.0">
+            Change<span class="visuallyhidden"> answer to "How much do you expect to pay in total for childcare for the next 52 weeks?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/yes/yes/weekly_same_amount" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What are your new weekly costs?
+  </h2>
+  <div class="question-body">
+      <p>Round the total up to the nearest pound.</p>
+
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have the costs of your childcare changed since you last made your claim?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have the costs of your childcare changed since you last made your claim?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Weekly, and I always pay the same amount</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes?previous_response=weekly_same_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount/10.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount/10.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Tax credits: working out your childcare costs - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Tax credits: working out your childcare costs
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/childcare-costs-for-tax-credits/y/yes/yes/weekly_same_amount/10.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the old average weekly amount you gave the Tax Credit Office?
+  </h2>
+  <div class="question-body">
+      <p>If you don’t know what your previous childcare costs were, check your award or renewal notice.</p>
+
+<p>Round the total up to the nearest pound.</p>
+
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/childcare-costs-for-tax-credits">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently claiming tax credits for childcare costs?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you currently claiming tax credits for childcare costs?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have the costs of your childcare changed since you last made your claim?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have the costs of your childcare changed since you last made your claim?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay your childcare provider(s)?</td>
+      <td class="previous-question-body">
+      Weekly, and I always pay the same amount</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes?previous_response=weekly_same_amount">
+            Change<span class="visuallyhidden"> answer to "How often do you pay your childcare provider(s)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your new weekly costs?</td>
+      <td class="previous-question-body">
+      £10</td>
+
+      <td class="link-right">
+          <a href="/childcare-costs-for-tax-credits/y/yes/yes/weekly_same_amount?previous_response=10.0">
+            Change<span class="visuallyhidden"> answer to "What are your new weekly costs?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_energy_efficiency" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What are your circumstances?
+  </h2>
+  <div class="question-body">
+      <p>Social housing tenants should talk to their social housing provider if they want to improve their energy efficiency.</p>
+
+
+      <p class="hint">Choose all that apply to you. If none apply just click ‘Next step’.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="benefits" />
+        You’re getting benefits
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="property" />
+        You own your property
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="permission" />
+        You rent privately but have permission from the owner to install or upgrade the boiler
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help to make your home more energy efficient</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_energy_efficiency">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_energy_efficiency/none" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When was your property built?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="on-or-after-1995" />
+          1995 or newer
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="1940s-1984" />
+          1940s – 1994
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="before-1940" />
+          Before 1940
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help to make your home more energy efficient</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_energy_efficiency">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your circumstances?</td>
+      <td class="previous-question-body"><ul>
+        <li>none</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency?previous_response=none">
+            Change<span class="visuallyhidden"> answer to "What are your circumstances?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_energy_efficiency/none/1940s-1984/house" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which  of these do you have:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="mains_gas" />
+        Mains gas
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="electric_heating" />
+        Electric heating
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="modern_double_glazing" />
+        Double glazing (or secondary glazing for listed properties)
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="loft_attic_conversion" />
+        Loft or attic conversion
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="loft_insulation" />
+        Loft insulation
+      </label>
+    </li>
+    <li>
+      <label for="response_5">
+        <input type="checkbox" name="response[]" id="response_5" value="solid_wall_insulation" />
+        Solid wall insulation
+      </label>
+    </li>
+    <li>
+      <label for="response_6">
+        <input type="checkbox" name="response[]" id="response_6" value="cavity_wall_insulation" />
+        Cavity wall insulation
+      </label>
+    </li>
+    <li>
+      <label for="response_7">
+        <input type="checkbox" name="response[]" id="response_7" value="modern_boiler" />
+        Modern boiler (less than 10 years)
+      </label>
+    </li>
+    <li>
+      <label for="response_8">
+        <input type="checkbox" name="response[]" id="response_8" value="draught_proofing" />
+        Draught proofing
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help to make your home more energy efficient</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_energy_efficiency">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your circumstances?</td>
+      <td class="previous-question-body"><ul>
+        <li>none</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency?previous_response=none">
+            Change<span class="visuallyhidden"> answer to "What are your circumstances?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was your property built?</td>
+      <td class="previous-question-body">
+      1940s – 1994</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency/none?previous_response=1940s-1984">
+            Change<span class="visuallyhidden"> answer to "When was your property built?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of property do you live in?</td>
+      <td class="previous-question-body">
+      A house, terraced house or bungalow</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency/none/1940s-1984?previous_response=house">
+            Change<span class="visuallyhidden"> answer to "What kind of property do you live in?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_energy_efficiency/none/before-1940/house" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which  of these do you have:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="mains_gas" />
+        Mains gas
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="electric_heating" />
+        Electric heating
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="modern_double_glazing" />
+        Double glazing (or secondary glazing for listed properties)
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="loft_attic_conversion" />
+        Loft or attic conversion
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="loft_insulation" />
+        Loft insulation
+      </label>
+    </li>
+    <li>
+      <label for="response_5">
+        <input type="checkbox" name="response[]" id="response_5" value="solid_wall_insulation" />
+        Solid wall insulation
+      </label>
+    </li>
+    <li>
+      <label for="response_6">
+        <input type="checkbox" name="response[]" id="response_6" value="modern_boiler" />
+        Modern boiler (less than 10 years)
+      </label>
+    </li>
+    <li>
+      <label for="response_7">
+        <input type="checkbox" name="response[]" id="response_7" value="draught_proofing" />
+        Draught proofing
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help to make your home more energy efficient</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_energy_efficiency">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your circumstances?</td>
+      <td class="previous-question-body"><ul>
+        <li>none</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency?previous_response=none">
+            Change<span class="visuallyhidden"> answer to "What are your circumstances?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was your property built?</td>
+      <td class="previous-question-body">
+      Before 1940</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency/none?previous_response=before-1940">
+            Change<span class="visuallyhidden"> answer to "When was your property built?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of property do you live in?</td>
+      <td class="previous-question-body">
+      A house, terraced house or bungalow</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency/none/before-1940?previous_response=house">
+            Change<span class="visuallyhidden"> answer to "What kind of property do you live in?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_energy_efficiency/none/on-or-after-1995" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What kind of property do you live in?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="house" />
+          A house, terraced house or bungalow
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="flat" />
+          A flat
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help to make your home more energy efficient</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_energy_efficiency">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your circumstances?</td>
+      <td class="previous-question-body"><ul>
+        <li>none</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency?previous_response=none">
+            Change<span class="visuallyhidden"> answer to "What are your circumstances?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was your property built?</td>
+      <td class="previous-question-body">
+      1995 or newer</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency/none?previous_response=on-or-after-1995">
+            Change<span class="visuallyhidden"> answer to "When was your property built?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_energy_efficiency/none/on-or-after-1995/flat" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is it a top-floor or a ground-floor flat?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="top_floor" />
+          Top-floor
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="ground_floor" />
+          Ground-floor
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help to make your home more energy efficient</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_energy_efficiency">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your circumstances?</td>
+      <td class="previous-question-body"><ul>
+        <li>none</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency?previous_response=none">
+            Change<span class="visuallyhidden"> answer to "What are your circumstances?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was your property built?</td>
+      <td class="previous-question-body">
+      1995 or newer</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency/none?previous_response=on-or-after-1995">
+            Change<span class="visuallyhidden"> answer to "When was your property built?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of property do you live in?</td>
+      <td class="previous-question-body">
+      A flat</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency/none/on-or-after-1995?previous_response=flat">
+            Change<span class="visuallyhidden"> answer to "What kind of property do you live in?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_energy_efficiency/none/on-or-after-1995/house" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which  of these do you have:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="mains_gas" />
+        Mains gas
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="electric_heating" />
+        Electric heating
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="loft_attic_conversion" />
+        Loft or attic conversion
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="draught_proofing" />
+        Draught proofing
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help to make your home more energy efficient</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_energy_efficiency">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your circumstances?</td>
+      <td class="previous-question-body"><ul>
+        <li>none</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency?previous_response=none">
+            Change<span class="visuallyhidden"> answer to "What are your circumstances?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was your property built?</td>
+      <td class="previous-question-body">
+      1995 or newer</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency/none?previous_response=on-or-after-1995">
+            Change<span class="visuallyhidden"> answer to "When was your property built?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of property do you live in?</td>
+      <td class="previous-question-body">
+      A house, terraced house or bungalow</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_energy_efficiency/none/on-or-after-1995?previous_response=house">
+            Change<span class="visuallyhidden"> answer to "What kind of property do you live in?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_with_fuel_bill" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What are your circumstances?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Choose all that apply to you. If none apply just click ‘Next step’.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="benefits" />
+        You’re getting benefits
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="property" />
+        You own your property
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="permission" />
+        You rent privately but have permission from the owner to make energy saving improvements (eg upgrade the boiler)
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="social_housing" />
+        You’re a social housing tenant
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help with your fuel bill</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_with_fuel_bill">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_with_fuel_bill/benefits,property/1950-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which of these benefits do you get?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Choose all that apply to you. If none apply just click ‘Next step’.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="pension_credit" />
+        Pension Credit
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="income_support" />
+        Income Support
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="jsa" />
+        Income based Jobseeker’s Allowance
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="esa" />
+        Income-related Employment and Support Allowance (ESA)
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="child_tax_credit" />
+        Child Tax Credit - only if your income is £16,010 or less
+      </label>
+    </li>
+    <li>
+      <label for="response_5">
+        <input type="checkbox" name="response[]" id="response_5" value="working_tax_credit" />
+        Working Tax Credit - only if your income is £16,010 or less
+      </label>
+    </li>
+    <li>
+      <label for="response_6">
+        <input type="checkbox" name="response[]" id="response_6" value="universal_credit" />
+        Universal Credit (and you earned £1,250 or less after tax in any assessment period in the last 12 months)
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help with your fuel bill</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_with_fuel_bill">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your circumstances?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’re getting benefits</li>
+        <li>You own your property</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_with_fuel_bill?previous_response=benefits%2Cproperty">
+            Change<span class="visuallyhidden"> answer to "What are your circumstances?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What’s your date of birth?</td>
+      <td class="previous-question-body">
+       1 January 1950</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_with_fuel_bill/benefits,property?previous_response=1950-01-01">
+            Change<span class="visuallyhidden"> answer to "What’s your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01/pension_credit,income_support,jsa,esa,child_tax_credit,working_tax_credit.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01/pension_credit,income_support,jsa,esa,child_tax_credit,working_tax_credit.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_with_fuel_bill/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you elderly, disabled, or do you have children?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Choose all that apply to you. If none apply just click ‘Next step’.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="disabled" />
+        You or your partner are disabled.
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="disabled_child" />
+        You have a disabled child.
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="child_under_5" />
+        You have a child under 5.
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="child_under_16" />
+        You have a child under 16 or under 20 if in full-time education.
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="pensioner_premium" />
+        You (or your partner) get a ‘pensioner premium’.
+      </label>
+    </li>
+    <li>
+      <label for="response_5">
+        <input type="checkbox" name="response[]" id="response_5" value="work_support_esa" />
+        You’re in the work-related or support group of ESA.
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help with your fuel bill</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_with_fuel_bill">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your circumstances?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’re getting benefits</li>
+        <li>You own your property</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_with_fuel_bill?previous_response=benefits%2Cproperty">
+            Change<span class="visuallyhidden"> answer to "What are your circumstances?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What’s your date of birth?</td>
+      <td class="previous-question-body">
+       1 January 1950</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_with_fuel_bill/benefits,property?previous_response=1950-01-01">
+            Change<span class="visuallyhidden"> answer to "What’s your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which of these benefits do you get?</td>
+      <td class="previous-question-body"><ul>
+        <li>Child Tax Credit - only if your income is £16,010 or less</li>
+        <li>Income-related Employment and Support Allowance (ESA)</li>
+        <li>Income Support</li>
+        <li>Income based Jobseeker’s Allowance</li>
+        <li>Pension Credit</li>
+        <li>Working Tax Credit - only if your income is £16,010 or less</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_with_fuel_bill/benefits,property/1950-01-01?previous_response=child_tax_credit%2Cesa%2Cincome_support%2Cjsa%2Cpension_credit%2Cworking_tax_credit">
+            Change<span class="visuallyhidden"> answer to "Which of these benefits do you get?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill/none.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill/none.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y/help_with_fuel_bill/none" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What’s your date of birth?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="1893">1893</option>
+<option value="1894">1894</option>
+<option value="1895">1895</option>
+<option value="1896">1896</option>
+<option value="1897">1897</option>
+<option value="1898">1898</option>
+<option value="1899">1899</option>
+<option value="1900">1900</option>
+<option value="1901">1901</option>
+<option value="1902">1902</option>
+<option value="1903">1903</option>
+<option value="1904">1904</option>
+<option value="1905">1905</option>
+<option value="1906">1906</option>
+<option value="1907">1907</option>
+<option value="1908">1908</option>
+<option value="1909">1909</option>
+<option value="1910">1910</option>
+<option value="1911">1911</option>
+<option value="1912">1912</option>
+<option value="1913">1913</option>
+<option value="1914">1914</option>
+<option value="1915">1915</option>
+<option value="1916">1916</option>
+<option value="1917">1917</option>
+<option value="1918">1918</option>
+<option value="1919">1919</option>
+<option value="1920">1920</option>
+<option value="1921">1921</option>
+<option value="1922">1922</option>
+<option value="1923">1923</option>
+<option value="1924">1924</option>
+<option value="1925">1925</option>
+<option value="1926">1926</option>
+<option value="1927">1927</option>
+<option value="1928">1928</option>
+<option value="1929">1929</option>
+<option value="1930">1930</option>
+<option value="1931">1931</option>
+<option value="1932">1932</option>
+<option value="1933">1933</option>
+<option value="1934">1934</option>
+<option value="1935">1935</option>
+<option value="1936">1936</option>
+<option value="1937">1937</option>
+<option value="1938">1938</option>
+<option value="1939">1939</option>
+<option value="1940">1940</option>
+<option value="1941">1941</option>
+<option value="1942">1942</option>
+<option value="1943">1943</option>
+<option value="1944">1944</option>
+<option value="1945">1945</option>
+<option value="1946">1946</option>
+<option value="1947">1947</option>
+<option value="1948">1948</option>
+<option value="1949">1949</option>
+<option value="1950">1950</option>
+<option value="1951">1951</option>
+<option value="1952">1952</option>
+<option value="1953">1953</option>
+<option value="1954">1954</option>
+<option value="1955">1955</option>
+<option value="1956">1956</option>
+<option value="1957">1957</option>
+<option value="1958">1958</option>
+<option value="1959">1959</option>
+<option value="1960">1960</option>
+<option value="1961">1961</option>
+<option value="1962">1962</option>
+<option value="1963">1963</option>
+<option value="1964">1964</option>
+<option value="1965">1965</option>
+<option value="1966">1966</option>
+<option value="1967">1967</option>
+<option value="1968">1968</option>
+<option value="1969">1969</option>
+<option value="1970">1970</option>
+<option value="1971">1971</option>
+<option value="1972">1972</option>
+<option value="1973">1973</option>
+<option value="1974">1974</option>
+<option value="1975">1975</option>
+<option value="1976">1976</option>
+<option value="1977">1977</option>
+<option value="1978">1978</option>
+<option value="1979">1979</option>
+<option value="1980">1980</option>
+<option value="1981">1981</option>
+<option value="1982">1982</option>
+<option value="1983">1983</option>
+<option value="1984">1984</option>
+<option value="1985">1985</option>
+<option value="1986">1986</option>
+<option value="1987">1987</option>
+<option value="1988">1988</option>
+<option value="1989">1989</option>
+<option value="1990">1990</option>
+<option value="1991">1991</option>
+<option value="1992">1992</option>
+<option value="1993">1993</option>
+<option value="1994">1994</option>
+<option value="1995">1995</option>
+<option value="1996">1996</option>
+<option value="1997">1997</option>
+<option value="1998">1998</option>
+<option value="1999">1999</option>
+<option value="2000">2000</option>
+<option value="2001">2001</option>
+<option value="2002">2002</option>
+<option value="2003">2003</option>
+<option value="2004">2004</option>
+<option value="2005">2005</option>
+<option value="2006">2006</option>
+<option value="2007">2007</option>
+<option value="2008">2008</option>
+<option value="2009">2009</option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/energy-grants-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you looking for:</td>
+      <td class="previous-question-body">
+      Help with your fuel bill</td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y?previous_response=help_with_fuel_bill">
+            Change<span class="visuallyhidden"> answer to "Are you looking for:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What are your circumstances?</td>
+      <td class="previous-question-body"><ul>
+        <li>none</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/energy-grants-calculator/y/help_with_fuel_bill?previous_response=none">
+            Change<span class="visuallyhidden"> answer to "What are your circumstances?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/energy-grants-calculator/y.html
+++ b/test/artefacts/energy-grants-calculator/y.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Find energy grants and ways to improve your energy efficiency - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Find energy grants and ways to improve your energy efficiency
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/energy-grants-calculator/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you looking for:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="help_with_fuel_bill" />
+          Help with your fuel bill
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="help_energy_efficiency" />
+          Help to make your home more energy efficient
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="help_boiler_measure" />
+          Help with a new boiler, insulation or other improvements
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="all_help" />
+          All of the above
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/estimate-self-assessment-penalties/2011-12.html
+++ b/test/artefacts/estimate-self-assessment-penalties/2011-12.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Estimate your penalty for late Self Assessment tax returns and payments - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Estimate your penalty for late Self Assessment tax returns and payments
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/estimate-self-assessment-penalties/y/2011-12" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How did you send your Self Assessment tax return?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="online" />
+          Online
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="paper" />
+          On paper
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/estimate-self-assessment-penalties">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">For which tax year do you want the estimate?</td>
+      <td class="previous-question-body">
+      6 April 2011 to 5 April 2012</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y?previous_response=2011-12">
+            Change<span class="visuallyhidden"> answer to "For which tax year do you want the estimate?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/estimate-self-assessment-penalties/2011-12/online.html
+++ b/test/artefacts/estimate-self-assessment-penalties/2011-12/online.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Estimate your penalty for late Self Assessment tax returns and payments - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Estimate your penalty for late Self Assessment tax returns and payments
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/estimate-self-assessment-penalties/y/2011-12/online" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When did you send your Self Assessment tax return?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you sent it online, enter the date you submitted the return. If you sent it on paper, add 2 days to the date you posted it. If you haven’t sent it yet, enter the date you expect to send it.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/estimate-self-assessment-penalties">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">For which tax year do you want the estimate?</td>
+      <td class="previous-question-body">
+      6 April 2011 to 5 April 2012</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y?previous_response=2011-12">
+            Change<span class="visuallyhidden"> answer to "For which tax year do you want the estimate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How did you send your Self Assessment tax return?</td>
+      <td class="previous-question-body">
+      Online</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y/2011-12?previous_response=online">
+            Change<span class="visuallyhidden"> answer to "How did you send your Self Assessment tax return?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07.html
+++ b/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Estimate your penalty for late Self Assessment tax returns and payments - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Estimate your penalty for late Self Assessment tax returns and payments
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/estimate-self-assessment-penalties/y/2011-12/online/2012-04-07" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When did you pay the bill?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you haven’t paid yet, enter the date you expect HM Revenue &amp; Customs to get your payment</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/estimate-self-assessment-penalties">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">For which tax year do you want the estimate?</td>
+      <td class="previous-question-body">
+      6 April 2011 to 5 April 2012</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y?previous_response=2011-12">
+            Change<span class="visuallyhidden"> answer to "For which tax year do you want the estimate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How did you send your Self Assessment tax return?</td>
+      <td class="previous-question-body">
+      Online</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y/2011-12?previous_response=online">
+            Change<span class="visuallyhidden"> answer to "How did you send your Self Assessment tax return?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When did you send your Self Assessment tax return?</td>
+      <td class="previous-question-body">
+       7 April 2012</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y/2011-12/online?previous_response=2012-04-07">
+            Change<span class="visuallyhidden"> answer to "When did you send your Self Assessment tax return?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07/2013-03-02.html
+++ b/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07/2013-03-02.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Estimate your penalty for late Self Assessment tax returns and payments - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Estimate your penalty for late Self Assessment tax returns and payments
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/estimate-self-assessment-penalties/y/2011-12/online/2012-04-07/2013-03-02" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Please enter how much your tax bill is (or an estimate if you don’t know)
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This calculator is anonymous. None of your details will be passed to HMRC.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />for the tax year</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/estimate-self-assessment-penalties">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">For which tax year do you want the estimate?</td>
+      <td class="previous-question-body">
+      6 April 2011 to 5 April 2012</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y?previous_response=2011-12">
+            Change<span class="visuallyhidden"> answer to "For which tax year do you want the estimate?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How did you send your Self Assessment tax return?</td>
+      <td class="previous-question-body">
+      Online</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y/2011-12?previous_response=online">
+            Change<span class="visuallyhidden"> answer to "How did you send your Self Assessment tax return?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When did you send your Self Assessment tax return?</td>
+      <td class="previous-question-body">
+       7 April 2012</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y/2011-12/online?previous_response=2012-04-07">
+            Change<span class="visuallyhidden"> answer to "When did you send your Self Assessment tax return?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When did you pay the bill?</td>
+      <td class="previous-question-body">
+       2 March 2013</td>
+
+      <td class="link-right">
+          <a href="/estimate-self-assessment-penalties/y/2011-12/online/2012-04-07?previous_response=2013-03-02">
+            Change<span class="visuallyhidden"> answer to "When did you pay the bill?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/estimate-self-assessment-penalties/y.html
+++ b/test/artefacts/estimate-self-assessment-penalties/y.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Estimate your penalty for late Self Assessment tax returns and payments - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Estimate your penalty for late Self Assessment tax returns and payments
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/estimate-self-assessment-penalties/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    For which tax year do you want the estimate?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="2011-12" />
+          6 April 2011 to 5 April 2012
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="2012-13" />
+          6 April 2012 to 5 April 2013
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="2013-14" />
+          6 April 2013 to 5 April 2014
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/help-if-you-are-arrested-abroad/y.html
+++ b/test/artefacts/help-if-you-are-arrested-abroad/y.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Help if you&#39;re arrested abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Help if you&#39;re arrested abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/help-if-you-are-arrested-abroad/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which country?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-guiana">French Guiana</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guadeloupe">Guadeloupe</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="martinique">Martinique</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mayotte">Mayotte</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="reunion">Reunion</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="the-occupied-palestinian-territories">The Occupied Palestinian Territories</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/england-and-wales" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is there a living husband, wife or civil partner?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">A surviving partner who wasn&#39;t married or in a civil partnership with the deceased has no automatic right to inherit.</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      England and Wales</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=england-and-wales">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/england-and-wales/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are there any living parents?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      England and Wales</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=england-and-wales">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did the deceased have any brothers or sisters?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      England and Wales</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=england-and-wales">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living parents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living parents?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did the deceased have any half-brothers or half-sisters?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      England and Wales</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=england-and-wales">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living parents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living parents?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any brothers or sisters?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any brothers or sisters?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are there any living grandparents?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      England and Wales</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=england-and-wales">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living parents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living parents?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any brothers or sisters?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any brothers or sisters?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any half-brothers or half-sisters?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any half-brothers or half-sisters?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no/no.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did the deceased have any aunts or uncles?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      England and Wales</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=england-and-wales">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living parents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living parents?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any brothers or sisters?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any brothers or sisters?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any half-brothers or half-sisters?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any half-brothers or half-sisters?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living grandparents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living grandparents?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no/no/no.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did the deceased have any half-aunts or half-uncles?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      England and Wales</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=england-and-wales">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living parents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living parents?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any brothers or sisters?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any brothers or sisters?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any half-brothers or half-sisters?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any half-brothers or half-sisters?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living grandparents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living grandparents?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any aunts or uncles?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/no/no/no/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any aunts or uncles?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/england-and-wales/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the estate likely to be worth more than £250,000?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      England and Wales</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=england-and-wales">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes/yes.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes/yes.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/england-and-wales/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Children include legally-adopted sons or daughters (but not stepchildren) and any children where the deceased had a parental role.</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      England and Wales</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=england-and-wales">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the estate likely to be worth more than £250,000?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/england-and-wales/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the estate likely to be worth more than £250,000?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/northern-ireland/yes/yes/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/northern-ireland/yes/yes/no/no.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/northern-ireland/yes/yes/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did the deceased have any brothers or sisters?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      Northern Ireland</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=northern-ireland">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/northern-ireland?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the estate likely to be worth more than £250,000?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/northern-ireland/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the estate likely to be worth more than £250,000?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/northern-ireland/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living parents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/northern-ireland/yes/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living parents?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/northern-ireland/yes/yes/yes.html
+++ b/test/artefacts/inherits-someone-dies-without-will/northern-ireland/yes/yes/yes.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/northern-ireland/yes/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did they have more than one child?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      Northern Ireland</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=northern-ireland">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/northern-ireland?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the estate likely to be worth more than £250,000?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/northern-ireland/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the estate likely to be worth more than £250,000?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/northern-ireland/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/scotland/no/no/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/scotland/no/no/no/no/no/no.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y/scotland/no/no/no/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are there any living great aunts or great uncles?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Great aunts and great uncles are brothers or sisters of the grandparents of the deceased.</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/inherits-someone-dies-without-will">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the deceased live?</td>
+      <td class="previous-question-body">
+      Scotland</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y?previous_response=scotland">
+            Change<span class="visuallyhidden"> answer to "Where did the deceased live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is there a living husband, wife or civil partner?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/scotland?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is there a living husband, wife or civil partner?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/scotland/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living parents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/scotland/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living parents?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any brothers or sisters?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/scotland/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any brothers or sisters?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the deceased have any aunts or uncles?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/scotland/no/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did the deceased have any aunts or uncles?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are there any living grandparents?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/inherits-someone-dies-without-will/y/scotland/no/no/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are there any living grandparents?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/inherits-someone-dies-without-will/y.html
+++ b/test/artefacts/inherits-someone-dies-without-will/y.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Intestacy - who inherits if someone dies without a will? - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Intestacy - who inherits if someone dies without a will?
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/inherits-someone-dies-without-will/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Where did the deceased live?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="england-and-wales" />
+          England and Wales
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="scotland" />
+          Scotland
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="northern-ireland" />
+          Northern Ireland
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the person renting the property as their main and only home?
+  </h2>
+  <div class="question-body">
+      <p>This includes:</p>
+
+<ul>
+  <li>tenancy agreement</li>
+  <li>a lease</li>
+  <li>a licence</li>
+  <li>sub-lease or sub-tenancy</li>
+  <li>lodgers</li>
+  <li>paying house guests</li>
+  <li>a family member living with the tenant as their main or only home</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/no.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What kind of property are you letting?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="holiday_accommodation" />
+          holiday accommodation
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="social_housing" />
+          social housing
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="care_home" />
+          a care home or hospice
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="hostel_or_refuge" />
+          a hostel or refuge
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="mobile_home" />
+          a mobile home
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="employee_accommodation" />
+          accommodation to an employee or as part of training, eg tied accommodation
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="student_accommodation" />
+          student accommodation
+        </label>
+    </li>
+    <li>
+        <label for="response_7" class="selectable">
+          <input type="radio" name="response" id="response_7" value="7_year_lease_property" />
+          a residential property with a lease for 7 years or more
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the person at least 18 years of age?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?
+  </h2>
+  <div class="question-body">
+      <p>A named person is someone who appears on someone else’s passport.</p>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the person have a certificate of right of abode in their passport?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the person have a Certificate of Registration or Naturalisation as a British citizen?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a certificate of right of abode in their passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a certificate of right of abode in their passport?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the person:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="eu_eea_switzerland" />
+          from the EU, EEA or Switzerland
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="non_eea_but_with_eu_eea_switzerland_family_member" />
+          a non-EEA family member of someone from the EU, EEA or Switzerland
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="somewhere_else" />
+          from somewhere else
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a certificate of right of abode in their passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a certificate of right of abode in their passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a Certificate of Registration or Naturalisation as a British citizen?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a Certificate of Registration or Naturalisation as a British citizen?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the person have any of the following:
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>a Registration Certificate or Document Certifying Permanent Residence issued by the Home Office to a national of the EU, EEA or Switzerland</li>
+  <li>a valid Biometric Residence Permit issued by the Home Office endorsed to show they’re allowed to stay indefinitely in the UK</li>
+  <li>a Permanent Residence Card, indefinite leave to remain, indefinite leave to enter or no time limit card issued by the Home Office</li>
+  <li>a valid passport showing that the person is exempt from immigration control, can stay indefinitely in the UK, has the right of abode in the UK or has no time limit on their stay in the UK</li>
+  <li>a current Immigration Status Document showing that the person has indefinite leave to stay in the UK or has no time limit to their stay</li>
+  <li>other documents exempting the person from immigration control (eg diplomatic passports, NATO ID card)</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a certificate of right of abode in their passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a certificate of right of abode in their passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a Certificate of Registration or Naturalisation as a British citizen?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a Certificate of Registration or Naturalisation as a British citizen?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person:</td>
+      <td class="previous-question-body">
+      from the EU, EEA or Switzerland</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no?previous_response=eu_eea_switzerland">
+            Change<span class="visuallyhidden"> answer to "Is the person:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the person have 2 of the following:
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>a full birth or adoption certificate (that shows details of at least one of the birth
+or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland</li>
+  <li>an official letter or document (dated within the last 3 months) from a government agency or department (with their name and work address), an employer (with their name and company address) or UK passport holder (with their name, address and passport number) that confirms the person’s name and that they’re an employee</li>
+  <li>a letter from a UK police force issued within the last 3 months confirming the person is a victim of crime and their documents have been stolen</li>
+  <li>evidence that the person is currently serving in the UK armed forces or has previously served</li>
+  <li>HM prison discharge papers or probation service letter (or the same from the Scottish or Northern Ireland Prison Service)</li>
+  <li>a letter from a UK further or higher education institution confirming the person has been accepted for studies</li>
+  <li>a current UK driving licence (either full or provisional)</li>
+  <li>a current UK firearms or shot gun certificate</li>
+  <li>a Disclosure or Barring Service certificate issued in the last 6 months</li>
+  <li>benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus within the last 12 months</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a certificate of right of abode in their passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a certificate of right of abode in their passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a Certificate of Registration or Naturalisation as a British citizen?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a Certificate of Registration or Naturalisation as a British citizen?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person:</td>
+      <td class="previous-question-body">
+      from the EU, EEA or Switzerland</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no?previous_response=eu_eea_switzerland">
+            Change<span class="visuallyhidden"> answer to "Is the person:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have any of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have any of the following:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the person have any of the following:
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>a current passport endorsed to show that the person can stay in the UK</li>
+  <li>a current Biometric Residence Permit issued by the Home Office to the person showing that they can currently stay in the UK</li>
+  <li>an Immigration Status Document issued by the Home Office with an endorsement showing the person can currently stay in the UK</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a certificate of right of abode in their passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a certificate of right of abode in their passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a Certificate of Registration or Naturalisation as a British citizen?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a Certificate of Registration or Naturalisation as a British citizen?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person:</td>
+      <td class="previous-question-body">
+      from the EU, EEA or Switzerland</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no?previous_response=eu_eea_switzerland">
+            Change<span class="visuallyhidden"> answer to "Is the person:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have any of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have any of the following:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have 2 of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have 2 of the following:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the person have a current Residence Card that is issued by the Home Office to a non-EEA national who is the family member of an EU, EEA or Swiss national?
+  </h2>
+  <div class="question-body">
+      <p>This includes a current Accession Card or Derivative Card.</p>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a certificate of right of abode in their passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a certificate of right of abode in their passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a Certificate of Registration or Naturalisation as a British citizen?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a Certificate of Registration or Naturalisation as a British citizen?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person:</td>
+      <td class="previous-question-body">
+      from the EU, EEA or Switzerland</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no?previous_response=eu_eea_switzerland">
+            Change<span class="visuallyhidden"> answer to "Is the person:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have any of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have any of the following:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have 2 of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have 2 of the following:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have any of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have any of the following:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the person have an application for a Registration Card issued by the Home Office showing that they can stay in the UK?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a certificate of right of abode in their passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a certificate of right of abode in their passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a Certificate of Registration or Naturalisation as a British citizen?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a Certificate of Registration or Naturalisation as a British citizen?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person:</td>
+      <td class="previous-question-body">
+      from the EU, EEA or Switzerland</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no?previous_response=eu_eea_switzerland">
+            Change<span class="visuallyhidden"> answer to "Is the person:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have any of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have any of the following:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have 2 of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have 2 of the following:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have any of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have any of the following:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current Residence Card that is issued by the Home Office to a non-EEA national who is the family member of an EU, EEA or Swiss national?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current Residence Card that is issued by the Home Office to a non-EEA national who is the family member of an EU, EEA or Swiss national?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no/no.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the person have an outstanding immigration application, immigration appeal or administrative review?
+  </h2>
+  <div class="question-body">
+      <p>They must also provide their Home Office reference number.</p>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/landlord-immigration-check">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Enter the postcode of the property you want to let:</td>
+      <td class="previous-question-body">
+      B1 1PW</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y?previous_response=B1+1PW">
+            Change<span class="visuallyhidden"> answer to "Enter the postcode of the property you want to let:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person renting the property as their main and only home?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person renting the property as their main and only home?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person at least 18 years of age?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the person at least 18 years of age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a certificate of right of abode in their passport?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a certificate of right of abode in their passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a Certificate of Registration or Naturalisation as a British citizen?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a Certificate of Registration or Naturalisation as a British citizen?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the person:</td>
+      <td class="previous-question-body">
+      from the EU, EEA or Switzerland</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no?previous_response=eu_eea_switzerland">
+            Change<span class="visuallyhidden"> answer to "Is the person:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have any of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have any of the following:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have 2 of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have 2 of the following:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have any of the following:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have any of the following:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have a current Residence Card that is issued by the Home Office to a non-EEA national who is the family member of an EU, EEA or Swiss national?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have a current Residence Card that is issued by the Home Office to a non-EEA national who is the family member of an EU, EEA or Swiss national?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the person have an application for a Registration Card issued by the Home Office showing that they can stay in the UK?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Does the person have an application for a Registration Card issued by the Home Office showing that they can stay in the UK?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/landlord-immigration-check/y.html
+++ b/test/artefacts/landlord-immigration-check/y.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if someone can rent your residential property - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if someone can rent your residential property
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/landlord-immigration-check/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Enter the postcode of the property you want to let:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response">
+  <input type="text" name="response" id="response" />
+</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/legalisation-document-checker/y.html
+++ b/test/artefacts/legalisation-document-checker/y.html
@@ -1,0 +1,443 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if documents can be legalised - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if documents can be legalised
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/legalisation-document-checker/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which documents do you want legalised?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="acro-police-certificate" />
+        ACRO Police Certificate
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="affidavit" />
+        Affidavit
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="articles-of-association" />
+        Articles of association
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="bank-statement" />
+        Bank statement
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="baptism-certificate" />
+        Baptism certificate
+      </label>
+    </li>
+    <li>
+      <label for="response_5">
+        <input type="checkbox" name="response[]" id="response_5" value="birth-certificate" />
+        Birth certificate
+      </label>
+    </li>
+    <li>
+      <label for="response_6">
+        <input type="checkbox" name="response[]" id="response_6" value="certificate-of-incorporation" />
+        Certificate of incorporation
+      </label>
+    </li>
+    <li>
+      <label for="response_7">
+        <input type="checkbox" name="response[]" id="response_7" value="certificate-of-freesale" />
+        Certificate of freesale
+      </label>
+    </li>
+    <li>
+      <label for="response_8">
+        <input type="checkbox" name="response[]" id="response_8" value="certificate-of-memorandum" />
+        Certificate of memorandum
+      </label>
+    </li>
+    <li>
+      <label for="response_9">
+        <input type="checkbox" name="response[]" id="response_9" value="certificate-of-naturalisation" />
+        Certificate of naturalisation
+      </label>
+    </li>
+    <li>
+      <label for="response_10">
+        <input type="checkbox" name="response[]" id="response_10" value="certificate-of-no-impediment" />
+        Certificate of no impediment
+      </label>
+    </li>
+    <li>
+      <label for="response_11">
+        <input type="checkbox" name="response[]" id="response_11" value="chamber-of-commerce-document" />
+        Chamber of Commerce document
+      </label>
+    </li>
+    <li>
+      <label for="response_12">
+        <input type="checkbox" name="response[]" id="response_12" value="change-of-name-deed" />
+        Change of name deed
+      </label>
+    </li>
+    <li>
+      <label for="response_13">
+        <input type="checkbox" name="response[]" id="response_13" value="civil-partnership-certificate" />
+        Civil partnership certificate
+      </label>
+    </li>
+    <li>
+      <label for="response_14">
+        <input type="checkbox" name="response[]" id="response_14" value="criminal-records-bureau-document" />
+        Criminal Records Bureau (CRB) document
+      </label>
+    </li>
+    <li>
+      <label for="response_15">
+        <input type="checkbox" name="response[]" id="response_15" value="criminal-records-check" />
+        Criminal records check
+      </label>
+    </li>
+    <li>
+      <label for="response_16">
+        <input type="checkbox" name="response[]" id="response_16" value="companies-house-document" />
+        Companies House document
+      </label>
+    </li>
+    <li>
+      <label for="response_17">
+        <input type="checkbox" name="response[]" id="response_17" value="county-court-document" />
+        County court document
+      </label>
+    </li>
+    <li>
+      <label for="response_18">
+        <input type="checkbox" name="response[]" id="response_18" value="court-document" />
+        Court document
+      </label>
+    </li>
+    <li>
+      <label for="response_19">
+        <input type="checkbox" name="response[]" id="response_19" value="court-of-bankruptcy-document" />
+        Court of Bankruptcy document
+      </label>
+    </li>
+    <li>
+      <label for="response_20">
+        <input type="checkbox" name="response[]" id="response_20" value="death-certificate" />
+        Death certificate
+      </label>
+    </li>
+    <li>
+      <label for="response_21">
+        <input type="checkbox" name="response[]" id="response_21" value="decree-nisi" />
+        Decree nisi
+      </label>
+    </li>
+    <li>
+      <label for="response_22">
+        <input type="checkbox" name="response[]" id="response_22" value="decree-absolute" />
+        Decree absolute
+      </label>
+    </li>
+    <li>
+      <label for="response_23">
+        <input type="checkbox" name="response[]" id="response_23" value="degree-certificate-uk" />
+        Degree certificate (UK)
+      </label>
+    </li>
+    <li>
+      <label for="response_24">
+        <input type="checkbox" name="response[]" id="response_24" value="department-of-business-innovation-skills-document" />
+        Department of Business, Innovation and Skills (BIS) document
+      </label>
+    </li>
+    <li>
+      <label for="response_25">
+        <input type="checkbox" name="response[]" id="response_25" value="department-of-health-document" />
+        Department of Health document
+      </label>
+    </li>
+    <li>
+      <label for="response_26">
+        <input type="checkbox" name="response[]" id="response_26" value="diploma" />
+        Diploma
+      </label>
+    </li>
+    <li>
+      <label for="response_27">
+        <input type="checkbox" name="response[]" id="response_27" value="disclosure-scotland-document" />
+        Disclosure Scotland document
+      </label>
+    </li>
+    <li>
+      <label for="response_28">
+        <input type="checkbox" name="response[]" id="response_28" value="doctor-letter-medical" />
+        Doctor’s letter (medical)
+      </label>
+    </li>
+    <li>
+      <label for="response_29">
+        <input type="checkbox" name="response[]" id="response_29" value="driving-licence" />
+        Driving licence (copy)
+      </label>
+    </li>
+    <li>
+      <label for="response_30">
+        <input type="checkbox" name="response[]" id="response_30" value="educational-certificate-uk" />
+        Educational certificate (UK)
+      </label>
+    </li>
+    <li>
+      <label for="response_31">
+        <input type="checkbox" name="response[]" id="response_31" value="export-certificate" />
+        Export certificate
+      </label>
+    </li>
+    <li>
+      <label for="response_32">
+        <input type="checkbox" name="response[]" id="response_32" value="family-division-high-court-justice-document" />
+        Family Division of the High Court of Justice document
+      </label>
+    </li>
+    <li>
+      <label for="response_33">
+        <input type="checkbox" name="response[]" id="response_33" value="fingerprints" />
+        Fingerprints document
+      </label>
+    </li>
+    <li>
+      <label for="response_34">
+        <input type="checkbox" name="response[]" id="response_34" value="fit-note-from-a-doctor" />
+        Fit note (from a doctor)
+      </label>
+    </li>
+    <li>
+      <label for="response_35">
+        <input type="checkbox" name="response[]" id="response_35" value="government-issued-document" />
+        Government issued document
+      </label>
+    </li>
+    <li>
+      <label for="response_36">
+        <input type="checkbox" name="response[]" id="response_36" value="grant-of-probate" />
+        Grant of probate
+      </label>
+    </li>
+    <li>
+      <label for="response_37">
+        <input type="checkbox" name="response[]" id="response_37" value="high-court-justice-document" />
+        High Court of Justice document
+      </label>
+    </li>
+    <li>
+      <label for="response_38">
+        <input type="checkbox" name="response[]" id="response_38" value="hmrc-document" />
+        HM Revenue and Customs document
+      </label>
+    </li>
+    <li>
+      <label for="response_39">
+        <input type="checkbox" name="response[]" id="response_39" value="home-office-document" />
+        Home Office document
+      </label>
+    </li>
+    <li>
+      <label for="response_40">
+        <input type="checkbox" name="response[]" id="response_40" value="last-will-testament" />
+        Last will and testament
+      </label>
+    </li>
+    <li>
+      <label for="response_41">
+        <input type="checkbox" name="response[]" id="response_41" value="letter-from-employer" />
+        Letter from an employer
+      </label>
+    </li>
+    <li>
+      <label for="response_42">
+        <input type="checkbox" name="response[]" id="response_42" value="letter-of-enrolment" />
+        Letter of enrolment
+      </label>
+    </li>
+    <li>
+      <label for="response_43">
+        <input type="checkbox" name="response[]" id="response_43" value="letter-of-invitation" />
+        Letter of invitation
+      </label>
+    </li>
+    <li>
+      <label for="response_44">
+        <input type="checkbox" name="response[]" id="response_44" value="letter-of-no-trace" />
+        Letter of no trace
+      </label>
+    </li>
+    <li>
+      <label for="response_45">
+        <input type="checkbox" name="response[]" id="response_45" value="medical-report" />
+        Medical report
+      </label>
+    </li>
+    <li>
+      <label for="response_46">
+        <input type="checkbox" name="response[]" id="response_46" value="marriage-certificate" />
+        Marriage certificate
+      </label>
+    </li>
+    <li>
+      <label for="response_47">
+        <input type="checkbox" name="response[]" id="response_47" value="name-change-deed-or-document" />
+        Name change deed or document
+      </label>
+    </li>
+    <li>
+      <label for="response_48">
+        <input type="checkbox" name="response[]" id="response_48" value="passport-copy-only" />
+        Passport (copy only)
+      </label>
+    </li>
+    <li>
+      <label for="response_49">
+        <input type="checkbox" name="response[]" id="response_49" value="pet-export-document" />
+        Pet export document from the Department of Environment, Food and Rural Affairs (DEFRA)
+      </label>
+    </li>
+    <li>
+      <label for="response_50">
+        <input type="checkbox" name="response[]" id="response_50" value="police-disclosure-document" />
+        Police disclosure document
+      </label>
+    </li>
+    <li>
+      <label for="response_51">
+        <input type="checkbox" name="response[]" id="response_51" value="power-of-attorney" />
+        Power of attorney
+      </label>
+    </li>
+    <li>
+      <label for="response_52">
+        <input type="checkbox" name="response[]" id="response_52" value="probate" />
+        Probate
+      </label>
+    </li>
+    <li>
+      <label for="response_53">
+        <input type="checkbox" name="response[]" id="response_53" value="reference-from-an-employer" />
+        Reference from an employer
+      </label>
+    </li>
+    <li>
+      <label for="response_54">
+        <input type="checkbox" name="response[]" id="response_54" value="religious-document" />
+        Religious document
+      </label>
+    </li>
+    <li>
+      <label for="response_55">
+        <input type="checkbox" name="response[]" id="response_55" value="sheriff-court-document" />
+        Sheriff court document
+      </label>
+    </li>
+    <li>
+      <label for="response_56">
+        <input type="checkbox" name="response[]" id="response_56" value="sick-note-from-doctor" />
+        Sick note (from a doctor)
+      </label>
+    </li>
+    <li>
+      <label for="response_57">
+        <input type="checkbox" name="response[]" id="response_57" value="statutory-declaration" />
+        Statutory declaration
+      </label>
+    </li>
+    <li>
+      <label for="response_58">
+        <input type="checkbox" name="response[]" id="response_58" value="test-results-medical" />
+        Test results (medical)
+      </label>
+    </li>
+    <li>
+      <label for="response_59">
+        <input type="checkbox" name="response[]" id="response_59" value="translation" />
+        Translation
+      </label>
+    </li>
+    <li>
+      <label for="response_60">
+        <input type="checkbox" name="response[]" id="response_60" value="utility-bill" />
+        Utility bill
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/marriage-abroad/albania.html
+++ b/test/artefacts/marriage-abroad/albania.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Getting married abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Getting married abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/marriage-abroad/y/albania" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Where do you live?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="uk" />
+          UK
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="ceremony_country" />
+          Albania
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="third_country" />
+          Elsewhere
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/marriage-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where do you want to get married?</td>
+      <td class="previous-question-body">
+      Albania</td>
+
+      <td class="link-right">
+          <a href="/marriage-abroad/y?previous_response=albania">
+            Change<span class="visuallyhidden"> answer to "Where do you want to get married?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/marriage-abroad/albania/uk.html
+++ b/test/artefacts/marriage-abroad/albania/uk.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Getting married abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Getting married abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/marriage-abroad/y/albania/uk" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your partner’s nationality?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="partner_british" />
+          British
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="partner_local" />
+          National of Albania
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="partner_other" />
+          National of another country
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/marriage-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where do you want to get married?</td>
+      <td class="previous-question-body">
+      Albania</td>
+
+      <td class="link-right">
+          <a href="/marriage-abroad/y?previous_response=albania">
+            Change<span class="visuallyhidden"> answer to "Where do you want to get married?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where do you live?</td>
+      <td class="previous-question-body">
+      UK</td>
+
+      <td class="link-right">
+          <a href="/marriage-abroad/y/albania?previous_response=uk">
+            Change<span class="visuallyhidden"> answer to "Where do you live?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/marriage-abroad/albania/uk/partner_british.html
+++ b/test/artefacts/marriage-abroad/albania/uk/partner_british.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Getting married abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Getting married abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/marriage-abroad/y/albania/uk/partner_british" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is your partner of the opposite sex, or the same sex?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="opposite_sex" />
+          Opposite sex
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="same_sex" />
+          Same sex
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/marriage-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where do you want to get married?</td>
+      <td class="previous-question-body">
+      Albania</td>
+
+      <td class="link-right">
+          <a href="/marriage-abroad/y?previous_response=albania">
+            Change<span class="visuallyhidden"> answer to "Where do you want to get married?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where do you live?</td>
+      <td class="previous-question-body">
+      UK</td>
+
+      <td class="link-right">
+          <a href="/marriage-abroad/y/albania?previous_response=uk">
+            Change<span class="visuallyhidden"> answer to "Where do you live?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your partner’s nationality?</td>
+      <td class="previous-question-body">
+      British</td>
+
+      <td class="link-right">
+          <a href="/marriage-abroad/y/albania/uk?previous_response=partner_british">
+            Change<span class="visuallyhidden"> answer to "What is your partner’s nationality?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/marriage-abroad/france.html
+++ b/test/artefacts/marriage-abroad/france.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Getting married abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Getting married abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/marriage-abroad/y/france" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you want to get married or enter into a PACS?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">PACS (‘pacte civil de solidarité’, or ‘civil solidarity pact’) is the French version of civil partnership, and can be entered into by same-sex or opposite-sex couples.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="marriage" />
+          Marriage
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="pacs" />
+          PACS
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/marriage-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where do you want to get married?</td>
+      <td class="previous-question-body">
+      France</td>
+
+      <td class="link-right">
+          <a href="/marriage-abroad/y?previous_response=france">
+            Change<span class="visuallyhidden"> answer to "Where do you want to get married?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/marriage-abroad/y.html
+++ b/test/artefacts/marriage-abroad/y.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Getting married abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Getting married abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/marriage-abroad/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Where do you want to get married?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-guiana">French Guiana</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guadeloupe">Guadeloupe</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="martinique">Martinique</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mayotte">Mayotte</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="reunion">Reunion</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the employee taking paternity leave to adopt a child?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When was the child matched with the employee?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">For overseas adoptions, enter the official notification date (the permission to adopt from abroad).</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When will the child be placed with the employee?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">For overseas adoptions enter the date of arrival in the UK.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did the employee work for you on or before 18 October 2014?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the employee have an employment contract with you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 18 October 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 18 October 2014?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the employee on your payroll?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 18 October 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 18 October 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When does the employee want to start their leave?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Leave can’t start before 23 March 2015. For overseas adoptions your leave must start within 28 days of the child arriving in the UK.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 18 October 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 18 October 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the last normal payday on or before Saturday, 11 April 2015?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 18 October 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 18 October 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the last normal payday before Friday, 07 November 2014?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 18 October 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 18 October 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 11 April 2015?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 11 April 2015?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you pay the employee?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If they’re paid irregularly choose ‘weekly’.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly" />
+          Weekly
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="every_2_weeks" />
+          Every 2 weeks
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="every_4_weeks" />
+          Every 4 weeks
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="monthly" />
+          Monthly
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 18 October 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 18 October 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 11 April 2015?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 11 April 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014?</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What were the employee’s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This is their earnings before deductions like PAYE, pension or National Insurance contributions.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 18 October 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 18 October 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 11 April 2015?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 11 April 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014?</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly/3000.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly/3000.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly/3000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How do you want the adoption pay calculated?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly_starting" />
+          Weekly starting  6 April 2015
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="usual_paydates" />
+          Based on their usual paydates
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Adoption</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=adoption">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee taking paternity leave to adopt a child?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the employee taking paternity leave to adopt a child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       5 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no?previous_response=2015-04-05">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 18 October 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 18 October 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       6 April 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes?previous_response=2015-04-06">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 11 April 2015?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 11 April 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014?</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee’s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?</td>
+      <td class="previous-question-body">
+      £3,000</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly?previous_response=3000.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee’s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is the baby’s due date?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the employee have an employment contract with you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When does the employee want to start their leave?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Based on the baby&#39;s due date, leave usually can’t start before 12 October 2014.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did the employee work for you on or before 29 March 2014?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the employee on your payroll?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the last normal payday on or before Saturday, 20 September 2014?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the last normal payday before Saturday, 26 July 2014?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you pay the employee?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If they’re paid irregularly choose ‘weekly’.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly" />
+          Weekly
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="every_2_weeks" />
+          Every 2 weeks
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="every_4_weeks" />
+          Every 4 weeks
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="monthly" />
+          Monthly
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Saturday, 26 July 2014?</td>
+      <td class="previous-question-body">
+      24 July 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19?previous_response=2014-07-24">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Saturday, 26 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When in the month is the employee paid?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If the pay date is the 29th, 30th or 31st choose &#39;Last working day of the month&#39;.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="first_day_of_the_month" />
+          First day of the month
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="last_day_of_the_month" />
+          Last day of the month
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="specific_date_each_month" />
+          Specific date each month
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="last_working_day_of_the_month" />
+          Last working day of the month
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="a_certain_week_day_each_month" />
+          A certain week day each month
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Saturday, 26 July 2014?</td>
+      <td class="previous-question-body">
+      24 July 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19?previous_response=2014-07-24">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Saturday, 26 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the SMP calculated?</td>
+      <td class="previous-question-body">
+      based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the SMP calculated?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What particular day of the month is the employee paid?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="Sunday" />
+          Sunday
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="Monday" />
+          Monday
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="Tuesday" />
+          Tuesday
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="Wednesday" />
+          Wednesday
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="Thursday" />
+          Thursday
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="Friday" />
+          Friday
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="Saturday" />
+          Saturday
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Saturday, 26 July 2014?</td>
+      <td class="previous-question-body">
+      24 July 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19?previous_response=2014-07-24">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Saturday, 26 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the SMP calculated?</td>
+      <td class="previous-question-body">
+      based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the SMP calculated?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When in the month is the employee paid?</td>
+      <td class="previous-question-body">
+      A certain week day each month</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates?previous_response=a_certain_week_day_each_month">
+            Change<span class="visuallyhidden"> answer to "When in the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the employee paid on the 1st, 2nd, 3rd, 4th or last Sunday?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="first" />
+          1st
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="second" />
+          2nd
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="third" />
+          3rd
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="fourth" />
+          4th
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="last" />
+          last
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Saturday, 26 July 2014?</td>
+      <td class="previous-question-body">
+      24 July 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19?previous_response=2014-07-24">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Saturday, 26 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the SMP calculated?</td>
+      <td class="previous-question-body">
+      based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the SMP calculated?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When in the month is the employee paid?</td>
+      <td class="previous-question-body">
+      A certain week day each month</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates?previous_response=a_certain_week_day_each_month">
+            Change<span class="visuallyhidden"> answer to "When in the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What particular day of the month is the employee paid?</td>
+      <td class="previous-question-body">
+      Sunday</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month?previous_response=Sunday">
+            Change<span class="visuallyhidden"> answer to "What particular day of the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What days does the employee work?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="0" />
+        Sunday
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="1" />
+        Monday
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="2" />
+        Tuesday
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="3" />
+        Wednesday
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="4" />
+        Thursday
+      </label>
+    </li>
+    <li>
+      <label for="response_5">
+        <input type="checkbox" name="response[]" id="response_5" value="5" />
+        Friday
+      </label>
+    </li>
+    <li>
+      <label for="response_6">
+        <input type="checkbox" name="response[]" id="response_6" value="6" />
+        Saturday
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Saturday, 26 July 2014?</td>
+      <td class="previous-question-body">
+      24 July 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19?previous_response=2014-07-24">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Saturday, 26 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the SMP calculated?</td>
+      <td class="previous-question-body">
+      based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the SMP calculated?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When in the month is the employee paid?</td>
+      <td class="previous-question-body">
+      Last working day of the month</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates?previous_response=last_working_day_of_the_month">
+            Change<span class="visuallyhidden"> answer to "When in the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/specific_date_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/specific_date_each_month.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/specific_date_each_month" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What specific date each month is the employee paid?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If they’re paid on the 25th enter &quot;25&quot;. The calculator will treat an employee as paid on the last day of the month if you enter 29, 30 or 31.</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Saturday, 26 July 2014?</td>
+      <td class="previous-question-body">
+      24 July 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19?previous_response=2014-07-24">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Saturday, 26 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the SMP calculated?</td>
+      <td class="previous-question-body">
+      based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the SMP calculated?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When in the month is the employee paid?</td>
+      <td class="previous-question-body">
+      Specific date each month</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates?previous_response=specific_date_each_month">
+            Change<span class="visuallyhidden"> answer to "When in the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This is their earnings before deductions like PAYE, pension or National Insurance contributions.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Saturday, 26 July 2014?</td>
+      <td class="previous-question-body">
+      24 July 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19?previous_response=2014-07-24">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Saturday, 26 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.0/usual_paydates.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.0/usual_paydates" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When is your employee’s next pay day on or after  1 January 2015?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Saturday, 26 July 2014?</td>
+      <td class="previous-question-body">
+      24 July 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19?previous_response=2014-07-24">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Saturday, 26 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the SMP calculated?</td>
+      <td class="previous-question-body">
+      based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the SMP calculated?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How do you want the SMP calculated?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly_starting" />
+          weekly starting  1 January 2015
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="usual_paydates" />
+          based on their usual paydates
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Maternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=maternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 29 March 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 29 March 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 20 September 2014?</td>
+      <td class="previous-question-body">
+      19 September 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes?previous_response=2014-09-19">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 20 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Saturday, 26 July 2014?</td>
+      <td class="previous-question-body">
+      24 July 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19?previous_response=2014-07-24">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Saturday, 26 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the paternity leave or pay for an adoption?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/no.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/no.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is the baby’s due date?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/no/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/no/2015-01-01.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/no/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is the actual birth date?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If unknown enter the due date.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/no?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/no/2015-01-01/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/no/2015-01-01/2015-01-01.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/no/2015-01-01/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the employee responsible for the child’s upbringing and either the biological father or the mother’s husband or partner?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the baby’s due date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/no?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the baby’s due date?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is the actual birth date?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/no/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What is the actual birth date?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When was the child matched with the employee?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When will the child be placed with the employee?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did the employee work for you on or before 12 July 2014?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the employee have an employment contract with you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the employee on your payroll?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Will the employee still be employed by you on  1 January 2015?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When does the employee want to start their paternity leave?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Leave cannot start before Thursday, 01 January 2015.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How long is the employee&#39;s paternity leave?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="one_week" />
+          One week
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="two_weeks" />
+          Two weeks
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the last normal payday on or before Saturday, 03 January 2015
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What was the last normal payday before Friday, 07 November 2014
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you pay the employee?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If they are paid irregularly choose &#39;weekly&#39;.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly" />
+          Weekly
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="every_2_weeks" />
+          Every 2 weeks
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="every_4_weeks" />
+          Every 4 weeks
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="monthly" />
+          Monthly
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When in the month is the employee paid?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If the pay date is the 29th, 30th or 31st choose &#39;Last working day of the month&#39;.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="first_day_of_the_month" />
+          First day of the month
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="last_day_of_the_month" />
+          Last day of the month
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="specific_date_each_month" />
+          Specific date each month
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="last_working_day_of_the_month" />
+          Last working day of the month
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="a_certain_week_day_each_month" />
+          A certain week day each month
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?</td>
+      <td class="previous-question-body">
+      £3,000</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly?previous_response=3000.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the paternity pay calculated?</td>
+      <td class="previous-question-body">
+      Based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the paternity pay calculated?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What particular day of the month is the employee paid?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="0" />
+          Sunday
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="1" />
+          Monday
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="2" />
+          Tuesday
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="3" />
+          Wednesday
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="4" />
+          Thursday
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="5" />
+          Friday
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="6" />
+          Saturday
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?</td>
+      <td class="previous-question-body">
+      £3,000</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly?previous_response=3000.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the paternity pay calculated?</td>
+      <td class="previous-question-body">
+      Based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the paternity pay calculated?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When in the month is the employee paid?</td>
+      <td class="previous-question-body">
+      A certain week day each month</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates?previous_response=a_certain_week_day_each_month">
+            Change<span class="visuallyhidden"> answer to "When in the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the employee paid on the 1st, 2nd, 3rd, 4th or last Sunday?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="first" />
+          1st
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="second" />
+          2nd
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="third" />
+          3rd
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="fourth" />
+          4th
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="last" />
+          last
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?</td>
+      <td class="previous-question-body">
+      £3,000</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly?previous_response=3000.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the paternity pay calculated?</td>
+      <td class="previous-question-body">
+      Based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the paternity pay calculated?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When in the month is the employee paid?</td>
+      <td class="previous-question-body">
+      A certain week day each month</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates?previous_response=a_certain_week_day_each_month">
+            Change<span class="visuallyhidden"> answer to "When in the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What particular day of the month is the employee paid?</td>
+      <td class="previous-question-body">
+      Sunday</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month?previous_response=0">
+            Change<span class="visuallyhidden"> answer to "What particular day of the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What days does the employee work?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="0" />
+        Sunday
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="1" />
+        Monday
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="2" />
+        Tuesday
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="3" />
+        Wednesday
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="4" />
+        Thursday
+      </label>
+    </li>
+    <li>
+      <label for="response_5">
+        <input type="checkbox" name="response[]" id="response_5" value="5" />
+        Friday
+      </label>
+    </li>
+    <li>
+      <label for="response_6">
+        <input type="checkbox" name="response[]" id="response_6" value="6" />
+        Saturday
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?</td>
+      <td class="previous-question-body">
+      £3,000</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly?previous_response=3000.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the paternity pay calculated?</td>
+      <td class="previous-question-body">
+      Based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the paternity pay calculated?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When in the month is the employee paid?</td>
+      <td class="previous-question-body">
+      Last working day of the month</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates?previous_response=last_working_day_of_the_month">
+            Change<span class="visuallyhidden"> answer to "When in the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/specific_date_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/specific_date_each_month.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/specific_date_each_month" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What specific date each month is the employee paid?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If they are paid on the 25th enter &#39;25&#39;. The calculator will treat an employee as paid on the last day of the month if you enter &#39;29&#39;, &#39;30&#39; or &#39;31&#39;.</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Monthly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01?previous_response=monthly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?</td>
+      <td class="previous-question-body">
+      £3,000</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly?previous_response=3000.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the paternity pay calculated?</td>
+      <td class="previous-question-body">
+      Based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the paternity pay calculated?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When in the month is the employee paid?</td>
+      <td class="previous-question-body">
+      Specific date each month</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates?previous_response=specific_date_each_month">
+            Change<span class="visuallyhidden"> answer to "When in the month is the employee paid?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This is the earnings before deductions like PAYE, pendion or National Insurance contributions.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.0/usual_paydates.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.0/usual_paydates" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When is your employee&#39;s next pay day on or after  1 January 2015
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?</td>
+      <td class="previous-question-body">
+      £3,000</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly?previous_response=3000.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How do you want the paternity pay calculated?</td>
+      <td class="previous-question-body">
+      Based on their usual paydates</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.0?previous_response=usual_paydates">
+            Change<span class="visuallyhidden"> answer to "How do you want the paternity pay calculated?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How do you want the paternity pay calculated?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="weekly_starting" />
+          Weekly starting  1 January 2015
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="usual_paydates" />
+          Based on their usual paydates
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/maternity-paternity-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you want to check?</td>
+      <td class="previous-question-body">
+      Paternity</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y?previous_response=paternity">
+            Change<span class="visuallyhidden"> answer to "What do you want to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the paternity leave or pay for an adoption?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the paternity leave or pay for an adoption?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was the child matched with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When was the child matched with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child be placed with the employee?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When will the child be placed with the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee responsible for the child&#39;s upbringing and the husband or partner of the adopter or the child&#39;s adopter?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the employee work for you on or before 12 July 2014?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the employee work for you on or before 12 July 2014?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Does the employee have an employment contract with you?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Does the employee have an employment contract with you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the employee on your payroll?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Will the employee still be employed by you on  1 January 2015?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will the employee still be employed by you on  1 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When does the employee want to start their paternity leave?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When does the employee want to start their paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long is the employee&#39;s paternity leave?</td>
+      <td class="previous-question-body">
+      One week</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01?previous_response=one_week">
+            Change<span class="visuallyhidden"> answer to "How long is the employee&#39;s paternity leave?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday on or before Saturday, 03 January 2015</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday on or before Saturday, 03 January 2015"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What was the last normal payday before Friday, 07 November 2014</td>
+      <td class="previous-question-body">
+       1 November 2014</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01?previous_response=2014-11-01">
+            Change<span class="visuallyhidden"> answer to "What was the last normal payday before Friday, 07 November 2014"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the employee?</td>
+      <td class="previous-question-body">
+      Weekly</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01?previous_response=weekly">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the employee?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?</td>
+      <td class="previous-question-body">
+      £3,000</td>
+
+      <td class="link-right">
+          <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly?previous_response=3000.0">
+            Change<span class="visuallyhidden"> answer to "What were the employee&#39;s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/maternity-paternity-calculator/y.html
+++ b/test/artefacts/maternity-paternity-calculator/y.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Maternity and paternity calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Maternity and paternity calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/maternity-paternity-calculator/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What do you want to check?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="maternity" />
+          Maternity
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="paternity" />
+          Paternity
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="adoption" />
+          Adoption
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the worker an apprentice?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If they’re 19 or over and past their first year they don’t count as an apprentice for minimum wage purposes.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="not_an_apprentice" />
+          Not an apprentice
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="apprentice_under_19" />
+          Apprentice under 19
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="apprentice_over_19_first_year" />
+          Apprentice aged 19 and over in their first year
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="apprentice_over_19_second_year_onwards" />
+          Apprentice 19 and over in their second year or onwards
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old is the worker?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years old</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the worker an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Is the worker an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often do you pay the worker?
+  </h2>
+  <div class="question-body">
+      <p>This is the pay period.</p>
+
+
+      <p class="hint">You pay the worker every
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />days</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the worker an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Is the worker an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old is the worker?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old is the worker?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours does the worker work during the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Don’t include any overtime or other extra hours the worker might work.
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />hours</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the worker an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Is the worker an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old is the worker?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old is the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you charge for accommodation per day?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the worker an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Is the worker an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old is the worker?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old is the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you provide accommodation?</td>
+      <td class="previous-question-body">
+      Yes, the accommodation is charged for</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0?previous_response=yes_charged">
+            Change<span class="visuallyhidden"> answer to "Do you provide accommodation?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many days per week does the worker live in the accommodation?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />days per week</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the worker an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Is the worker an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old is the worker?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old is the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you provide accommodation?</td>
+      <td class="previous-question-body">
+      Yes, the accommodation is free</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0?previous_response=yes_free">
+            Change<span class="visuallyhidden"> answer to "Do you provide accommodation?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you provide accommodation?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="no" />
+          No
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="yes_free" />
+          Yes, the accommodation is free
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="yes_charged" />
+          Yes, the accommodation is charged for
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the worker an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Is the worker an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old is the worker?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old is the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0/8.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you pay the worker for overtime per hour?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the worker an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Is the worker an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old is the worker?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old is the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      8.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0?previous_response=8.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0/100.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours of overtime does the worker work during the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If they don’t work overtime enter 0</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />hours</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the worker an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Is the worker an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old is the worker?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old is the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much do you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1/16.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you pay the worker in the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Don’t include payments for overtime or anything extra to their pay, eg money for clothes or goods.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you’re paying a worker the National Wage (from October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=current_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the worker an apprentice?</td>
+      <td class="previous-question-body">
+      Not an apprentice</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment?previous_response=not_an_apprentice">
+            Change<span class="visuallyhidden"> answer to "Is the worker an apprentice?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old is the worker?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old is the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often do you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often do you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours does the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/current_payment/not_an_apprentice/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours does the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which year would you like to check past payments for?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You can go back up to 6 years</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="2013-10-01" />
+          Oct 2013 - Sep 2014
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="2012-10-01" />
+          Oct 2012 - Sep 2013
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="2011-10-01" />
+          Oct 2011 - Sep 2012
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="2010-10-01" />
+          Oct 2010 - Sep 2011
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="2009-10-01" />
+          Oct 2009 - Sep 2010
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="2008-10-01" />
+          Oct 2008 - Sep 2009
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Was the worker an apprentice at the time?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="no" />
+          No
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="apprentice_under_19" />
+          Apprentice under 19
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="apprentice_over_19" />
+          Apprentice aged 19 and over and in their first year
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old was the worker at the time?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />years old</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was the worker an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Was the worker an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How often did you pay the worker?
+  </h2>
+  <div class="question-body">
+      <p>This is the pay period.</p>
+
+
+      <p class="hint">You pay the worker every
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />days</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was the worker an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Was the worker an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was the worker at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old was the worker at the time?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours did the worker work during the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Don’t include any overtime or other extra hours the worker worked.
+</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />hours</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was the worker an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Was the worker an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was the worker at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old was the worker at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_charged" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much did you charge for accommodation per day?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per day</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was the worker an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Was the worker an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was the worker at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old was the worker at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much did you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much did you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you provide accommodation?</td>
+      <td class="previous-question-body">
+      Yes, the accommodation was charged for</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0?previous_response=yes_charged">
+            Change<span class="visuallyhidden"> answer to "Did you provide accommodation?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_free.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_free.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0/yes_free" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many days per week did the worker live in the accommodation?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />days per week</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was the worker an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Was the worker an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was the worker at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old was the worker at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much did you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much did you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you provide accommodation?</td>
+      <td class="previous-question-body">
+      Yes, the accommodation was free</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0?previous_response=yes_free">
+            Change<span class="visuallyhidden"> answer to "Did you provide accommodation?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.0/0.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.0/0.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0/0.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did you provide accommodation?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="no" />
+          No
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="yes_free" />
+          Yes, the accommodation was free
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="yes_charged" />
+          Yes, the accommodation was charged for
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was the worker an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Was the worker an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was the worker at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old was the worker at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much did you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much did you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      0.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0?previous_response=0.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.0/8.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.0/8.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0/8.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much did you pay the worker for overtime per hour?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />per hour</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was the worker an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Was the worker an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was the worker at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old was the worker at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much did you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much did you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours of overtime did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      8.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0?previous_response=8.0">
+            Change<span class="visuallyhidden"> answer to "How many hours of overtime did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.0/100.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0/100.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many hours of overtime did the worker work during the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If they didn’t work overtime enter 0</p>
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />hours</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was the worker an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Was the worker an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was the worker at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old was the worker at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much did you pay the worker in the pay period?</td>
+      <td class="previous-question-body">
+      £100</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0?previous_response=100.0">
+            Change<span class="visuallyhidden"> answer to "How much did you pay the worker in the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2013-10-01/no/25/1/16.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1/16.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much did you pay the worker in the pay period?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Don’t include payments for overtime or anything extra to their pay, eg money for clothes or goods.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" />in the pay period</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/minimum-wage-calculator-employers">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What would you like to check?</td>
+      <td class="previous-question-body">
+      If you owe a worker past payments (before October 2014)</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y?previous_response=past_payment">
+            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which year would you like to check past payments for?</td>
+      <td class="previous-question-body">
+      Oct 2013 - Sep 2014</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment?previous_response=2013-10-01">
+            Change<span class="visuallyhidden"> answer to "Which year would you like to check past payments for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Was the worker an apprentice at the time?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Was the worker an apprentice at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How old was the worker at the time?</td>
+      <td class="previous-question-body">
+      25</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no?previous_response=25">
+            Change<span class="visuallyhidden"> answer to "How old was the worker at the time?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How often did you pay the worker?</td>
+      <td class="previous-question-body">
+      1</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25?previous_response=1">
+            Change<span class="visuallyhidden"> answer to "How often did you pay the worker?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many hours did the worker work during the pay period?</td>
+      <td class="previous-question-body">
+      16.0</td>
+
+      <td class="link-right">
+          <a href="/minimum-wage-calculator-employers/y/past_payment/2013-10-01/no/25/1?previous_response=16.0">
+            Change<span class="visuallyhidden"> answer to "How many hours did the worker work during the pay period?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/minimum-wage-calculator-employers/y.html
+++ b/test/artefacts/minimum-wage-calculator-employers/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>National Minimum Wage calculator for employers - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        National Minimum Wage calculator for employers
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/minimum-wage-calculator-employers/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What would you like to check?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="current_payment" />
+          If you’re paying a worker the National Wage (from October 2014)
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="past_payment" />
+          If you owe a worker past payments (before October 2014)
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/overseas-passports/france.html
+++ b/test/artefacts/overseas-passports/france.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Overseas British passport applications - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Overseas British passport applications
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/overseas-passports/y/france" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you renewing, replacing or applying for a first passport?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="renewing_new" />
+          Renewing a red passport
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="renewing_old" />
+          Renewing an old black or blue passport
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="applying" />
+          Applying for a first passport
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="replacing" />
+          Replacing a lost or stolen passport
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/overseas-passports">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country or territory are you in?</td>
+      <td class="previous-question-body">
+      France</td>
+
+      <td class="link-right">
+          <a href="/overseas-passports/y?previous_response=france">
+            Change<span class="visuallyhidden"> answer to "Which country or territory are you in?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/overseas-passports/france/renewing_new.html
+++ b/test/artefacts/overseas-passports/france/renewing_new.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Overseas British passport applications - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Overseas British passport applications
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/overseas-passports/y/france/renewing_new" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you need an adult or child passport?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="adult" />
+          Adult (aged 16 and over)
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="child" />
+          Child (aged 15 or under)
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/overseas-passports">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country or territory are you in?</td>
+      <td class="previous-question-body">
+      France</td>
+
+      <td class="link-right">
+          <a href="/overseas-passports/y?previous_response=france">
+            Change<span class="visuallyhidden"> answer to "Which country or territory are you in?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you renewing, replacing or applying for a first passport?</td>
+      <td class="previous-question-body">
+      Renewing a red passport</td>
+
+      <td class="link-right">
+          <a href="/overseas-passports/y/france?previous_response=renewing_new">
+            Change<span class="visuallyhidden"> answer to "Are you renewing, replacing or applying for a first passport?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/overseas-passports/france/renewing_old/adult.html
+++ b/test/artefacts/overseas-passports/france/renewing_old/adult.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Overseas British passport applications - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Overseas British passport applications
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/overseas-passports/y/france/renewing_old/adult" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which country were you born in?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-guiana">French Guiana</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guadeloupe">Guadeloupe</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="martinique">Martinique</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mayotte">Mayotte</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="reunion">Reunion</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="the-occupied-palestinian-territories">The Occupied Palestinian Territories</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="united-kingdom">United Kingdom</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/overseas-passports">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country or territory are you in?</td>
+      <td class="previous-question-body">
+      France</td>
+
+      <td class="link-right">
+          <a href="/overseas-passports/y?previous_response=france">
+            Change<span class="visuallyhidden"> answer to "Which country or territory are you in?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you renewing, replacing or applying for a first passport?</td>
+      <td class="previous-question-body">
+      Renewing an old black or blue passport</td>
+
+      <td class="link-right">
+          <a href="/overseas-passports/y/france?previous_response=renewing_old">
+            Change<span class="visuallyhidden"> answer to "Are you renewing, replacing or applying for a first passport?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you need an adult or child passport?</td>
+      <td class="previous-question-body">
+      Adult (aged 16 and over)</td>
+
+      <td class="link-right">
+          <a href="/overseas-passports/y/france/renewing_old?previous_response=adult">
+            Change<span class="visuallyhidden"> answer to "Do you need an adult or child passport?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories.html
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Overseas British passport applications - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Overseas British passport applications
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/overseas-passports/y/the-occupied-palestinian-territories" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Where are you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="gaza" />
+          Gaza
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="jerusalem-or-westbank" />
+          Jerusalem and the West Bank
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/overseas-passports">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country or territory are you in?</td>
+      <td class="previous-question-body">
+      The Occupied Palestinian Territories</td>
+
+      <td class="link-right">
+          <a href="/overseas-passports/y?previous_response=the-occupied-palestinian-territories">
+            Change<span class="visuallyhidden"> answer to "Which country or territory are you in?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/overseas-passports/y.html
+++ b/test/artefacts/overseas-passports/y.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Overseas British passport applications - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Overseas British passport applications
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/overseas-passports/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which country or territory are you in?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-guiana">French Guiana</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guadeloupe">Guadeloupe</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="martinique">Martinique</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mayotte">Mayotte</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="reunion">Reunion</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="the-occupied-palestinian-territories">The Occupied Palestinian Territories</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/pip-checker/y.html
+++ b/test/artefacts/pip-checker/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check how Personal Independence Payment (PIP) affects you - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check how Personal Independence Payment (PIP) affects you
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/pip-checker/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you getting Disability Living Allowance?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/pip-checker/yes.html
+++ b/test/artefacts/pip-checker/yes.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check how Personal Independence Payment (PIP) affects you - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check how Personal Independence Payment (PIP) affects you
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/pip-checker/y/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What&#39;s your date of birth?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you’re checking for someone else, enter their date of birth.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="1893">1893</option>
+<option value="1894">1894</option>
+<option value="1895">1895</option>
+<option value="1896">1896</option>
+<option value="1897">1897</option>
+<option value="1898">1898</option>
+<option value="1899">1899</option>
+<option value="1900">1900</option>
+<option value="1901">1901</option>
+<option value="1902">1902</option>
+<option value="1903">1903</option>
+<option value="1904">1904</option>
+<option value="1905">1905</option>
+<option value="1906">1906</option>
+<option value="1907">1907</option>
+<option value="1908">1908</option>
+<option value="1909">1909</option>
+<option value="1910">1910</option>
+<option value="1911">1911</option>
+<option value="1912">1912</option>
+<option value="1913">1913</option>
+<option value="1914">1914</option>
+<option value="1915">1915</option>
+<option value="1916">1916</option>
+<option value="1917">1917</option>
+<option value="1918">1918</option>
+<option value="1919">1919</option>
+<option value="1920">1920</option>
+<option value="1921">1921</option>
+<option value="1922">1922</option>
+<option value="1923">1923</option>
+<option value="1924">1924</option>
+<option value="1925">1925</option>
+<option value="1926">1926</option>
+<option value="1927">1927</option>
+<option value="1928">1928</option>
+<option value="1929">1929</option>
+<option value="1930">1930</option>
+<option value="1931">1931</option>
+<option value="1932">1932</option>
+<option value="1933">1933</option>
+<option value="1934">1934</option>
+<option value="1935">1935</option>
+<option value="1936">1936</option>
+<option value="1937">1937</option>
+<option value="1938">1938</option>
+<option value="1939">1939</option>
+<option value="1940">1940</option>
+<option value="1941">1941</option>
+<option value="1942">1942</option>
+<option value="1943">1943</option>
+<option value="1944">1944</option>
+<option value="1945">1945</option>
+<option value="1946">1946</option>
+<option value="1947">1947</option>
+<option value="1948">1948</option>
+<option value="1949">1949</option>
+<option value="1950">1950</option>
+<option value="1951">1951</option>
+<option value="1952">1952</option>
+<option value="1953">1953</option>
+<option value="1954">1954</option>
+<option value="1955">1955</option>
+<option value="1956">1956</option>
+<option value="1957">1957</option>
+<option value="1958">1958</option>
+<option value="1959">1959</option>
+<option value="1960">1960</option>
+<option value="1961">1961</option>
+<option value="1962">1962</option>
+<option value="1963">1963</option>
+<option value="1964">1964</option>
+<option value="1965">1965</option>
+<option value="1966">1966</option>
+<option value="1967">1967</option>
+<option value="1968">1968</option>
+<option value="1969">1969</option>
+<option value="1970">1970</option>
+<option value="1971">1971</option>
+<option value="1972">1972</option>
+<option value="1973">1973</option>
+<option value="1974">1974</option>
+<option value="1975">1975</option>
+<option value="1976">1976</option>
+<option value="1977">1977</option>
+<option value="1978">1978</option>
+<option value="1979">1979</option>
+<option value="1980">1980</option>
+<option value="1981">1981</option>
+<option value="1982">1982</option>
+<option value="1983">1983</option>
+<option value="1984">1984</option>
+<option value="1985">1985</option>
+<option value="1986">1986</option>
+<option value="1987">1987</option>
+<option value="1988">1988</option>
+<option value="1989">1989</option>
+<option value="1990">1990</option>
+<option value="1991">1991</option>
+<option value="1992">1992</option>
+<option value="1993">1993</option>
+<option value="1994">1994</option>
+<option value="1995">1995</option>
+<option value="1996">1996</option>
+<option value="1997">1997</option>
+<option value="1998">1998</option>
+<option value="1999">1999</option>
+<option value="2000">2000</option>
+<option value="2001">2001</option>
+<option value="2002">2002</option>
+<option value="2003">2003</option>
+<option value="2004">2004</option>
+<option value="2005">2005</option>
+<option value="2006">2006</option>
+<option value="2007">2007</option>
+<option value="2008">2008</option>
+<option value="2009">2009</option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/pip-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you getting Disability Living Allowance?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/pip-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you getting Disability Living Allowance?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/plan-adoption-leave/2015-01-01.html
+++ b/test/artefacts/plan-adoption-leave/2015-01-01.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Plan your adoption leave - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Plan your adoption leave
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/plan-adoption-leave/y/2015-01-01" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When will the child start to live with you?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This is sometimes known as the &#39;date of placement&#39;.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/plan-adoption-leave">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When were you matched with the child?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/plan-adoption-leave/y?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When were you matched with the child?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/plan-adoption-leave/2015-01-01/2015-02-08.html
+++ b/test/artefacts/plan-adoption-leave/2015-01-01/2015-02-08.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Plan your adoption leave - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Plan your adoption leave
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/plan-adoption-leave/y/2015-01-01/2015-02-08" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When do you want to start your adoption leave?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Leave can start up to 14 days before the child comes to live with you.</p>
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/plan-adoption-leave">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When were you matched with the child?</td>
+      <td class="previous-question-body">
+       1 January 2015</td>
+
+      <td class="link-right">
+          <a href="/plan-adoption-leave/y?previous_response=2015-01-01">
+            Change<span class="visuallyhidden"> answer to "When were you matched with the child?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will the child start to live with you?</td>
+      <td class="previous-question-body">
+       8 February 2015</td>
+
+      <td class="link-right">
+          <a href="/plan-adoption-leave/y/2015-01-01?previous_response=2015-02-08">
+            Change<span class="visuallyhidden"> answer to "When will the child start to live with you?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/plan-adoption-leave/y.html
+++ b/test/artefacts/plan-adoption-leave/y.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Plan your adoption leave - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Plan your adoption leave
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/plan-adoption-leave/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When were you matched with the child?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-birth/afghanistan.html
+++ b/test/artefacts/register-a-birth/afghanistan.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a birth abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a birth abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-birth/y/afghanistan" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Who has British nationality?
+  </h2>
+  <div class="question-body">
+      <p>If the British parent was born abroad, they may be a British citizen ‘by descent’. This means they may not be allowed to pass on their British nationality to a child also born abroad. <a href="/check-british-citizen">Check if the parent is a British citizen</a>.</p>
+
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="mother" />
+          Mother only
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="father" />
+          Father only
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="mother_and_father" />
+          Mother and father
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="neither" />
+          Neither
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-birth">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country was the child born in?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "Which country was the child born in?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-birth/afghanistan/father/no.html
+++ b/test/artefacts/register-a-birth/afghanistan/father/no.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a birth abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a birth abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-birth/y/afghanistan/father/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your child’s date of birth?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2015">2015</option>
+<option value="2014">2014</option>
+<option value="2013">2013</option>
+<option value="2012">2012</option>
+<option value="2011">2011</option>
+<option value="2010">2010</option>
+<option value="2009">2009</option>
+<option value="2008">2008</option>
+<option value="2007">2007</option>
+<option value="2006">2006</option>
+<option value="2005">2005</option>
+<option value="2004">2004</option>
+<option value="2003">2003</option>
+<option value="2002">2002</option>
+<option value="2001">2001</option>
+<option value="2000">2000</option>
+<option value="1999">1999</option>
+<option value="1998">1998</option>
+<option value="1997">1997</option>
+<option value="1996">1996</option>
+<option value="1995">1995</option>
+<option value="1994">1994</option>
+<option value="1993">1993</option>
+<option value="1992">1992</option>
+<option value="1991">1991</option>
+<option value="1990">1990</option>
+<option value="1989">1989</option>
+<option value="1988">1988</option>
+<option value="1987">1987</option>
+<option value="1986">1986</option>
+<option value="1985">1985</option>
+<option value="1984">1984</option>
+<option value="1983">1983</option>
+<option value="1982">1982</option>
+<option value="1981">1981</option>
+<option value="1980">1980</option>
+<option value="1979">1979</option>
+<option value="1978">1978</option>
+<option value="1977">1977</option>
+<option value="1976">1976</option>
+<option value="1975">1975</option>
+<option value="1974">1974</option>
+<option value="1973">1973</option>
+<option value="1972">1972</option>
+<option value="1971">1971</option>
+<option value="1970">1970</option>
+<option value="1969">1969</option>
+<option value="1968">1968</option>
+<option value="1967">1967</option>
+<option value="1966">1966</option>
+<option value="1965">1965</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-birth">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country was the child born in?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "Which country was the child born in?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Who has British nationality?</td>
+      <td class="previous-question-body">
+      Father only</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y/afghanistan?previous_response=father">
+            Change<span class="visuallyhidden"> answer to "Who has British nationality?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you married to the other parent when your child was born?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y/afghanistan/father?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Were you married to the other parent when your child was born?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-birth/afghanistan/mother.html
+++ b/test/artefacts/register-a-birth/afghanistan/mother.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a birth abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a birth abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-birth/y/afghanistan/mother" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Were you married to the other parent when your child was born?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-birth">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country was the child born in?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "Which country was the child born in?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Who has British nationality?</td>
+      <td class="previous-question-body">
+      Mother only</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y/afghanistan?previous_response=mother">
+            Change<span class="visuallyhidden"> answer to "Who has British nationality?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes.html
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a birth abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a birth abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-birth/y/afghanistan/mother/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Where are you now?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="same_country" />
+          In the country where the child was born
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="another_country" />
+          In another country
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="in_the_uk" />
+          In the UK
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-birth">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country was the child born in?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "Which country was the child born in?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Who has British nationality?</td>
+      <td class="previous-question-body">
+      Mother only</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y/afghanistan?previous_response=mother">
+            Change<span class="visuallyhidden"> answer to "Who has British nationality?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you married to the other parent when your child was born?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y/afghanistan/mother?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you married to the other parent when your child was born?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country.html
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a birth abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a birth abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-birth/y/afghanistan/mother/yes/another_country" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which country?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-guiana">French Guiana</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guadeloupe">Guadeloupe</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="martinique">Martinique</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mayotte">Mayotte</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="reunion">Reunion</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="the-occupied-palestinian-territories">The Occupied Palestinian Territories</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-birth">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country was the child born in?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "Which country was the child born in?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Who has British nationality?</td>
+      <td class="previous-question-body">
+      Mother only</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y/afghanistan?previous_response=mother">
+            Change<span class="visuallyhidden"> answer to "Who has British nationality?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Were you married to the other parent when your child was born?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y/afghanistan/mother?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Were you married to the other parent when your child was born?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where are you now?</td>
+      <td class="previous-question-body">
+      In another country</td>
+
+      <td class="link-right">
+          <a href="/register-a-birth/y/afghanistan/mother/yes?previous_response=another_country">
+            Change<span class="visuallyhidden"> answer to "Where are you now?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-birth/y.html
+++ b/test/artefacts/register-a-birth/y.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a birth abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a birth abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-birth/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which country was the child born in?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-guiana">French Guiana</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guadeloupe">Guadeloupe</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="martinique">Martinique</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mayotte">Mayotte</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="reunion">Reunion</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="the-occupied-palestinian-territories">The Occupied Palestinian Territories</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-death/england_wales.html
+++ b/test/artefacts/register-a-death/england_wales.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a death - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a death
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-death/y/england_wales" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did the person die at home, in hospital or elsewhere?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="at_home_hospital" />
+          At home or in hospital
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="elsewhere" />
+          Elsewhere
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-death">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the death happen?</td>
+      <td class="previous-question-body">
+      England or Wales</td>
+
+      <td class="link-right">
+          <a href="/register-a-death/y?previous_response=england_wales">
+            Change<span class="visuallyhidden"> answer to "Where did the death happen?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-death/england_wales/at_home_hospital.html
+++ b/test/artefacts/register-a-death/england_wales/at_home_hospital.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a death - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a death
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-death/y/england_wales/at_home_hospital" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Was the death expected?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-death">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the death happen?</td>
+      <td class="previous-question-body">
+      England or Wales</td>
+
+      <td class="link-right">
+          <a href="/register-a-death/y?previous_response=england_wales">
+            Change<span class="visuallyhidden"> answer to "Where did the death happen?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did the person die at home, in hospital or elsewhere?</td>
+      <td class="previous-question-body">
+      At home or in hospital</td>
+
+      <td class="link-right">
+          <a href="/register-a-death/y/england_wales?previous_response=at_home_hospital">
+            Change<span class="visuallyhidden"> answer to "Did the person die at home, in hospital or elsewhere?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-death/overseas.html
+++ b/test/artefacts/register-a-death/overseas.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a death - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a death
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-death/y/overseas" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which country did the death happen in?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-guiana">French Guiana</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guadeloupe">Guadeloupe</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="martinique">Martinique</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mayotte">Mayotte</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="reunion">Reunion</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="the-occupied-palestinian-territories">The Occupied Palestinian Territories</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-death">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the death happen?</td>
+      <td class="previous-question-body">
+      Abroad</td>
+
+      <td class="link-right">
+          <a href="/register-a-death/y?previous_response=overseas">
+            Change<span class="visuallyhidden"> answer to "Where did the death happen?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-death/overseas/libya.html
+++ b/test/artefacts/register-a-death/overseas/libya.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a death - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a death
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-death/y/overseas/libya" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Where are you now?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="same_country" />
+          In the country where the death happened
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="another_country" />
+          In another country
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="in_the_uk" />
+          In the UK
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-death">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the death happen?</td>
+      <td class="previous-question-body">
+      Abroad</td>
+
+      <td class="link-right">
+          <a href="/register-a-death/y?previous_response=overseas">
+            Change<span class="visuallyhidden"> answer to "Where did the death happen?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country did the death happen in?</td>
+      <td class="previous-question-body">
+      Libya</td>
+
+      <td class="link-right">
+          <a href="/register-a-death/y/overseas?previous_response=libya">
+            Change<span class="visuallyhidden"> answer to "Which country did the death happen in?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-death/overseas/libya/another_country.html
+++ b/test/artefacts/register-a-death/overseas/libya/another_country.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a death - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a death
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-death/y/overseas/libya/another_country" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which country are you in now?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-guiana">French Guiana</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guadeloupe">Guadeloupe</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="martinique">Martinique</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mayotte">Mayotte</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="reunion">Reunion</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="the-occupied-palestinian-territories">The Occupied Palestinian Territories</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/register-a-death">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where did the death happen?</td>
+      <td class="previous-question-body">
+      Abroad</td>
+
+      <td class="link-right">
+          <a href="/register-a-death/y?previous_response=overseas">
+            Change<span class="visuallyhidden"> answer to "Where did the death happen?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country did the death happen in?</td>
+      <td class="previous-question-body">
+      Libya</td>
+
+      <td class="link-right">
+          <a href="/register-a-death/y/overseas?previous_response=libya">
+            Change<span class="visuallyhidden"> answer to "Which country did the death happen in?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where are you now?</td>
+      <td class="previous-question-body">
+      In another country</td>
+
+      <td class="link-right">
+          <a href="/register-a-death/y/overseas/libya?previous_response=another_country">
+            Change<span class="visuallyhidden"> answer to "Where are you now?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/register-a-death/y.html
+++ b/test/artefacts/register-a-death/y.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Register a death - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Register a death
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/register-a-death/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Where did the death happen?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="england_wales" />
+          England or Wales
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="scotland" />
+          Scotland
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="northern_ireland" />
+          Northern Ireland
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="overseas" />
+          Abroad
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/report-a-lost-or-stolen-passport/abroad.html
+++ b/test/artefacts/report-a-lost-or-stolen-passport/abroad.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Cancel a lost or stolen passport - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Cancel a lost or stolen passport
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/report-a-lost-or-stolen-passport/y/abroad" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    In which country?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-guiana">French Guiana</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guadeloupe">Guadeloupe</option>
+<option value="guatemala">Guatemala</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="martinique">Martinique</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mayotte">Mayotte</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="reunion">Reunion</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-maarten">St Maarten</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="the-occupied-palestinian-territories">The Occupied Palestinian Territories</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/report-a-lost-or-stolen-passport">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Where was the passport lost or stolen?</td>
+      <td class="previous-question-body">
+      Abroad</td>
+
+      <td class="link-right">
+          <a href="/report-a-lost-or-stolen-passport/y?previous_response=abroad">
+            Change<span class="visuallyhidden"> answer to "Where was the passport lost or stolen?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/report-a-lost-or-stolen-passport/y.html
+++ b/test/artefacts/report-a-lost-or-stolen-passport/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Cancel a lost or stolen passport - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Cancel a lost or stolen passport
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/report-a-lost-or-stolen-passport/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Where was the passport lost or stolen?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="in_the_uk" />
+          In the UK
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="abroad" />
+          Abroad
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/y.html
+++ b/test/artefacts/simplified-expenses-checker/y.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Have you claimed expenses for your current business before?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you’re a new business you won’t have claimed expenses before.</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes.html
+++ b/test/artefacts/simplified-expenses-checker/yes.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you have any of these expenses as part of your business?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">If you don&#39;t have any of these expenses go to &#39;Next step&#39;.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="car_or_van" />
+        Car or van (business use)
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="motorcycle" />
+        Motorcycle (business use)
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="using_home_for_business" />
+        Working from home (the main purpose of the building is your home)
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="live_on_business_premises" />
+        Living on your business premises (the main purpose of the building where you live is your business, eg a B&amp;B, and you&#39;re likely to pay business rates instead of council tax)
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    On average, how many hours a month do you work or expect to work from home?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You have to work at least 25 hours per month from home to use simplified home expenses.</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Car or van (business use)</li>
+        <li>Working from home (the main purpose of the building is your home)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=car_or_van%2Cusing_home_for_business">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the vehicle you&#39;re buying green, ie a low emission vehicle?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the vehicle you&#39;re buying green, ie a low emission vehicle?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much is the car, van or motorcycle you’re buying?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes/yes?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "How much is the car, van or motorcycle you’re buying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much of your driving time do you expect to be for business use?</td>
+      <td class="previous-question-body">
+      35.0</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes/yes/35000.0?previous_response=35.0">
+            Change<span class="visuallyhidden"> answer to "How much of your driving time do you expect to be for business use?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many miles do you expect to drive your car or van for business during the tax year?</td>
+      <td class="previous-question-body">
+      10,000</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0?previous_response=10000">
+            Change<span class="visuallyhidden"> answer to "How many miles do you expect to drive your car or van for business during the tax year?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000/26.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000/26.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000/26" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much of your home costs do you expect to claim as business expenses this tax year?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The business proportion of utility bills, eg gas and electricity. Don&#39;t include phone and internet bills.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Car or van (business use)</li>
+        <li>Working from home (the main purpose of the building is your home)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=car_or_van%2Cusing_home_for_business">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the vehicle you&#39;re buying green, ie a low emission vehicle?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the vehicle you&#39;re buying green, ie a low emission vehicle?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much is the car, van or motorcycle you’re buying?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes/yes?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "How much is the car, van or motorcycle you’re buying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much of your driving time do you expect to be for business use?</td>
+      <td class="previous-question-body">
+      35.0</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes/yes/35000.0?previous_response=35.0">
+            Change<span class="visuallyhidden"> answer to "How much of your driving time do you expect to be for business use?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many miles do you expect to drive your car or van for business during the tax year?</td>
+      <td class="previous-question-body">
+      10,000</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0?previous_response=10000">
+            Change<span class="visuallyhidden"> answer to "How many miles do you expect to drive your car or van for business during the tax year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">On average, how many hours a month do you work or expect to work from home?</td>
+      <td class="previous-question-body">
+      26</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000?previous_response=26">
+            Change<span class="visuallyhidden"> answer to "On average, how many hours a month do you work or expect to work from home?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/car_or_van" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Car or van (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=car_or_van">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/no.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/no.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/car_or_van/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Have you claimed Capital Allowances for your existing car, van or motorcycle before?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Car or van (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=car_or_van">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/no/no.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/no/no.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/car_or_van/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you expect to claim as business expenses for running and maintaining your car, van or motorcycle over the tax year?
+
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Only include the business proportion of costs for your main vehicle, eg fuel, servicing, repairs and insurance.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Car or van (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=car_or_van">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed Capital Allowances for your existing car, van or motorcycle before?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Have you claimed Capital Allowances for your existing car, van or motorcycle before?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/car_or_van/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is the vehicle you&#39;re buying green, ie a low emission vehicle?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Car or van (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=car_or_van">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/car_or_van/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much is the car, van or motorcycle you’re buying?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Include VAT unless your business is VAT registered.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Car or van (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=car_or_van">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the vehicle you&#39;re buying green, ie a low emission vehicle?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the vehicle you&#39;re buying green, ie a low emission vehicle?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes/35000.0/35.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes/35000.0/35.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/car_or_van/yes/yes/35000.0/35.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many miles do you expect to drive your car or van for business during the tax year?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Car or van (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=car_or_van">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the vehicle you&#39;re buying green, ie a low emission vehicle?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the vehicle you&#39;re buying green, ie a low emission vehicle?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much is the car, van or motorcycle you’re buying?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van/yes/yes?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "How much is the car, van or motorcycle you’re buying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much of your driving time do you expect to be for business use?</td>
+      <td class="previous-question-body">
+      35.0</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van/yes/yes/35000.0?previous_response=35.0">
+            Change<span class="visuallyhidden"> answer to "How much of your driving time do you expect to be for business use?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes/35000.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes/35000.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/car_or_van/yes/yes/35000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much of your driving time do you expect to be for business use?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <label for="response"><input type="text" name="response" id="response" />% of the time
+</label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Car or van (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=car_or_van">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the vehicle you&#39;re buying green, ie a low emission vehicle?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the vehicle you&#39;re buying green, ie a low emission vehicle?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much is the car, van or motorcycle you’re buying?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/car_or_van/yes/yes?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "How much is the car, van or motorcycle you’re buying?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500.html
+++ b/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much do you expect to deduct from your business expenses this tax year for your private use of the premises?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">For example, a proportion of your maintenance, utility and insurance bills.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Living on your business premises (the main purpose of the building where you live is your business, eg a B&amp;B, and you&#39;re likely to pay business rates instead of council tax)</li>
+        <li>Motorcycle (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=live_on_business_premises%2Cmotorcycle">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the vehicle you&#39;re buying green, ie a low emission vehicle?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the vehicle you&#39;re buying green, ie a low emission vehicle?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much is the car, van or motorcycle you’re buying?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "How much is the car, van or motorcycle you’re buying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much of your driving time do you expect to be for business use?</td>
+      <td class="previous-question-body">
+      35.0</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes/35000.0?previous_response=35.0">
+            Change<span class="visuallyhidden"> answer to "How much of your driving time do you expect to be for business use?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many miles do you expect to drive your motorcycle for business during the tax year?</td>
+      <td class="previous-question-body">
+      7,500</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0?previous_response=7500">
+            Change<span class="visuallyhidden"> answer to "How many miles do you expect to drive your motorcycle for business during the tax year?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500/789.html
+++ b/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500/789.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500/789.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many people normally live on the business premises?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Include children and non-paying guests. Don&#39;t include paying guests or anyone using the premises as part of your business. Give an average if there are more people at certain times of the year.</p>
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Living on your business premises (the main purpose of the building where you live is your business, eg a B&amp;B, and you&#39;re likely to pay business rates instead of council tax)</li>
+        <li>Motorcycle (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=live_on_business_premises%2Cmotorcycle">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the vehicle you&#39;re buying green, ie a low emission vehicle?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the vehicle you&#39;re buying green, ie a low emission vehicle?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much is the car, van or motorcycle you’re buying?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "How much is the car, van or motorcycle you’re buying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much of your driving time do you expect to be for business use?</td>
+      <td class="previous-question-body">
+      35.0</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes/35000.0?previous_response=35.0">
+            Change<span class="visuallyhidden"> answer to "How much of your driving time do you expect to be for business use?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How many miles do you expect to drive your motorcycle for business during the tax year?</td>
+      <td class="previous-question-body">
+      7,500</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0?previous_response=7500">
+            Change<span class="visuallyhidden"> answer to "How many miles do you expect to drive your motorcycle for business during the tax year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much do you expect to deduct from your business expenses this tax year for your private use of the premises?</td>
+      <td class="previous-question-body">
+      £789</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500?previous_response=789.0">
+            Change<span class="visuallyhidden"> answer to "How much do you expect to deduct from your business expenses this tax year for your private use of the premises?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.html
+++ b/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Check if simplified expenses works for your business - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Check if simplified expenses works for your business
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How many miles do you expect to drive your motorcycle for business during the tax year?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <input type="text" name="response" id="response" />
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/simplified-expenses-checker">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Have you claimed expenses for your current business before?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Have you claimed expenses for your current business before?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any of these expenses as part of your business?</td>
+      <td class="previous-question-body"><ul>
+        <li>Living on your business premises (the main purpose of the building where you live is your business, eg a B&amp;B, and you&#39;re likely to pay business rates instead of council tax)</li>
+        <li>Motorcycle (business use)</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes?previous_response=live_on_business_premises%2Cmotorcycle">
+            Change<span class="visuallyhidden"> answer to "Do you have any of these expenses as part of your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is the vehicle you&#39;re buying green, ie a low emission vehicle?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is the vehicle you&#39;re buying green, ie a low emission vehicle?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much is the car, van or motorcycle you’re buying?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "How much is the car, van or motorcycle you’re buying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much of your driving time do you expect to be for business use?</td>
+      <td class="previous-question-body">
+      35.0</td>
+
+      <td class="link-right">
+          <a href="/simplified-expenses-checker/y/yes/live_on_business_premises,motorcycle/yes/yes/35000.0?previous_response=35.0">
+            Change<span class="visuallyhidden"> answer to "How much of your driving time do you expect to be for business use?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/state-pension-through-partner/married.html
+++ b/test/artefacts/state-pension-through-partner/married.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Your partner’s National Insurance record and your State Pension - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Your partner’s National Insurance record and your State Pension
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/state-pension-through-partner/y/married" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When will you reach State Pension age?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="your_pension_age_before_specific_date" />
+          on or before 5 April 2016
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="your_pension_age_after_specific_date" />
+          on or after 6 April 2016
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/state-pension-through-partner">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your marital status?</td>
+      <td class="previous-question-body">
+      married or in a civil partnership</td>
+
+      <td class="link-right">
+          <a href="/state-pension-through-partner/y?previous_response=married">
+            Change<span class="visuallyhidden"> answer to "What is your marital status?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/state-pension-through-partner/married/your_pension_age_after_specific_date/partner_pension_age_before_specific_date.html
+++ b/test/artefacts/state-pension-through-partner/married/your_pension_age_after_specific_date/partner_pension_age_before_specific_date.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Your partner’s National Insurance record and your State Pension - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Your partner’s National Insurance record and your State Pension
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/state-pension-through-partner/y/married/your_pension_age_after_specific_date/partner_pension_age_before_specific_date" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="male_gender" />
+          a man
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="female_gender" />
+          a woman
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/state-pension-through-partner">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your marital status?</td>
+      <td class="previous-question-body">
+      married or in a civil partnership</td>
+
+      <td class="link-right">
+          <a href="/state-pension-through-partner/y?previous_response=married">
+            Change<span class="visuallyhidden"> answer to "What is your marital status?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will you reach State Pension age?</td>
+      <td class="previous-question-body">
+      on or after 6 April 2016</td>
+
+      <td class="link-right">
+          <a href="/state-pension-through-partner/y/married?previous_response=your_pension_age_after_specific_date">
+            Change<span class="visuallyhidden"> answer to "When will you reach State Pension age?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will your spouse or civil partner reach State Pension age?</td>
+      <td class="previous-question-body">
+      on or before 5 April 2016</td>
+
+      <td class="link-right">
+          <a href="/state-pension-through-partner/y/married/your_pension_age_after_specific_date?previous_response=partner_pension_age_before_specific_date">
+            Change<span class="visuallyhidden"> answer to "When will your spouse or civil partner reach State Pension age?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/state-pension-through-partner/married/your_pension_age_before_specific_date.html
+++ b/test/artefacts/state-pension-through-partner/married/your_pension_age_before_specific_date.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Your partner’s National Insurance record and your State Pension - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Your partner’s National Insurance record and your State Pension
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/state-pension-through-partner/y/married/your_pension_age_before_specific_date" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When will your spouse or civil partner reach State Pension age?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="partner_pension_age_before_specific_date" />
+          on or before 5 April 2016
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="partner_pension_age_after_specific_date" />
+          on or after 6 April 2016
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/state-pension-through-partner">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your marital status?</td>
+      <td class="previous-question-body">
+      married or in a civil partnership</td>
+
+      <td class="link-right">
+          <a href="/state-pension-through-partner/y?previous_response=married">
+            Change<span class="visuallyhidden"> answer to "What is your marital status?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When will you reach State Pension age?</td>
+      <td class="previous-question-body">
+      on or before 5 April 2016</td>
+
+      <td class="link-right">
+          <a href="/state-pension-through-partner/y/married?previous_response=your_pension_age_before_specific_date">
+            Change<span class="visuallyhidden"> answer to "When will you reach State Pension age?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/state-pension-through-partner/y.html
+++ b/test/artefacts/state-pension-through-partner/y.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Your partner’s National Insurance record and your State Pension - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Your partner’s National Insurance record and your State Pension
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/state-pension-through-partner/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your marital status?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="married" />
+          married or in a civil partnership
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="will_marry_before_specific_date" />
+          I’ll be married or in a civil partnership before 5 April 2016
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="will_marry_on_or_after_specific_date" />
+          I’ll be married or in a civil partnership after 6 April 2016
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="widowed" />
+          widowed
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="divorced" />
+          divorced or have dissolved your civil partnership
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/state-pension-topup/1914-10-13.html
+++ b/test/artefacts/state-pension-topup/1914-10-13.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension top up calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension top up calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/state-pension-topup/y/1914-10-13" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your gender?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="male" />
+          Male
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="female" />
+          Female
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/state-pension-topup">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+      13 October 1914</td>
+
+      <td class="link-right">
+          <a href="/state-pension-topup/y?previous_response=1914-10-13">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/state-pension-topup/1914-10-13/male.html
+++ b/test/artefacts/state-pension-topup/1914-10-13/male.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension top up calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension top up calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/state-pension-topup/y/1914-10-13/male" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much would you like to get per week?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">Enter a number between 1 and 25.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/state-pension-topup">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your date of birth?</td>
+      <td class="previous-question-body">
+      13 October 1914</td>
+
+      <td class="link-right">
+          <a href="/state-pension-topup/y?previous_response=1914-10-13">
+            Change<span class="visuallyhidden"> answer to "What is your date of birth?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What is your gender?</td>
+      <td class="previous-question-body">
+      Male</td>
+
+      <td class="link-right">
+          <a href="/state-pension-topup/y/1914-10-13?previous_response=male">
+            Change<span class="visuallyhidden"> answer to "What is your gender?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/state-pension-topup/y.html
+++ b/test/artefacts/state-pension-topup/y.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>State Pension top up calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        State Pension top up calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/state-pension-topup/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What is your date of birth?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_day">Day
+      <select id="response_day" name="response[day]">
+<option value=""></option>
+<option value="1">1</option>
+<option value="2">2</option>
+<option value="3">3</option>
+<option value="4">4</option>
+<option value="5">5</option>
+<option value="6">6</option>
+<option value="7">7</option>
+<option value="8">8</option>
+<option value="9">9</option>
+<option value="10">10</option>
+<option value="11">11</option>
+<option value="12">12</option>
+<option value="13">13</option>
+<option value="14">14</option>
+<option value="15">15</option>
+<option value="16">16</option>
+<option value="17">17</option>
+<option value="18">18</option>
+<option value="19">19</option>
+<option value="20">20</option>
+<option value="21">21</option>
+<option value="22">22</option>
+<option value="23">23</option>
+<option value="24">24</option>
+<option value="25">25</option>
+<option value="26">26</option>
+<option value="27">27</option>
+<option value="28">28</option>
+<option value="29">29</option>
+<option value="30">30</option>
+<option value="31">31</option>
+</select>
+
+    </label>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="1893">1893</option>
+<option value="1894">1894</option>
+<option value="1895">1895</option>
+<option value="1896">1896</option>
+<option value="1897">1897</option>
+<option value="1898">1898</option>
+<option value="1899">1899</option>
+<option value="1900">1900</option>
+<option value="1901">1901</option>
+<option value="1902">1902</option>
+<option value="1903">1903</option>
+<option value="1904">1904</option>
+<option value="1905">1905</option>
+<option value="1906">1906</option>
+<option value="1907">1907</option>
+<option value="1908">1908</option>
+<option value="1909">1909</option>
+<option value="1910">1910</option>
+<option value="1911">1911</option>
+<option value="1912">1912</option>
+<option value="1913">1913</option>
+<option value="1914">1914</option>
+<option value="1915">1915</option>
+<option value="1916">1916</option>
+<option value="1917">1917</option>
+<option value="1918">1918</option>
+<option value="1919">1919</option>
+<option value="1920">1920</option>
+<option value="1921">1921</option>
+<option value="1922">1922</option>
+<option value="1923">1923</option>
+<option value="1924">1924</option>
+<option value="1925">1925</option>
+<option value="1926">1926</option>
+<option value="1927">1927</option>
+<option value="1928">1928</option>
+<option value="1929">1929</option>
+<option value="1930">1930</option>
+<option value="1931">1931</option>
+<option value="1932">1932</option>
+<option value="1933">1933</option>
+<option value="1934">1934</option>
+<option value="1935">1935</option>
+<option value="1936">1936</option>
+<option value="1937">1937</option>
+<option value="1938">1938</option>
+<option value="1939">1939</option>
+<option value="1940">1940</option>
+<option value="1941">1941</option>
+<option value="1942">1942</option>
+<option value="1943">1943</option>
+<option value="1944">1944</option>
+<option value="1945">1945</option>
+<option value="1946">1946</option>
+<option value="1947">1947</option>
+<option value="1948">1948</option>
+<option value="1949">1949</option>
+<option value="1950">1950</option>
+<option value="1951">1951</option>
+<option value="1952">1952</option>
+<option value="1953">1953</option>
+<option value="1954">1954</option>
+<option value="1955">1955</option>
+<option value="1956">1956</option>
+<option value="1957">1957</option>
+<option value="1958">1958</option>
+<option value="1959">1959</option>
+<option value="1960">1960</option>
+<option value="1961">1961</option>
+<option value="1962">1962</option>
+<option value="1963">1963</option>
+<option value="1964">1964</option>
+<option value="1965">1965</option>
+<option value="1966">1966</option>
+<option value="1967">1967</option>
+<option value="1968">1968</option>
+<option value="1969">1969</option>
+<option value="1970">1970</option>
+<option value="1971">1971</option>
+<option value="1972">1972</option>
+<option value="1973">1973</option>
+<option value="1974">1974</option>
+<option value="1975">1975</option>
+<option value="1976">1976</option>
+<option value="1977">1977</option>
+<option value="1978">1978</option>
+<option value="1979">1979</option>
+<option value="1980">1980</option>
+<option value="1981">1981</option>
+<option value="1982">1982</option>
+<option value="1983">1983</option>
+<option value="1984">1984</option>
+<option value="1985">1985</option>
+<option value="1986">1986</option>
+<option value="1987">1987</option>
+<option value="1988">1988</option>
+<option value="1989">1989</option>
+<option value="1990">1990</option>
+<option value="1991">1991</option>
+<option value="1992">1992</option>
+<option value="1993">1993</option>
+<option value="1994">1994</option>
+<option value="1995">1995</option>
+<option value="1996">1996</option>
+<option value="1997">1997</option>
+<option value="1998">1998</option>
+<option value="1999">1999</option>
+<option value="2000">2000</option>
+<option value="2001">2001</option>
+<option value="2002">2002</option>
+<option value="2003">2003</option>
+<option value="2004">2004</option>
+<option value="2005">2005</option>
+<option value="2006">2006</option>
+<option value="2007">2007</option>
+<option value="2008">2008</option>
+<option value="2009">2009</option>
+<option value="2010">2010</option>
+<option value="2011">2011</option>
+<option value="2012">2012</option>
+<option value="2013">2013</option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015.html
+++ b/test/artefacts/student-finance-calculator/2014-2015.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-calculator/y/2014-2015" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What type of student are you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="uk-full-time" />
+          UK student full-time
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="uk-part-time" />
+          UK student part-time
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="eu-full-time" />
+          EU student full-time
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="eu-part-time" />
+          EU student part-time
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015/uk-full-time.html
+++ b/test/artefacts/student-finance-calculator/2014-2015/uk-full-time.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-calculator/y/2014-2015/uk-full-time" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How much are your tuition fees per year?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">The maximum is £9,000 for full-time students and £6,750 for part-time students.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015/uk-full-time/6000.0/at-home.html
+++ b/test/artefacts/student-finance-calculator/2014-2015/uk-full-time/6000.0/at-home.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What&#39;s your annual household income?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">This is your parents’ or partner’s gross (pre-tax) income plus your own. It affects how much Maintenance Loan and Maintenance Grant (help with living costs) you get.</p>
+
+    <div class="">
+
+      <label for="response_amount">&pound; <input type="text" name="response" id="response" size="5" /></label>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income.html
+++ b/test/artefacts/student-finance-calculator/2014-2015/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you studying one of these courses?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="teacher-training" />
+          Teacher training
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="dental-medical-healthcare" />
+          Dental, medical or healthcare
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="social-work" />
+          Social work
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="none-of-the-above" />
+           None of these
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015/uk-full-time/6000.0/at-home/100000.html
+++ b/test/artefacts/student-finance-calculator/2014-2015/uk-full-time/6000.0/at-home/100000.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do any of the following apply (you might get extra funding)?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="children-under-17" />
+        You’ve got children under 17
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="dependant-adult" />
+        An adult depends on you financially
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="has-disability" />
+        You’ve a disability, health condition or learning difficulty -  eg dyslexia
+      </label>
+    </li>
+    <li>
+      <label for="response_3">
+        <input type="checkbox" name="response[]" id="response_3" value="low-income" />
+        You’re on low income - eg you find it hard to pay for basics like food and accommodation
+      </label>
+    </li>
+    <li>
+      <label for="response_4">
+        <input type="checkbox" name="response[]" id="response_4" value="no" />
+        None of these
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015/uk-full-time/6000.html
+++ b/test/artefacts/student-finance-calculator/2014-2015/uk-full-time/6000.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Where will you live while studying?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="at-home" />
+          Living with parents
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="away-outside-london" />
+          Not living with parents and studying outside of London
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="away-in-london" />
+          Not living with parents and studying in London
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015/uk-part-time/6000.html
+++ b/test/artefacts/student-finance-calculator/2014-2015/uk-part-time/6000.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do any of the following apply (you might get extra funding)?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+      <label for="response_0">
+        <input type="checkbox" name="response[]" id="response_0" value="has-disability" />
+        You have a disability, health condition or learning difficulty, eg dyslexia
+      </label>
+    </li>
+    <li>
+      <label for="response_1">
+        <input type="checkbox" name="response[]" id="response_1" value="low-income" />
+        You’re on a low income, eg you find it hard to pay for food and accommodation
+      </label>
+    </li>
+    <li>
+      <label for="response_2">
+        <input type="checkbox" name="response[]" id="response_2" value="no" />
+        None of these
+      </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/y.html
+++ b/test/artefacts/student-finance-calculator/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-calculator/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When does your course start?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="2014-2015" />
+          Between September 2014 and August 2015
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="2015-2016" />
+          Between September 2015 and August 2016
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-forms/uk-full-time.html
+++ b/test/artefacts/student-finance-forms/uk-full-time.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance forms - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance forms
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-forms/y/uk-full-time" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What do you need the form for?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="apply-loans-grants" />
+          apply-loans-grants
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="proof-identity" />
+          Send proof of identity
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="income-details" />
+          Send parent or partner’s income detail - eg PFF2 or CYI
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="apply-dsa" />
+          Apply for Disabled Students’ Allowances
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="dsa-expenses" />
+          Claim Disabled Students’ Allowances expenses
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="apply-ccg" />
+          Apply for Childcare Grant
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="ccg-expenses" />
+          Childcare Grant costs confirmation
+        </label>
+    </li>
+    <li>
+        <label for="response_7" class="selectable">
+          <input type="radio" name="response" id="response_7" value="travel-grant" />
+          Travel Grant
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-forms">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of a student are you?</td>
+      <td class="previous-question-body">
+      English student - full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of a student are you?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants.html
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance forms - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance forms
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-forms/y/uk-full-time/apply-loans-grants" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What academic year do you want funding for?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="year-1516" />
+          2015 to 2016
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="year-1415" />
+          2014 to 2015
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-forms">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of a student are you?</td>
+      <td class="previous-question-body">
+      English student - full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of a student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you need the form for?</td>
+      <td class="previous-question-body">
+      apply-loans-grants</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y/uk-full-time?previous_response=apply-loans-grants">
+            Change<span class="visuallyhidden"> answer to "What do you need the form for?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516.html
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance forms - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance forms
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-forms/y/uk-full-time/apply-loans-grants/year-1516" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you a continuing student?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You’re usually a continuing student if you got student finance last year.</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="continuing-student" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="new-student" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-forms">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of a student are you?</td>
+      <td class="previous-question-body">
+      English student - full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of a student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you need the form for?</td>
+      <td class="previous-question-body">
+      apply-loans-grants</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y/uk-full-time?previous_response=apply-loans-grants">
+            Change<span class="visuallyhidden"> answer to "What do you need the form for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What academic year do you want funding for?</td>
+      <td class="previous-question-body">
+      2015 to 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y/uk-full-time/apply-loans-grants?previous_response=year-1516">
+            Change<span class="visuallyhidden"> answer to "What academic year do you want funding for?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-forms/uk-part-time.html
+++ b/test/artefacts/student-finance-forms/uk-part-time.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance forms - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance forms
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-forms/y/uk-part-time" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What do you need the form for?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="apply-loans-grants" />
+          Apply for student loans and grants
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="proof-identity" />
+          Send proof of identity
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="apply-dsa" />
+          Apply for Disabled Students’ Allowances
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="dsa-expenses" />
+          Claim Disabled Students’ Allowances expenses
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-forms">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of a student are you?</td>
+      <td class="previous-question-body">
+      English student - part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of a student are you?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/continuing-student.html
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/continuing-student.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance forms - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance forms
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-forms/y/uk-part-time/apply-loans-grants/year-1516/continuing-student" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did your part-time course start before 1 September 2012?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="course-start-before-01092012" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="course-start-after-01092012" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-forms">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of a student are you?</td>
+      <td class="previous-question-body">
+      English student - part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of a student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What do you need the form for?</td>
+      <td class="previous-question-body">
+      Apply for student loans and grants</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y/uk-part-time?previous_response=apply-loans-grants">
+            Change<span class="visuallyhidden"> answer to "What do you need the form for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What academic year do you want funding for?</td>
+      <td class="previous-question-body">
+      2015 to 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y/uk-part-time/apply-loans-grants?previous_response=year-1516">
+            Change<span class="visuallyhidden"> answer to "What academic year do you want funding for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you a continuing student?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/student-finance-forms/y/uk-part-time/apply-loans-grants/year-1516?previous_response=continuing-student">
+            Change<span class="visuallyhidden"> answer to "Are you a continuing student?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-forms/y.html
+++ b/test/artefacts/student-finance-forms/y.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance forms - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance forms
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/student-finance-forms/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What type of a student are you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="uk-full-time" />
+          English student - full-time
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="uk-part-time" />
+          English student - part-time
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="eu-full-time" />
+          EU student - full-time
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="eu-part-time" />
+          EU student - part-time
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/bus.html
+++ b/test/artefacts/towing-rules/bus.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/bus" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you already have a full category D bus licence?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Bus (category D)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=bus">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/bus/no.html
+++ b/test/artefacts/towing-rules/bus/no.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/bus/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old are you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="under-21" />
+          Under 21
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="21-or-over" />
+          21 or over
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Bus (category D)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=bus">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a full category D bus licence?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/bus?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you already have a full category D bus licence?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/car-or-light-vehicle.html
+++ b/test/artefacts/towing-rules/car-or-light-vehicle.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/car-or-light-vehicle" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you already have a driving licence with any of the following entitlements on it:
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>C1+E (towing with a medium sized vehicle)</li>
+  <li>C+E (towing with a large vehicle)</li>
+  <li>D1+E (towing with a minibus)</li>
+  <li>D+E (towing with a bus)</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Car (category B)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=car-or-light-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/car-or-light-vehicle/no.html
+++ b/test/artefacts/towing-rules/car-or-light-vehicle/no.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/car-or-light-vehicle/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When did you pass your car driving test?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="licence-issued-before-19-Jan-2013" />
+          Before 19 January 2013
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="licence-issued-after-19-Jan-2013" />
+          From 19 January 2013
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Car (category B)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=car-or-light-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a driving licence with any of the following entitlements on it:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/car-or-light-vehicle?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you already have a driving licence with any of the following entitlements on it:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/car-or-light-vehicle/yes.html
+++ b/test/artefacts/towing-rules/car-or-light-vehicle/yes.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/car-or-light-vehicle/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When did you get this entitlement on your licence?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="before-19-Jan-2013" />
+          Before 19 January 2013
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="after-19-Jan-2013" />
+          From 19 January 2013
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Car (category B)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=car-or-light-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a driving licence with any of the following entitlements on it:</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/car-or-light-vehicle?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you already have a driving licence with any of the following entitlements on it:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/large-vehicle.html
+++ b/test/artefacts/towing-rules/large-vehicle.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/large-vehicle" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you already have a category C large vehicle licence?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Large vehicle (category C)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=large-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/large-vehicle/no.html
+++ b/test/artefacts/towing-rules/large-vehicle/no.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/large-vehicle/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old are you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="under-21" />
+          Under 21
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="21-or-over" />
+          21 or over
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Large vehicle (category C)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=large-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a category C large vehicle licence?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/large-vehicle?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you already have a category C large vehicle licence?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/medium-sized-vehicle.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/medium-sized-vehicle" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you already have a C1 medium-sized vehicle licence?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Medium-sized vehicle (category C1)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=medium-sized-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/medium-sized-vehicle/no.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle/no.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/medium-sized-vehicle/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you already have a driving licence with the C+E towing with a large vehicle entitlement on it?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Medium-sized vehicle (category C1)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=medium-sized-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a C1 medium-sized vehicle licence?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/medium-sized-vehicle?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you already have a C1 medium-sized vehicle licence?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/medium-sized-vehicle/no/no.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle/no/no.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/medium-sized-vehicle/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When was your driving licence issued?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="before-jan-1997" />
+          Before 1 January 1997
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="from-jan-1997" />
+          From 1 January 1997
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Medium-sized vehicle (category C1)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=medium-sized-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a C1 medium-sized vehicle licence?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/medium-sized-vehicle?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you already have a C1 medium-sized vehicle licence?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a driving licence with the C+E towing with a large vehicle entitlement on it?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/medium-sized-vehicle/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you already have a driving licence with the C+E towing with a large vehicle entitlement on it?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/medium-sized-vehicle/no/no/from-jan-1997.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle/no/no/from-jan-1997.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/medium-sized-vehicle/no/no/from-jan-1997" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old are you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="under-18" />
+          Under 18
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="under-21" />
+          18 to 20
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="21-or-over" />
+          21 or over
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Medium-sized vehicle (category C1)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=medium-sized-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a C1 medium-sized vehicle licence?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/medium-sized-vehicle?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you already have a C1 medium-sized vehicle licence?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a driving licence with the C+E towing with a large vehicle entitlement on it?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/medium-sized-vehicle/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you already have a driving licence with the C+E towing with a large vehicle entitlement on it?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">When was your driving licence issued?</td>
+      <td class="previous-question-body">
+      From 1 January 1997</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/medium-sized-vehicle/no/no?previous_response=from-jan-1997">
+            Change<span class="visuallyhidden"> answer to "When was your driving licence issued?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/medium-sized-vehicle/yes.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle/yes.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/medium-sized-vehicle/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old are you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="under-21" />
+          Under 21
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="21-or-over" />
+          21 or over
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Medium-sized vehicle (category C1)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=medium-sized-vehicle">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you already have a C1 medium-sized vehicle licence?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/medium-sized-vehicle?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you already have a C1 medium-sized vehicle licence?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/minibus.html
+++ b/test/artefacts/towing-rules/minibus.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/minibus" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Did you pass your test before 1 January 1997?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Minibus (category D1)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=minibus">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/minibus/no.html
+++ b/test/artefacts/towing-rules/minibus/no.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/minibus/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you have a full category D+E towing with a bus licence?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Minibus (category D1)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=minibus">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you pass your test before 1 January 1997?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/minibus?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did you pass your test before 1 January 1997?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/minibus/no/no.html
+++ b/test/artefacts/towing-rules/minibus/no/no.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/minibus/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you have a full category D1 minibus licence?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Minibus (category D1)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=minibus">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you pass your test before 1 January 1997?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/minibus?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did you pass your test before 1 January 1997?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have a full category D+E towing with a bus licence?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/minibus/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you have a full category D+E towing with a bus licence?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/minibus/no/no/no.html
+++ b/test/artefacts/towing-rules/minibus/no/no/no.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y/minibus/no/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How old are you?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="under-21" />
+          Under 21
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="21-or-over" />
+          21 or over
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/towing-rules">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">What kind of vehicle do you want to tow with?</td>
+      <td class="previous-question-body">
+      Minibus (category D1)</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y?previous_response=minibus">
+            Change<span class="visuallyhidden"> answer to "What kind of vehicle do you want to tow with?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Did you pass your test before 1 January 1997?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/minibus?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Did you pass your test before 1 January 1997?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have a full category D+E towing with a bus licence?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/minibus/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you have a full category D+E towing with a bus licence?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have a full category D1 minibus licence?</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/towing-rules/y/minibus/no/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do you have a full category D1 minibus licence?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/towing-rules/y.html
+++ b/test/artefacts/towing-rules/y.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Towing: licence and age requirements - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Towing: licence and age requirements
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/towing-rules/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    What kind of vehicle do you want to tow with?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="car-or-light-vehicle" />
+          Car (category B)
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="medium-sized-vehicle" />
+          Medium-sized vehicle (category C1)
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="large-vehicle" />
+          Large vehicle (category C)
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="minibus" />
+          Minibus (category D1)
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="bus" />
+          Bus (category D)
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which benefit will you be claiming?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="jsa" />
+          Jobseeker&#39;s Allowance (JSA)
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="pension" />
+          State Pension
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="winter_fuel_payment" />
+          Winter Fuel Payment
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="maternity_benefits" />
+          Maternity benefits
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="child_benefit" />
+          Child Benefit
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="iidb" />
+          Industrial Injuries Disablement Benefit
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="ssp" />
+          Statutory Sick Pay (SSP)
+        </label>
+    </li>
+    <li>
+        <label for="response_7" class="selectable">
+          <input type="radio" name="response" id="response_7" value="esa" />
+          Employment and Support Allowance (ESA)
+        </label>
+    </li>
+    <li>
+        <label for="response_8" class="selectable">
+          <input type="radio" name="response" id="response_8" value="disability_benefits" />
+          Benefits for carers and people with disabilities 
+        </label>
+    </li>
+    <li>
+        <label for="response_9" class="selectable">
+          <input type="radio" name="response" id="response_9" value="bereavement_benefits" />
+          Bereavement benefits
+        </label>
+    </li>
+    <li>
+        <label for="response_10" class="selectable">
+          <input type="radio" name="response" id="response_10" value="tax_credits" />
+          Tax credits
+        </label>
+    </li>
+    <li>
+        <label for="response_11" class="selectable">
+          <input type="radio" name="response" id="response_11" value="income_support" />
+          Income Support
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/child_benefit/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/child_benefit/austria.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/child_benefit/austria" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Does the following apply to you?
+  </h2>
+  <div class="question-body">
+      <p>You&rsquo;re currently receiving at least one of the following UK benefits:</p>
+
+<ul>
+  <li>Bereavement benefits</li>
+  <li>Severe Disablement Allowance</li>
+  <li>Employment and Support Allowance</li>
+  <li>Incapacity Benefit</li>
+  <li>Industrial Injuries Disablement Benefit</li>
+  <li>State Pension</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Child Benefit</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=child_benefit">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country are you moving to?</td>
+      <td class="previous-question-body">
+      Austria</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/child_benefit?previous_response=austria">
+            Change<span class="visuallyhidden"> answer to "Which country are you moving to?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/disability_benefits" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How long will you be abroad for?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="temporary" />
+          Temporarily, eg for a holiday
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="permanent" />
+          Permanently
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Benefits for carers and people with disabilities </td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=disability_benefits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits/permanent/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits/permanent/austria.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/disability_benefits/permanent/austria" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you or a family member getting State Pension, Industrial Injuries Benefit, ESA (contributory) or bereavement benefits?
+
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Benefits for carers and people with disabilities </td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=disability_benefits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long will you be abroad for?</td>
+      <td class="previous-question-body">
+      Permanently</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/disability_benefits?previous_response=permanent">
+            Change<span class="visuallyhidden"> answer to "How long will you be abroad for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country are you moving to?</td>
+      <td class="previous-question-body">
+      Austria</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/disability_benefits/permanent?previous_response=austria">
+            Change<span class="visuallyhidden"> answer to "Which country are you moving to?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/esa.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/esa.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/esa" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How long are you going abroad for?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="esa_under_a_year_medical" />
+          Less than 1 year, to get medical treatment for yourself or your child
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="esa_under_a_year_other" />
+          Less than 1 year, for a different reason
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="esa_more_than_a_year" />
+          More than 1 year
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Employment and Support Allowance (ESA)</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=esa">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/iidb.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/iidb.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/iidb" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you currently receiving Industrial Injuries Disablement Benefit?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Industrial Injuries Disablement Benefit</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=iidb">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/income_support" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How long are you going abroad for?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">You can&#39;t apply for Income Support from abroad.</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="is_under_a_year_medical" />
+          Less than 1 year, to get medical treatment for you or your child
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="is_under_a_year_other" />
+          Less than 1 year, for a different reason
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="is_more_than_a_year" />
+          More than 1 year
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Income Support</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=income_support">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you travelling abroad with a partner who is getting Income Support with one of the following:
+
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li><a href="/income-support/what-youll-get">Pensioner premium</a></li>
+  <li><a href="/income-support/what-youll-get">Higher Pensioner premium</a></li>
+  <li><a href="/disability-premiums-income-support/eligibility">Disability premium</a></li>
+  <li><a href="/disability-premiums-income-support/eligibility">Severe Disability premium</a></li>
+</ul>
+
+
+      <p class="hint">Your partner must be getting the premium, not you.
+</p>
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Income Support</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=income_support">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long are you going abroad for?</td>
+      <td class="previous-question-body">
+      Less than 1 year, for a different reason</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support?previous_response=is_under_a_year_other">
+            Change<span class="visuallyhidden"> answer to "How long are you going abroad for?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you getting Income Support while either:
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>getting <a href="/statutory-sick-pay/">Statutory Sick Pay</a></li>
+  <li>incapable of work, but being treated as capable of work because you are temporarily disqualified from receiving Income Support</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Income Support</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=income_support">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long are you going abroad for?</td>
+      <td class="previous-question-body">
+      Less than 1 year, for a different reason</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support?previous_response=is_under_a_year_other">
+            Change<span class="visuallyhidden"> answer to "How long are you going abroad for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you travelling abroad with a partner who is getting Income Support with one of the following:
+</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you travelling abroad with a partner who is getting Income Support with one of the following:
+"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/no.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/no.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other/no/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you one of the following:
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>affected by a trades dispute (eg on strike)</li>
+  <li>age 16 to 19 and in full-time secondary education</li>
+  <li>appealing against a decision about your ability to work</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Income Support</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=income_support">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long are you going abroad for?</td>
+      <td class="previous-question-body">
+      Less than 1 year, for a different reason</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support?previous_response=is_under_a_year_other">
+            Change<span class="visuallyhidden"> answer to "How long are you going abroad for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you travelling abroad with a partner who is getting Income Support with one of the following:
+</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you travelling abroad with a partner who is getting Income Support with one of the following:
+"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you getting Income Support while either:</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other/no?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you getting Income Support while either:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other/no/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you going abroad to get medical treatment for the illness or disability that prevents you from working?
+
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Income Support</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=income_support">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long are you going abroad for?</td>
+      <td class="previous-question-body">
+      Less than 1 year, for a different reason</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support?previous_response=is_under_a_year_other">
+            Change<span class="visuallyhidden"> answer to "How long are you going abroad for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you travelling abroad with a partner who is getting Income Support with one of the following:
+</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you travelling abroad with a partner who is getting Income Support with one of the following:
+"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you getting Income Support while either:</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other/no?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you getting Income Support while either:"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes/no.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes/no.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other/no/yes/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Have you been unable to work or received Statutory Sick Pay for one of the following:
+
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>364 days</li>
+  <li>196 days if you&rsquo;re terminally ill, or getting the highest rate of Disability Living Allowance (care component) or the enhanced rate of Personal Independence Payment (daily living component)</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Income Support</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=income_support">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long are you going abroad for?</td>
+      <td class="previous-question-body">
+      Less than 1 year, for a different reason</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support?previous_response=is_under_a_year_other">
+            Change<span class="visuallyhidden"> answer to "How long are you going abroad for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you travelling abroad with a partner who is getting Income Support with one of the following:
+</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you travelling abroad with a partner who is getting Income Support with one of the following:
+"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you getting Income Support while either:</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other/no?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Are you getting Income Support while either:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you going abroad to get medical treatment for the illness or disability that prevents you from working?
+</td>
+      <td class="previous-question-body">
+      No</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/income_support/is_under_a_year_other/no/yes?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Are you going abroad to get medical treatment for the illness or disability that prevents you from working?
+"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/jsa.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/jsa.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/jsa" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    If you&#39;re claiming JSA, how long are you going abroad for?
+
+  </h2>
+  <div class="question-body">
+      
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="less_than_a_year_medical" />
+          Less than 1 year, to get medical treatment for yourself or your child 
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="less_than_a_year_other" />
+          Less than 1 year, for a different reason
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="more_than_a_year" />
+          More than 1 year
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Jobseeker&#39;s Allowance (JSA)</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=jsa">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/jsa/more_than_a_year.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/jsa/more_than_a_year.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/jsa/more_than_a_year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Which country are you moving to?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <select name="response" id="response"><option value="afghanistan">Afghanistan</option>
+<option value="albania">Albania</option>
+<option value="algeria">Algeria</option>
+<option value="american-samoa">American Samoa</option>
+<option value="andorra">Andorra</option>
+<option value="angola">Angola</option>
+<option value="anguilla">Anguilla</option>
+<option value="antigua-and-barbuda">Antigua And Barbuda</option>
+<option value="argentina">Argentina</option>
+<option value="armenia">Armenia</option>
+<option value="aruba">Aruba</option>
+<option value="australia">Australia</option>
+<option value="austria">Austria</option>
+<option value="azerbaijan">Azerbaijan</option>
+<option value="bahamas">Bahamas</option>
+<option value="bahrain">Bahrain</option>
+<option value="bangladesh">Bangladesh</option>
+<option value="barbados">Barbados</option>
+<option value="belarus">Belarus</option>
+<option value="belgium">Belgium</option>
+<option value="belize">Belize</option>
+<option value="benin">Benin</option>
+<option value="bermuda">Bermuda</option>
+<option value="bhutan">Bhutan</option>
+<option value="bolivia">Bolivia</option>
+<option value="bonaire-st-eustatius-saba">Bonaire St Eustatius Saba</option>
+<option value="bosnia-and-herzegovina">Bosnia And Herzegovina</option>
+<option value="botswana">Botswana</option>
+<option value="brazil">Brazil</option>
+<option value="british-indian-ocean-territory">British Indian Ocean Territory</option>
+<option value="british-virgin-islands">British Virgin Islands</option>
+<option value="brunei">Brunei</option>
+<option value="bulgaria">Bulgaria</option>
+<option value="burkina-faso">Burkina Faso</option>
+<option value="burma">Burma</option>
+<option value="burundi">Burundi</option>
+<option value="cambodia">Cambodia</option>
+<option value="cameroon">Cameroon</option>
+<option value="canada">Canada</option>
+<option value="cape-verde">Cape Verde</option>
+<option value="cayman-islands">Cayman Islands</option>
+<option value="central-african-republic">Central African Republic</option>
+<option value="chad">Chad</option>
+<option value="chile">Chile</option>
+<option value="china">China</option>
+<option value="colombia">Colombia</option>
+<option value="comoros">Comoros</option>
+<option value="congo">Congo</option>
+<option value="costa-rica">Costa Rica</option>
+<option value="cote-d-ivoire">Cote D Ivoire</option>
+<option value="croatia">Croatia</option>
+<option value="cuba">Cuba</option>
+<option value="curacao">Curacao</option>
+<option value="cyprus">Cyprus</option>
+<option value="czech-republic">Czech Republic</option>
+<option value="democratic-republic-of-congo">Democratic Republic Of Congo</option>
+<option value="denmark">Denmark</option>
+<option value="djibouti">Djibouti</option>
+<option value="dominica">Dominica</option>
+<option value="dominican-republic">Dominican Republic</option>
+<option value="ecuador">Ecuador</option>
+<option value="egypt">Egypt</option>
+<option value="el-salvador">El Salvador</option>
+<option value="equatorial-guinea">Equatorial Guinea</option>
+<option value="eritrea">Eritrea</option>
+<option value="estonia">Estonia</option>
+<option value="ethiopia">Ethiopia</option>
+<option value="falkland-islands">Falkland Islands</option>
+<option value="fiji">Fiji</option>
+<option value="finland">Finland</option>
+<option value="france">France</option>
+<option value="french-polynesia">French Polynesia</option>
+<option value="gabon">Gabon</option>
+<option value="gambia">Gambia</option>
+<option value="georgia">Georgia</option>
+<option value="germany">Germany</option>
+<option value="ghana">Ghana</option>
+<option value="gibraltar">Gibraltar</option>
+<option value="greece">Greece</option>
+<option value="grenada">Grenada</option>
+<option value="guatemala">Guatemala</option>
+<option value="guernsey">Guernsey</option>
+<option value="guinea">Guinea</option>
+<option value="guinea-bissau">Guinea Bissau</option>
+<option value="guyana">Guyana</option>
+<option value="haiti">Haiti</option>
+<option value="honduras">Honduras</option>
+<option value="hong-kong">Hong Kong</option>
+<option value="hungary">Hungary</option>
+<option value="iceland">Iceland</option>
+<option value="india">India</option>
+<option value="indonesia">Indonesia</option>
+<option value="iran">Iran</option>
+<option value="iraq">Iraq</option>
+<option value="ireland">Ireland</option>
+<option value="israel">Israel</option>
+<option value="italy">Italy</option>
+<option value="jamaica">Jamaica</option>
+<option value="japan">Japan</option>
+<option value="jersey">Jersey</option>
+<option value="jordan">Jordan</option>
+<option value="kazakhstan">Kazakhstan</option>
+<option value="kenya">Kenya</option>
+<option value="kiribati">Kiribati</option>
+<option value="kosovo">Kosovo</option>
+<option value="kuwait">Kuwait</option>
+<option value="kyrgyzstan">Kyrgyzstan</option>
+<option value="laos">Laos</option>
+<option value="latvia">Latvia</option>
+<option value="lebanon">Lebanon</option>
+<option value="lesotho">Lesotho</option>
+<option value="liberia">Liberia</option>
+<option value="libya">Libya</option>
+<option value="liechtenstein">Liechtenstein</option>
+<option value="lithuania">Lithuania</option>
+<option value="luxembourg">Luxembourg</option>
+<option value="macao">Macao</option>
+<option value="macedonia">Macedonia</option>
+<option value="madagascar">Madagascar</option>
+<option value="malawi">Malawi</option>
+<option value="malaysia">Malaysia</option>
+<option value="maldives">Maldives</option>
+<option value="mali">Mali</option>
+<option value="malta">Malta</option>
+<option value="marshall-islands">Marshall Islands</option>
+<option value="mauritania">Mauritania</option>
+<option value="mauritius">Mauritius</option>
+<option value="mexico">Mexico</option>
+<option value="micronesia">Micronesia</option>
+<option value="moldova">Moldova</option>
+<option value="monaco">Monaco</option>
+<option value="mongolia">Mongolia</option>
+<option value="montenegro">Montenegro</option>
+<option value="montserrat">Montserrat</option>
+<option value="morocco">Morocco</option>
+<option value="mozambique">Mozambique</option>
+<option value="namibia">Namibia</option>
+<option value="nauru">Nauru</option>
+<option value="nepal">Nepal</option>
+<option value="netherlands">Netherlands</option>
+<option value="new-caledonia">New Caledonia</option>
+<option value="new-zealand">New Zealand</option>
+<option value="nicaragua">Nicaragua</option>
+<option value="niger">Niger</option>
+<option value="nigeria">Nigeria</option>
+<option value="north-korea">North Korea</option>
+<option value="norway">Norway</option>
+<option value="oman">Oman</option>
+<option value="pakistan">Pakistan</option>
+<option value="palau">Palau</option>
+<option value="panama">Panama</option>
+<option value="papua-new-guinea">Papua New Guinea</option>
+<option value="paraguay">Paraguay</option>
+<option value="peru">Peru</option>
+<option value="philippines">Philippines</option>
+<option value="pitcairn-island">Pitcairn Island</option>
+<option value="poland">Poland</option>
+<option value="portugal">Portugal</option>
+<option value="qatar">Qatar</option>
+<option value="romania">Romania</option>
+<option value="russia">Russia</option>
+<option value="rwanda">Rwanda</option>
+<option value="saint-barthelemy">Saint Barthelemy</option>
+<option value="samoa">Samoa</option>
+<option value="san-marino">San Marino</option>
+<option value="sao-tome-and-principe">Sao Tome And Principe</option>
+<option value="saudi-arabia">Saudi Arabia</option>
+<option value="senegal">Senegal</option>
+<option value="serbia">Serbia</option>
+<option value="seychelles">Seychelles</option>
+<option value="sierra-leone">Sierra Leone</option>
+<option value="singapore">Singapore</option>
+<option value="slovakia">Slovakia</option>
+<option value="slovenia">Slovenia</option>
+<option value="solomon-islands">Solomon Islands</option>
+<option value="somalia">Somalia</option>
+<option value="south-africa">South Africa</option>
+<option value="south-georgia-and-south-sandwich-islands">South Georgia And South Sandwich Islands</option>
+<option value="south-korea">South Korea</option>
+<option value="south-sudan">South Sudan</option>
+<option value="spain">Spain</option>
+<option value="sri-lanka">Sri Lanka</option>
+<option value="st-helena-ascension-and-tristan-da-cunha">St Helena Ascension And Tristan Da Cunha</option>
+<option value="st-kitts-and-nevis">St Kitts And Nevis</option>
+<option value="st-lucia">St Lucia</option>
+<option value="st-martin">St Martin</option>
+<option value="st-pierre-and-miquelon">St Pierre And Miquelon</option>
+<option value="st-vincent-and-the-grenadines">St Vincent And The Grenadines</option>
+<option value="sudan">Sudan</option>
+<option value="suriname">Suriname</option>
+<option value="swaziland">Swaziland</option>
+<option value="sweden">Sweden</option>
+<option value="switzerland">Switzerland</option>
+<option value="syria">Syria</option>
+<option value="taiwan">Taiwan</option>
+<option value="tajikistan">Tajikistan</option>
+<option value="tanzania">Tanzania</option>
+<option value="thailand">Thailand</option>
+<option value="the-occupied-palestinian-territories">The Occupied Palestinian Territories</option>
+<option value="timor-leste">Timor Leste</option>
+<option value="togo">Togo</option>
+<option value="tonga">Tonga</option>
+<option value="trinidad-and-tobago">Trinidad And Tobago</option>
+<option value="tunisia">Tunisia</option>
+<option value="turkey">Turkey</option>
+<option value="turkmenistan">Turkmenistan</option>
+<option value="turks-and-caicos-islands">Turks And Caicos Islands</option>
+<option value="tuvalu">Tuvalu</option>
+<option value="uganda">Uganda</option>
+<option value="ukraine">Ukraine</option>
+<option value="united-arab-emirates">United Arab Emirates</option>
+<option value="uruguay">Uruguay</option>
+<option value="usa">Usa</option>
+<option value="uzbekistan">Uzbekistan</option>
+<option value="vanuatu">Vanuatu</option>
+<option value="venezuela">Venezuela</option>
+<option value="vietnam">Vietnam</option>
+<option value="wallis-and-futuna">Wallis And Futuna</option>
+<option value="western-sahara">Western Sahara</option>
+<option value="yemen">Yemen</option>
+<option value="zambia">Zambia</option>
+<option value="zimbabwe">Zimbabwe</option></select>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Jobseeker&#39;s Allowance (JSA)</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=jsa">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">If you&#39;re claiming JSA, how long are you going abroad for?
+</td>
+      <td class="previous-question-body">
+      More than 1 year</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/jsa?previous_response=more_than_a_year">
+            Change<span class="visuallyhidden"> answer to "If you&#39;re claiming JSA, how long are you going abroad for?
+"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/maternity_benefits/afghanistan" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Is your employer paying National Insurance contributions for you?
+
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Maternity benefits</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=maternity_benefits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country are you moving to?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/maternity_benefits?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "Which country are you moving to?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan/yes.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan/yes.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/maternity_benefits/afghanistan/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you eligible for Statutory Maternity Pay?
+  </h2>
+  <div class="question-body">
+      <p>If you&rsquo;re unsure you can read our <a href="/statutory-maternity-pay#eligibility">Maternity pay and leave guide</a></p>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Maternity benefits</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=maternity_benefits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country are you moving to?</td>
+      <td class="previous-question-body">
+      Afghanistan</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/maternity_benefits?previous_response=afghanistan">
+            Change<span class="visuallyhidden"> answer to "Which country are you moving to?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Is your employer paying National Insurance contributions for you?
+</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/maternity_benefits/afghanistan?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Is your employer paying National Insurance contributions for you?
+"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/austria.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/maternity_benefits/austria" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you working for a UK employer and paying Class 1 National Insurance Contributions?
+
+  </h2>
+  <div class="question-body">
+      <p>If you&rsquo;re unsure you can read our <a href="/national-insurance/how-much-national-insurance-you-pay">National Insurance Guide</a>.</p>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Maternity benefits</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=maternity_benefits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country are you moving to?</td>
+      <td class="previous-question-body">
+      Austria</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/maternity_benefits?previous_response=austria">
+            Change<span class="visuallyhidden"> answer to "Which country are you moving to?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/ssp/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/ssp/austria.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/ssp/austria" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you working for a UK employer?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Statutory Sick Pay (SSP)</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=ssp">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country are you moving to?</td>
+      <td class="previous-question-body">
+      Austria</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/ssp?previous_response=austria">
+            Change<span class="visuallyhidden"> answer to "Which country are you moving to?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/tax_credits" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you or your partner one of the following?
+  </h2>
+  <div class="question-body">
+
+      <p class="hint">A Crown servant is someone who works for the UK government.
+
+A cross-border worker is someone who regularly travels to or from another country to work.
+</p>
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="crown_servant" />
+          A Crown servant
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="cross_border_worker" />
+          A cross-border worker
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="none_of_the_above" />
+          None of the above
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Tax credits</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=tax_credits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/tax_credits/none_of_the_above" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How long are you going abroad for?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="tax_credits_up_to_a_year" />
+          Up to 1 year
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="tax_credits_more_than_a_year" />
+          More than 1 year or permanently
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Tax credits</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=tax_credits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you or your partner one of the following?</td>
+      <td class="previous-question-body">
+      None of the above</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/tax_credits?previous_response=none_of_the_above">
+            Change<span class="visuallyhidden"> answer to "Are you or your partner one of the following?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Do you have any children?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Tax credits</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=tax_credits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you or your partner one of the following?</td>
+      <td class="previous-question-body">
+      None of the above</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/tax_credits?previous_response=none_of_the_above">
+            Change<span class="visuallyhidden"> answer to "Are you or your partner one of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long are you going abroad for?</td>
+      <td class="previous-question-body">
+      More than 1 year or permanently</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/tax_credits/none_of_the_above?previous_response=tax_credits_more_than_a_year">
+            Change<span class="visuallyhidden"> answer to "How long are you going abroad for?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you currently claiming State Pension or any of the following benefits?
+  </h2>
+  <div class="question-body">
+      <ul>
+  <li>Incapacity Benefit</li>
+  <li>Widow&rsquo;s Benefit</li>
+  <li>Bereavement Benefit</li>
+  <li>Industrial Injuries Disablement Benefit</li>
+  <li>contribution-based Employment and Support Allowance</li>
+  <li>Severe Disablement Allowance</li>
+</ul>
+
+
+
+    <div class="">
+
+      <ul class="options inline">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="yes" />
+          Yes
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="no" />
+          No
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Tax credits</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=tax_credits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you or your partner one of the following?</td>
+      <td class="previous-question-body">
+      None of the above</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/tax_credits?previous_response=none_of_the_above">
+            Change<span class="visuallyhidden"> answer to "Are you or your partner one of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long are you going abroad for?</td>
+      <td class="previous-question-body">
+      More than 1 year or permanently</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/tax_credits/none_of_the_above?previous_response=tax_credits_more_than_a_year">
+            Change<span class="visuallyhidden"> answer to "How long are you going abroad for?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do you have any children?</td>
+      <td class="previous-question-body">
+      Yes</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Do you have any children?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which country are you moving to?</td>
+      <td class="previous-question-body">
+      Austria</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes?previous_response=austria">
+            Change<span class="visuallyhidden"> answer to "Which country are you moving to?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Why are you going abroad?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="tax_credits_holiday" />
+          A holiday or business trip
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="tax_credits_medical_treatment" />
+          For medical treatment for yourself, your partner or your child
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="tax_credits_death" />
+          Because of the death of your partner, child or close family member
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/uk-benefits-abroad">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you currently:</td>
+      <td class="previous-question-body">
+      in the UK and planning to move abroad</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y?previous_response=going_abroad">
+            Change<span class="visuallyhidden"> answer to "Are you currently:"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Which benefit will you be claiming?</td>
+      <td class="previous-question-body">
+      Tax credits</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad?previous_response=tax_credits">
+            Change<span class="visuallyhidden"> answer to "Which benefit will you be claiming?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you or your partner one of the following?</td>
+      <td class="previous-question-body">
+      None of the above</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/tax_credits?previous_response=none_of_the_above">
+            Change<span class="visuallyhidden"> answer to "Are you or your partner one of the following?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How long are you going abroad for?</td>
+      <td class="previous-question-body">
+      Up to 1 year</td>
+
+      <td class="link-right">
+          <a href="/uk-benefits-abroad/y/going_abroad/tax_credits/none_of_the_above?previous_response=tax_credits_up_to_a_year">
+            Change<span class="visuallyhidden"> answer to "How long are you going abroad for?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/uk-benefits-abroad/y.html
+++ b/test/artefacts/uk-benefits-abroad/y.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        UK benefits if you&#39;re going or living abroad
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/uk-benefits-abroad/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    Are you currently:
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="going_abroad" />
+          in the UK and planning to move abroad
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="already_abroad" />
+          someone who has lived and worked in the UK who is now living abroad
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/vat-payment-deadlines/2015-01-31.html
+++ b/test/artefacts/vat-payment-deadlines/2015-01-31.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>VAT payment deadline calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        VAT payment deadline calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/vat-payment-deadlines/y/2015-01-31" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    How do you want to pay?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <ul class="options">
+    <li>
+        <label for="response_0" class="selectable">
+          <input type="radio" name="response" id="response_0" value="direct-debit" />
+          Direct debit
+        </label>
+    </li>
+    <li>
+        <label for="response_1" class="selectable">
+          <input type="radio" name="response" id="response_1" value="online-telephone-banking" />
+          Online or telephone banking (Faster Payments)
+        </label>
+    </li>
+    <li>
+        <label for="response_2" class="selectable">
+          <input type="radio" name="response" id="response_2" value="online-debit-credit-card" />
+          Online debit or credit card (BillPay)
+        </label>
+    </li>
+    <li>
+        <label for="response_3" class="selectable">
+          <input type="radio" name="response" id="response_3" value="bacs-direct-credit" />
+          Bacs direct credit
+        </label>
+    </li>
+    <li>
+        <label for="response_4" class="selectable">
+          <input type="radio" name="response" id="response_4" value="bank-giro" />
+          Bank Giro
+        </label>
+    </li>
+    <li>
+        <label for="response_5" class="selectable">
+          <input type="radio" name="response" id="response_5" value="chaps" />
+          CHAPS
+        </label>
+    </li>
+    <li>
+        <label for="response_6" class="selectable">
+          <input type="radio" name="response" id="response_6" value="cheque" />
+          Cheque
+        </label>
+    </li>
+</ul>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/vat-payment-deadlines">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your VAT accounting period end?</td>
+      <td class="previous-question-body">
+      31 January 2015</td>
+
+      <td class="link-right">
+          <a href="/vat-payment-deadlines/y?previous_response=2015-01-31">
+            Change<span class="visuallyhidden"> answer to "When does your VAT accounting period end?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/vat-payment-deadlines/y.html
+++ b/test/artefacts/vat-payment-deadlines/y.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>VAT payment deadline calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        VAT payment deadline calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="step current" data-step="employment-status">
+      <form action="/vat-payment-deadlines/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+        <div class="current-question" id="current-question">
+            <div class="question">
+  <h2>
+    When does your VAT accounting period end?
+  </h2>
+  <div class="question-body">
+
+
+    <div class="">
+
+      <fieldset>
+    <label for="response_month">Month
+      <select id="response_month" name="response[month]">
+<option value=""></option>
+<option value="1">January</option>
+<option value="2">February</option>
+<option value="3">March</option>
+<option value="4">April</option>
+<option value="5">May</option>
+<option value="6">June</option>
+<option value="7">July</option>
+<option value="8">August</option>
+<option value="9">September</option>
+<option value="10">October</option>
+<option value="11">November</option>
+<option value="12">December</option>
+</select>
+
+    </label>
+    <label for="response_year">Year
+      <select id="response_year" name="response[year]">
+<option value=""></option>
+<option value="2014">2014</option>
+<option value="2015">2015</option>
+<option value="2016">2016</option>
+<option value="2017">2017</option>
+<option value="2018">2018</option>
+</select>
+
+    </label>
+</fieldset>
+
+
+    </div>
+  </div>
+</div>
+
+          <div class="next-question">
+            <input type="hidden" name="next" value="1" />
+            <button type="submit" class="medium button">Next step</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This is in preparation for refactoring the code around question pages.

Unlike the code for outcome pages, question pages have little (?) or no
response-related logic, and so, even if we only render the page for each
question node *once*, this should give us decent regression test coverage.

Rendering the page for each question just once means that time taken to run
the regression tests is only very slightly increased.

Unlike the landing and outcome pages, there is currently no easy way to
render a simplified (e.g. Govspeak) version of a question page, so we're
rendering the full HTML version of the page for these nodes.