### PR TITLE
Send `content_id` to panopticon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'uglifier'
 if ENV['SMARTDOWN_DEV']
   gem 'smartdown', path: '../smartdown'
 else
-  gem 'smartdown', '~> 0.15.1'
+  gem 'smartdown', '~> 0.16.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,9 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '20.1.1'
+  gem 'gds-api-adapters', '~> 24.4.0'
 end
+
 gem 'htmlentities', '~> 4'
 
 gem 'extlib', '0.9.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     filesize (0.0.4)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (24.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -133,7 +133,7 @@ GEM
       mime-types (>= 1.16, < 3)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.6.1)
+    mime-types (2.6.2)
     mini_portile (0.6.2)
     minitest (5.7.0)
     mocha (1.1.0)
@@ -159,7 +159,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.6.2)
+    rack (1.6.4)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-test (0.6.3)
@@ -298,7 +298,7 @@ DEPENDENCIES
   diffy (= 3.0.6)
   extlib (= 0.9.16)
   filesize
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (~> 24.4.0)
   google-api-client
   govspeak (~> 3.3.0)
   govuk-lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       rack (>= 1.3.5)
       rest-client
     slop (3.6.0)
-    smartdown (0.15.1)
+    smartdown (0.16.0)
       parslet (~> 1.6.2)
       uk_postcode (~> 1.0.1)
     sprockets (2.12.3)
@@ -322,7 +322,7 @@ DEPENDENCIES
   simplecov (~> 0.10.0)
   simplecov-rcov (~> 0.2.3)
   slimmer (= 9.0.0)
-  smartdown (~> 0.15.1)
+  smartdown (~> 0.16.0)
   therubyracer (~> 0.12.1)
   tilt (= 1.4.1)
   timecop

--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ files relating to the regression tests e.g. file checksums, Govspeak artefacts, 
 
 - [How to archive a Smart Answer](doc/archiving.md)
 
+## Content IDs
+
+Smart answers need content-ids. You can generate one by running:
+
+    $ be rails r "puts SecureRandom.uuid"
+
 ## Issues/todos
 
 Please see the [github issues](https://github.com/alphagov/smart-answers/issues) page.

--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -13,6 +13,10 @@ class FlowRegistrationPresenter
     @flow.need_id
   end
 
+  def content_id
+    @flow.content_id
+  end
+
   def title
     start_node.title
   end

--- a/app/services/panopticon_registerer.rb
+++ b/app/services/panopticon_registerer.rb
@@ -1,4 +1,10 @@
 class PanopticonRegisterer
+  attr_reader :unique_registerables
+
+  def initialize(unique_registerables)
+    @unique_registerables = unique_registerables
+  end
+
   def register
     require 'gds_api/panopticon'
     logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
@@ -11,26 +17,5 @@ class PanopticonRegisterer
       puts "Registering flow: #{registerable.slug} => #{registerable.title}"
       registerer.register(registerable)
     }
-  end
-
-private
-
-  def unique_registerables
-    # Picks smartdown of smart_answer for any dupe keys, same as routing behaviour
-    smart_answer_registrables.merge(smartdown_registrables).values
-  end
-
-  def smart_answer_registrables
-    flow_registry = SmartAnswer::FlowRegistry.new(FLOW_REGISTRY_OPTIONS)
-
-    Hash[flow_registry.flows.collect { |flow|
-      [flow.name, FlowRegistrationPresenter.new(flow)]
-    }]
-  end
-
-  def smartdown_registrables
-    Hash[SmartdownAdapter::Registry.instance.flows.collect { |flow|
-      [flow.name, SmartdownAdapter::FlowRegistrationPresenter.new(flow)]
-    }]
   end
 end

--- a/app/services/panopticon_registerer.rb
+++ b/app/services/panopticon_registerer.rb
@@ -1,0 +1,36 @@
+class PanopticonRegisterer
+  def register
+    require 'gds_api/panopticon'
+    logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+    logger.info "Registering with panopticon..."
+    registerer = GdsApi::Panopticon::Registerer.new(owning_app: "smartanswers", kind: "smart-answer")
+
+    puts "Looking up flows, with options: #{FLOW_REGISTRY_OPTIONS}"
+
+    unique_registerables.each { |registerable|
+      puts "Registering flow: #{registerable.slug} => #{registerable.title}"
+      registerer.register(registerable)
+    }
+  end
+
+private
+
+  def unique_registerables
+    # Picks smartdown of smart_answer for any dupe keys, same as routing behaviour
+    smart_answer_registrables.merge(smartdown_registrables).values
+  end
+
+  def smart_answer_registrables
+    flow_registry = SmartAnswer::FlowRegistry.new(FLOW_REGISTRY_OPTIONS)
+
+    Hash[flow_registry.flows.collect { |flow|
+      [flow.name, FlowRegistrationPresenter.new(flow)]
+    }]
+  end
+
+  def smartdown_registrables
+    Hash[SmartdownAdapter::Registry.instance.flows.collect { |flow|
+      [flow.name, SmartdownAdapter::FlowRegistrationPresenter.new(flow)]
+    }]
+  end
+end

--- a/app/services/registerable_smart_answers.rb
+++ b/app/services/registerable_smart_answers.rb
@@ -1,22 +1,20 @@
 class RegisterableSmartAnswers
   def unique_registerables
-    # Picks smartdown of smart_answer for any dupe keys, same as routing behaviour
-    smart_answer_registrables.merge(smartdown_registrables).values
+    smart_answer_registrables + smartdown_registrables
   end
 
 private
 
   def smart_answer_registrables
     flow_registry = SmartAnswer::FlowRegistry.new(FLOW_REGISTRY_OPTIONS)
-
-    Hash[flow_registry.flows.collect { |flow|
-      [flow.name, FlowRegistrationPresenter.new(flow)]
-    }]
+    flow_registry.flows.map do |flow|
+      FlowRegistrationPresenter.new(flow)
+    end
   end
 
   def smartdown_registrables
-    Hash[SmartdownAdapter::Registry.instance.flows.collect { |flow|
-      [flow.name, SmartdownAdapter::FlowRegistrationPresenter.new(flow)]
-    }]
+    SmartdownAdapter::Registry.instance.flows.map do |flow|
+      SmartdownAdapter::FlowRegistrationPresenter.new(flow)
+    end
   end
 end

--- a/app/services/registerable_smart_answers.rb
+++ b/app/services/registerable_smart_answers.rb
@@ -1,0 +1,22 @@
+class RegisterableSmartAnswers
+  def unique_registerables
+    # Picks smartdown of smart_answer for any dupe keys, same as routing behaviour
+    smart_answer_registrables.merge(smartdown_registrables).values
+  end
+
+private
+
+  def smart_answer_registrables
+    flow_registry = SmartAnswer::FlowRegistry.new(FLOW_REGISTRY_OPTIONS)
+
+    Hash[flow_registry.flows.collect { |flow|
+      [flow.name, FlowRegistrationPresenter.new(flow)]
+    }]
+  end
+
+  def smartdown_registrables
+    Hash[SmartdownAdapter::Registry.instance.flows.collect { |flow|
+      [flow.name, SmartdownAdapter::FlowRegistrationPresenter.new(flow)]
+    }]
+  end
+end

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -17,6 +17,11 @@ module SmartAnswer
       instance_eval(&block) if block_given?
     end
 
+    def content_id(cid = nil)
+      @content_id = cid unless cid.nil?
+      @content_id
+    end
+
     def use_shared_logic(filename)
       eval File.read(Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")), binding
     end

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class AdditionalCommodityCodeFlow < Flow
     def define
+      content_id "bfda3b4f-166b-48e7-9aaf-21bfbd606207"
       name 'additional-commodity-code'
 
       status :published

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class AmIGettingMinimumWageFlow < Flow
     def define
+      content_id "111e006d-2b22-4b1f-989a-56bb61355d68"
       name 'am-i-getting-minimum-wage'
       status :published
       satisfies_need "100145"
@@ -9,4 +10,3 @@ module SmartAnswer
     end
   end
 end
-

--- a/lib/smart_answer_flows/apply-tier-4-visa.rb
+++ b/lib/smart_answer_flows/apply-tier-4-visa.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class ApplyTier4VisaFlow < Flow
     def define
+      content_id "af23458d-3437-4545-adae-3bd776ceb8f9"
       name 'apply-tier-4-visa'
       status :published
       satisfies_need "101059"
@@ -53,4 +54,3 @@ module SmartAnswer
     end
   end
 end
-

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class BenefitCapCalculatorFlow < Flow
     def define
+      content_id "ffe22070-123b-4390-8cc4-51f9d5b5cc74"
       name 'benefit-cap-calculator'
       status :published
       satisfies_need "100696"

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class CalculateAgriculturalHolidayEntitlementFlow < Flow
     def define
+      content_id "8834bc7c-7ac7-4d45-8a57-1d5a5dcd70a0"
       name 'calculate-agricultural-holiday-entitlement'
       status :published
       satisfies_need "100143"

--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class CalculateEmployeeRedundancyPayFlow < Flow
     def define
+      content_id "a5b52037-1712-4544-a3d1-a352ce8a8287"
       name 'calculate-employee-redundancy-pay'
 
       status :published

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class CalculateMarriedCouplesAllowanceFlow < Flow
     def define
+      content_id "e04dc5fe-9a31-4229-9de9-884dd0c0a8ce"
       name 'calculate-married-couples-allowance'
       status :published
       satisfies_need "101007"
@@ -131,4 +132,3 @@ module SmartAnswer
     end
   end
 end
-

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -3,6 +3,7 @@ require "data/state_pension_date_query"
 module SmartAnswer
   class CalculateStatePensionFlow < Flow
     def define
+      content_id "5491c439-1c83-4044-80d3-32cc3613b739"
       name 'calculate-state-pension'
       status :published
       satisfies_need "100245"

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class CalculateStatutorySickPayFlow < Flow
     def define
+      content_id "1c676a9e-0424-4ebb-bab8-d8cb8d2fc6f8"
       name 'calculate-statutory-sick-pay'
 
       status :published

--- a/lib/smart_answer_flows/calculate-your-child-maintenance.rb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class CalculateYourChildMaintenanceFlow < Flow
     def define
+      content_id "42c2e944-7977-4297-b142-aa9406756dd2"
       name 'calculate-your-child-maintenance'
       status :published
       satisfies_need "100147"

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class CalculateYourHolidayEntitlementFlow < Flow
     def define
+      content_id "deedf6f8-389b-4b34-a5b1-faa9ef909a70"
       name 'calculate-your-holiday-entitlement'
       status :published
       satisfies_need "100143"

--- a/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class CalculateYourRedundancyPayFlow < Flow
     def define
+      content_id "d2786d90-20fa-467e-ac4a-ff51dcd01b4f"
       name 'calculate-your-redundancy-pay'
 
       status :published

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class CheckUkVisaFlow < Flow
     def define
+      content_id "dc1a1744-4089-43b3-b2e3-4e397b6b15b1"
       name 'check-uk-visa'
       status :published
       satisfies_need "100982"

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class ChildcareCostsForTaxCreditsFlow < Flow
     def define
+      content_id "f8c575b7-d7a2-41a4-9911-069a06f1a2cc"
       name 'childcare-costs-for-tax-credits'
       status :published
       satisfies_need "100422"

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class EnergyGrantsCalculatorFlow < Flow
     def define
+      content_id "20c0a04d-1db4-4828-bd40-bc99954ca5f9"
       name 'energy-grants-calculator'
       status :published
       satisfies_need "100259"

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class EstimateSelfAssessmentPenaltiesFlow < Flow
     def define
+      content_id "32b54f44-fca1-4480-b13b-ddeb0b0238e1"
       name 'estimate-self-assessment-penalties'
       status :published
       satisfies_need "100615"

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class HelpIfYouAreArrestedAbroadFlow < Flow
     def define
+      content_id "cb62c931-a0fa-4363-b33d-12ac06d6232a"
       name 'help-if-you-are-arrested-abroad'
       status :published
       satisfies_need "100220"

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class InheritsSomeoneDiesWithoutWillFlow < Flow
     def define
+      content_id "1f75de31-1f07-4c68-b1ab-8330b1ee8670"
       name 'inherits-someone-dies-without-will'
       status :published
       satisfies_need "100988"

--- a/lib/smart_answer_flows/landlord-immigration-check.rb
+++ b/lib/smart_answer_flows/landlord-immigration-check.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class LandlordImmigrationCheckFlow < Flow
     def define
+      content_id "a6c2dbbb-a26e-4cc5-a244-48ef45523269"
       name "landlord-immigration-check"
       status :draft
       satisfies_need "102373"

--- a/lib/smart_answer_flows/legalisation-document-checker.rb
+++ b/lib/smart_answer_flows/legalisation-document-checker.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class LegalisationDocumentCheckerFlow < Flow
     def define
+      content_id "86acf061-f878-4da1-b05b-80c7ef61305c"
       name 'legalisation-document-checker'
       status :published
       satisfies_need "101010"

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -10,6 +10,7 @@
 module SmartAnswer
   class MarriageAbroadFlow < Flow
     def define
+      content_id "d0a95767-f6ab-432a-aebc-096e37fb3039"
       name 'marriage-abroad'
       status :published
       satisfies_need "101000"

--- a/lib/smart_answer_flows/maternity-paternity-calculator.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class MaternityPaternityCalculatorFlow < Flow
     def define
+      content_id "05d5412d-455b-485e-a570-020c9176a46e"
       name 'maternity-paternity-calculator'
       status :published
       satisfies_need "100990"

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class MinimumWageCalculatorEmployersFlow < Flow
     def define
+      content_id "cc25f6ca-0553-4400-9dba-a43294fee84b"
       name 'minimum-wage-calculator-employers'
       status :published
       satisfies_need "100145"

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class OverseasPassportsFlow < Flow
     def define
+      content_id "dd113259-fcaf-4e9b-83d5-d1148f33cf34"
       name 'overseas-passports'
       status :published
       satisfies_need "100131"

--- a/lib/smart_answer_flows/pip-checker.rb
+++ b/lib/smart_answer_flows/pip-checker.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class PipCheckerFlow < Flow
     def define
+      content_id "fcd0d669-2dfd-4c43-9892-d7e942f60912"
       name 'pip-checker'
       status :published
       satisfies_need "100389"

--- a/lib/smart_answer_flows/plan-adoption-leave.rb
+++ b/lib/smart_answer_flows/plan-adoption-leave.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class PlanAdoptionLeaveFlow < Flow
     def define
+      content_id "b0e80c8b-d19f-4a50-82f4-71ab08f88207"
       name 'plan-adoption-leave'
       status :published
       satisfies_need "101018"

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class RegisterABirthFlow < Flow
     def define
+      content_id "bb68ca88-b56b-4df2-a33d-3aaec66a5098"
       name 'register-a-birth'
       status :published
       satisfies_need "101003"

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class RegisterADeathFlow < Flow
     def define
+      content_id "9e3af3d4-f044-4ac5-830e-d604d701695b"
       name 'register-a-death'
       status :published
       satisfies_need "101006"

--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class ReportALostOrStolenPassportFlow < Flow
     def define
+      content_id "f02fc2c9-f5ff-4ea2-acc4-730bbda957bb"
       name 'report-a-lost-or-stolen-passport'
       status :published
       satisfies_need "100221"

--- a/lib/smart_answer_flows/simplified-expenses-checker.rb
+++ b/lib/smart_answer_flows/simplified-expenses-checker.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class SimplifiedExpensesCheckerFlow < Flow
     def define
+      content_id "8ad76560-8a27-42ee-9a99-8aaa8f0109a5"
       name 'simplified-expenses-checker'
       status :published
       satisfies_need "100119"

--- a/lib/smart_answer_flows/state-pension-through-partner.rb
+++ b/lib/smart_answer_flows/state-pension-through-partner.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class StatePensionThroughPartnerFlow < Flow
     def define
+      content_id "42a41808-b338-4e4b-a703-47195982f4c8"
       name 'state-pension-through-partner'
       status :published
       satisfies_need "100578"

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class StatePensionTopupFlow < Flow
     def define
+      content_id "8721750f-f0dc-4756-81be-1716c7d47844"
       name 'state-pension-topup'
       status :published
       satisfies_need "100865"

--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class StudentFinanceCalculatorFlow < Flow
     def define
+      content_id "434b6eb5-33c8-4300-aba3-f5ead58600b8"
       name 'student-finance-calculator'
       status :published
       satisfies_need "100133"

--- a/lib/smart_answer_flows/student-finance-forms.rb
+++ b/lib/smart_answer_flows/student-finance-forms.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class StudentFinanceFormsFlow < Flow
     def define
+      content_id "67764435-e8ed-4700-a657-2e0432cb1f5b"
       name 'student-finance-forms'
       status :published
       satisfies_need "100982"

--- a/lib/smart_answer_flows/towing-rules.rb
+++ b/lib/smart_answer_flows/towing-rules.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class TowingRulesFlow < Flow
     def define
+      content_id "7bab842c-a9aa-4369-b162-4e3e2a475245"
       name 'towing-rules'
       status :published
       satisfies_need "101014"

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class UkBenefitsAbroadFlow < Flow
     def define
+      content_id "e1eaf183-1211-4fd7-b439-5c94498814ef"
       name 'uk-benefits-abroad'
       status :published
       satisfies_need "100490"

--- a/lib/smart_answer_flows/vat-payment-deadlines.rb
+++ b/lib/smart_answer_flows/vat-payment-deadlines.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class VatPaymentDeadlinesFlow < Flow
     def define
+      content_id "dfa9a5c3-d52e-479c-8505-855f475dc338"
       name 'vat-payment-deadlines'
       status :published
       satisfies_need "100624"

--- a/lib/smartdown_adapter/flow_registration_presenter.rb
+++ b/lib/smartdown_adapter/flow_registration_presenter.rb
@@ -15,6 +15,10 @@ module SmartdownAdapter
       @flow.need_id
     end
 
+    def content_id
+      @flow.content_id
+    end
+
     def title
       @flow.title
     end

--- a/lib/smartdown_flows/animal-example-multiple/animal-example-multiple.txt
+++ b/lib/smartdown_flows/animal-example-multiple/animal-example-multiple.txt
@@ -2,6 +2,7 @@
 meta_description: Animals eh?
 satisfies_need: 100982
 status: draft
+content_id: 3ccbba04-fd85-4a7f-8452-5dcb5daae8b7
 ---
 
 # A simple example of smartdown

--- a/lib/smartdown_flows/animal-example-simple/animal-example-simple.txt
+++ b/lib/smartdown_flows/animal-example-simple/animal-example-simple.txt
@@ -2,6 +2,7 @@
 meta_description: Animals eh?
 satisfies_need: 100982
 status: draft
+content_id: 5bb6964b-3147-4423-aab3-b87e1cb8b838
 ---
 
 # A simple example of smartdown

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/pay-leave-for-parents-adoption.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/pay-leave-for-parents-adoption.txt
@@ -2,6 +2,7 @@
 meta_description: Pay and leave for parents
 status: draft
 satisfies_need: 101018
+content_id: 6f461de9-debd-44e2-a690-99352e175212
 ---
 
 # Calculate your leave and pay when you have a child

--- a/lib/smartdown_flows/pay-leave-for-parents/pay-leave-for-parents.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents/pay-leave-for-parents.txt
@@ -2,6 +2,7 @@
 meta_description: Pay and leave for parents
 status: published
 satisfies_need: 101018
+content_id: 1f6b4ecc-ce2c-488a-b9c7-b78b3bba5598
 ---
 
 # Calculate your leave and pay when you have a child

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -3,35 +3,6 @@ require 'ostruct'
 namespace :panopticon do
   desc "Register application metadata with panopticon"
   task register: :environment do
-    require 'gds_api/panopticon'
-    logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
-    logger.info "Registering with panopticon..."
-    registerer = GdsApi::Panopticon::Registerer.new(owning_app: "smartanswers", kind: "smart-answer")
-
-    puts "Looking up flows, with options: #{FLOW_REGISTRY_OPTIONS}"
-
-    unique_registerables.each { |registerable|
-      puts "Registering flow: #{registerable.slug} => #{registerable.title}"
-      registerer.register(registerable)
-    }
-  end
-
-  def unique_registerables
-    # Picks smartdown of smart_answer for any dupe keys, same as routing behaviour
-    smart_answer_registrables.merge(smartdown_registrables).values
-  end
-
-  def smart_answer_registrables
-    flow_registry = SmartAnswer::FlowRegistry.new(FLOW_REGISTRY_OPTIONS)
-
-    Hash[flow_registry.flows.collect { |flow|
-      [flow.name, FlowRegistrationPresenter.new(flow)]
-    }]
-  end
-
-  def smartdown_registrables
-    Hash[SmartdownAdapter::Registry.instance.flows.collect { |flow|
-      [flow.name, SmartdownAdapter::FlowRegistrationPresenter.new(flow)]
-    }]
+    PanopticonRegisterer.new.register
   end
 end

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -3,6 +3,7 @@ require 'ostruct'
 namespace :panopticon do
   desc "Register application metadata with panopticon"
   task register: :environment do
-    PanopticonRegisterer.new.register
+    registerables = RegisterableSmartAnswers.new.unique_registerables
+    PanopticonRegisterer.new(registerables).register
   end
 end

--- a/test/data/additional-commodity-code-files.yml
+++ b/test/data/additional-commodity-code-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/additional-commodity-code.rb: 862223763eb34d7342d789ba2fa8cc27
+lib/smart_answer_flows/additional-commodity-code.rb: a824498493048a251eefac4c2cbc97fb
 lib/smart_answer_flows/locales/en/additional-commodity-code.yml: 417fd0ca1fc4cfb449d334e8c03c0622
 test/data/additional-commodity-code-questions-and-responses.yml: f2149cbfa6ec8c5ead572f0a89542a79
 test/data/additional-commodity-code-responses-and-expected-results.yml: 6ca51c22f472dbe159ac81f31006a7b1

--- a/test/data/am-i-getting-minimum-wage-files.yml
+++ b/test/data/am-i-getting-minimum-wage-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/am-i-getting-minimum-wage.rb: a5f9ccf8dfe0c6835ef605aa1c5cbacc
+lib/smart_answer_flows/am-i-getting-minimum-wage.rb: 09d171f02c640624e59c6e520a10d4c4
 lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml: b2fb53ff9f63b04b180737e620137db9
 test/data/am-i-getting-minimum-wage-questions-and-responses.yml: 8d05a23bb72740b2d9c9f1196f212e0e
 test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml: 4f24160d38e41983f72ce1352fad9702

--- a/test/data/apply-tier-4-visa-files.yml
+++ b/test/data/apply-tier-4-visa-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/apply-tier-4-visa.rb: b9905c4436e3599fcf87870f9144f1a3
+lib/smart_answer_flows/apply-tier-4-visa.rb: c92ba1a58e14aaa76aa673b3a2e378e0
 lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml: cf313e01e5a6ccf9894c7a6bfbeb23d5
 test/data/apply-tier-4-visa-questions-and-responses.yml: fe87a99e4337e45586806181742f0b8f
 test/data/apply-tier-4-visa-responses-and-expected-results.yml: 339690f2a3125ef29d63f29a79ae1cba

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/benefit-cap-calculator.rb: 7ab5e7f7043eabc1b903a2e1729c679e
+lib/smart_answer_flows/benefit-cap-calculator.rb: acc7833e5ea23ff3349753991fb6bb1e
 lib/smart_answer_flows/locales/en/benefit-cap-calculator.yml: 841fddf2c76ca5f8856979716488f9b7
 test/data/benefit-cap-calculator-questions-and-responses.yml: 460336f2cf1f2acc62729ef5d831f25e
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 19c0bc207cde0d94c76b769b0da5d0bd

--- a/test/data/calculate-agricultural-holiday-entitlement-files.yml
+++ b/test/data/calculate-agricultural-holiday-entitlement-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb: bc27a9976a1016f5d7da30db9cd1f182
+lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb: 74da82e05c472b59cd00d37f7f518ee0
 lib/smart_answer_flows/locales/en/calculate-agricultural-holiday-entitlement.yml: cfee4966bfba0653519cde2f03dec775
 test/data/calculate-agricultural-holiday-entitlement-questions-and-responses.yml: 4b91e0ca75c21fa5d93abc1944bfa8d4
 test/data/calculate-agricultural-holiday-entitlement-responses-and-expected-results.yml: 686cb77b2a3737021c020e6b56c3e586

--- a/test/data/calculate-employee-redundancy-pay-files.yml
+++ b/test/data/calculate-employee-redundancy-pay-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-employee-redundancy-pay.rb: f82afbba5721b039e19a4d8c5e253c3f
+lib/smart_answer_flows/calculate-employee-redundancy-pay.rb: 82aaee0fe06df0a92bc17027ff5f8b92
 lib/smart_answer_flows/locales/en/calculate-employee-redundancy-pay.yml: ded96e8059d2e4fd4c544571015ac880
 test/data/calculate-employee-redundancy-pay-questions-and-responses.yml: dca676f9f9cd34571e4338b66d18bd89
 test/data/calculate-employee-redundancy-pay-responses-and-expected-results.yml: c2a4b09c482a4c3afdbedad7ce8089e0

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-married-couples-allowance.rb: c7e93d8d17bfa0f57793048c6a100ff0
+lib/smart_answer_flows/calculate-married-couples-allowance.rb: 3d7bce5378b53ef23680c2f84c2a3459
 lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml: 4d69826e7196274c5e4f87001c441262
 test/data/calculate-married-couples-allowance-questions-and-responses.yml: 1bbef5f2f30d470433bbb63f029881cd
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3bb53e4211718b8b1b7dacfaa52f3f49

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-state-pension.rb: 8ec36aa8f1d35942dfdfe2af8018a028
+lib/smart_answer_flows/calculate-state-pension.rb: a67c7e878b421309f2ed1e56de34c73a
 lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 80767794dcf1a1557b7d141cc66338bf
 test/data/calculate-state-pension-questions-and-responses.yml: 8fe4d28d6b90ff1030ed15470d5b458f
 test/data/calculate-state-pension-responses-and-expected-results.yml: 61e8ccba31841f6616cf8b26f3da6ff9

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-statutory-sick-pay.rb: 35b53e3c0307caa15921bb2b079a42cf
+lib/smart_answer_flows/calculate-statutory-sick-pay.rb: 05819aff08d85a6a47bb78eaa3e0f008
 lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml: b59d7198145ce14376e12cf34e4a3c2b
 test/data/calculate-statutory-sick-pay-questions-and-responses.yml: 225bf0303e9d1c7fa1a929c24b543db3
 test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: 171dcf9d94ad17c5c64d6e776c73c69b

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-your-child-maintenance.rb: bebd85f1515ceccc756fdedc9aa4ae25
+lib/smart_answer_flows/calculate-your-child-maintenance.rb: 2dcb25a6f88c10ba535eb2279d4d9af6
 lib/smart_answer_flows/locales/en/calculate-your-child-maintenance.yml: 4fd50e1cfd937e338258643ff94fbb1b
 test/data/calculate-your-child-maintenance-questions-and-responses.yml: 5e6e6e5307c1d385da9abfeb18900c51
 test/data/calculate-your-child-maintenance-responses-and-expected-results.yml: 30457fdf39035ab0333e3e9ad9fedec9

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-your-holiday-entitlement.rb: 5965a557c8d504fae49f7381d687c856
+lib/smart_answer_flows/calculate-your-holiday-entitlement.rb: 6eec1440f4fc73734fb4d5a40861fbea
 lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml: 077bcd2fa3dbbb37d18e6a176fa18d8b
 test/data/calculate-your-holiday-entitlement-questions-and-responses.yml: a5d687911e6173e74f2b70af6a5ff7bd
 test/data/calculate-your-holiday-entitlement-responses-and-expected-results.yml: b7d4735ae33ef0dceeeb97c12019db84

--- a/test/data/calculate-your-redundancy-pay-files.yml
+++ b/test/data/calculate-your-redundancy-pay-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-your-redundancy-pay.rb: 74b0bb1ff133a4691bd1b3cde434b6f7
+lib/smart_answer_flows/calculate-your-redundancy-pay.rb: 92c2c6eb3cfc3933af23be35abcdc81d
 lib/smart_answer_flows/locales/en/calculate-your-redundancy-pay.yml: 5905d20a16d0d8b95220532a37aa6864
 test/data/calculate-your-redundancy-pay-questions-and-responses.yml: dca676f9f9cd34571e4338b66d18bd89
 test/data/calculate-your-redundancy-pay-responses-and-expected-results.yml: c2a4b09c482a4c3afdbedad7ce8089e0

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/check-uk-visa.rb: 28e40e3202a22eb1228a9af24da80988
+lib/smart_answer_flows/check-uk-visa.rb: 3b77e12e5ec2436bd67b2f12d8593694
 lib/smart_answer_flows/locales/en/check-uk-visa.yml: 91033ce01b49021d967daa0c76dd1c0a
 test/data/check-uk-visa-questions-and-responses.yml: f3bbf465d62274d46769eee8fb99d9bc
 test/data/check-uk-visa-responses-and-expected-results.yml: 5efd380bd1adca1aad2506c003c44f05

--- a/test/data/childcare-costs-for-tax-credits-files.yml
+++ b/test/data/childcare-costs-for-tax-credits-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: b29eb75294314e894fb4476ce6d80fee
+lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: 2c5d3e00ecce939574dfa9663bf478f8
 lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml: d55246739a411a6e0142b32c47e905b5
 test/data/childcare-costs-for-tax-credits-questions-and-responses.yml: 136aea3591662aa753c3c630546e68ad
 test/data/childcare-costs-for-tax-credits-responses-and-expected-results.yml: 7d90f3446d1e2c9551d7d363fbc4d639

--- a/test/data/energy-grants-calculator-files.yml
+++ b/test/data/energy-grants-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/energy-grants-calculator.rb: c73cd0d00f106de2d06e2f00fbeedc12
+lib/smart_answer_flows/energy-grants-calculator.rb: 167b1c7372c43f754a91ce0dab85dede
 lib/smart_answer_flows/locales/en/energy-grants-calculator.yml: cd46192351d40f256538061d41689a04
 test/data/energy-grants-calculator-questions-and-responses.yml: e725aa49320518369f4fdc601cd217b2
 test/data/energy-grants-calculator-responses-and-expected-results.yml: 7700bd72da2da267ae960e5d7eac91c2

--- a/test/data/estimate-self-assessment-penalties-files.yml
+++ b/test/data/estimate-self-assessment-penalties-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/estimate-self-assessment-penalties.rb: f5614259510468192d88e64414bbd4f4
+lib/smart_answer_flows/estimate-self-assessment-penalties.rb: c097850300a0c888c26552870b32cb66
 lib/smart_answer_flows/locales/en/estimate-self-assessment-penalties.yml: 97c0cf1ea0ce03f9012ff60ec5a02559
 test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 186d93854ea5dc9321408e14dcc8d61f
 test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 07a0cd26b8c5e4b1fff6dfe51c20142e

--- a/test/data/help-if-you-are-arrested-abroad-files.yml
+++ b/test/data/help-if-you-are-arrested-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: 98c42d92091f8df3c4f72dbfdbe45802
+lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: 0d1e142d0929429219421fcab1260616
 lib/smart_answer_flows/locales/en/help-if-you-are-arrested-abroad.yml: 8dbb908db1cb70bdf47c166d127a3703
 test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml: c007b0dd259d1c09ccc2dd3163fa1e56
 test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml: 26a4d487258c3984a6cd73da22c2d8e6

--- a/test/data/inherits-someone-dies-without-will-files.yml
+++ b/test/data/inherits-someone-dies-without-will-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/inherits-someone-dies-without-will.rb: 007d7e9809cdc82048e9b752a06464fe
+lib/smart_answer_flows/inherits-someone-dies-without-will.rb: 9aa3d7ab45969c37401bf1cb5e341d6d
 lib/smart_answer_flows/locales/en/inherits-someone-dies-without-will.yml: 2de30f10cf713318638ef7cb8e7067b8
 test/data/inherits-someone-dies-without-will-questions-and-responses.yml: e2e1ed6d7bb7c839f6ae34db9697dbbd
 test/data/inherits-someone-dies-without-will-responses-and-expected-results.yml: df21c3f65db333e619238f3baa3e9859

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/landlord-immigration-check.rb: 0369ca72543071be92f1d20051272b4f
+lib/smart_answer_flows/landlord-immigration-check.rb: f87297c9c751e8cd5410155fe864712a
 lib/smart_answer_flows/locales/en/landlord-immigration-check.yml: 590064bf90819fb8cc0484d7c46d0261
 test/data/landlord-immigration-check-questions-and-responses.yml: 7259b20b404af56667915a12e43d6da0
 test/data/landlord-immigration-check-responses-and-expected-results.yml: 329e7752e670f0ee92bc1c671ba478a7

--- a/test/data/legalisation-document-checker-files.yml
+++ b/test/data/legalisation-document-checker-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/legalisation-document-checker.rb: 81ad2cd8f8ab034f29a9a74814c0a2b9
+lib/smart_answer_flows/legalisation-document-checker.rb: b160054be666a2317125e6646bd7cb4c
 lib/smart_answer_flows/locales/en/legalisation-document-checker.yml: a9ca977abcf14999469adc7f47d1f051
 test/data/legalisation-document-checker-questions-and-responses.yml: 37c99c68ba04e459447622b01938ce0b
 test/data/legalisation-document-checker-responses-and-expected-results.yml: a6de7673704ef7ff4348546128f52b75

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: 3d3c3dce01cb44ec4fb2f46808266bfe
+lib/smart_answer_flows/marriage-abroad.rb: 7bbfced3e80c87be2826d0cdc13fb4ac
 lib/smart_answer_flows/locales/en/marriage-abroad.yml: e8225cc9c281e31a884d41cb7c4482bf
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: 364c07a077f707fff8c408a888b67a7f

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/maternity-paternity-calculator.rb: 685e6ad891cbcc7859d795b8e1ce3b81
+lib/smart_answer_flows/maternity-paternity-calculator.rb: 423c26577066ed7c7e70dcba85b60178
 lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: f2f0a62274b2da95314a679437edfc1e
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 0907253765bf7e265a2399281f2b6cc5
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: 775834b47561e46bf1bb8f54dd197c60

--- a/test/data/minimum-wage-calculator-employers-files.yml
+++ b/test/data/minimum-wage-calculator-employers-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/minimum-wage-calculator-employers.rb: 7d3535af37a25bb87337e8a118c3cf5f
+lib/smart_answer_flows/minimum-wage-calculator-employers.rb: 3acdd42973737a9c09ffa017cce5066c
 lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml: 83a4405aaf471f315d5442b0f4faa2a4
 test/data/minimum-wage-calculator-employers-questions-and-responses.yml: 8d05a23bb72740b2d9c9f1196f212e0e
 test/data/minimum-wage-calculator-employers-responses-and-expected-results.yml: 4f24160d38e41983f72ce1352fad9702

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/overseas-passports.rb: d0ca6382bbe3570d952fc05c9d3bac0b
+lib/smart_answer_flows/overseas-passports.rb: 613a11e9f07f779dab45b83adb392ff6
 lib/smart_answer_flows/locales/en/overseas-passports.yml: e3c7aa9bb85ea0e1f34a562f9954e5cd
 test/data/overseas-passports-questions-and-responses.yml: dc6c103245cab8e2f33aee73d7c46556
 test/data/overseas-passports-responses-and-expected-results.yml: 13d8f1d2d9ac2d996e8f337702593417

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/pip-checker.rb: 25e050ae4edb4ce74a50e3b8618a16bc
+lib/smart_answer_flows/pip-checker.rb: d1e6a1262d11e9413a43f4173462a174
 lib/smart_answer_flows/locales/en/pip-checker.yml: 985bc50d508bf8922e9de6e0703087b6
 test/data/pip-checker-questions-and-responses.yml: b1d68ebfb76a9e2793705c55b82294f5
 test/data/pip-checker-responses-and-expected-results.yml: a2c772b69a493d1844cfa32681057796

--- a/test/data/plan-adoption-leave-files.yml
+++ b/test/data/plan-adoption-leave-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/plan-adoption-leave.rb: 3255e3c8c8704888f7993c87354be2ea
+lib/smart_answer_flows/plan-adoption-leave.rb: 8d7b2c69fdebf33ef1dab56b08293900
 lib/smart_answer_flows/locales/en/plan-adoption-leave.yml: 857c472839ae8a5075d18e12f4ce3a10
 test/data/plan-adoption-leave-questions-and-responses.yml: 19cde22548bdc648de4a1616676283ae
 test/data/plan-adoption-leave-responses-and-expected-results.yml: 11998cff3f7d722bfb842851dde611b8

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/register-a-birth.rb: 7b842abccc1e27321268d3d79bbb7af0
+lib/smart_answer_flows/register-a-birth.rb: f0ce6a625e63f48a45b9a0bae2a7e4e0
 lib/smart_answer_flows/locales/en/register-a-birth.yml: dbee291f6049354e1e397d0ca74929a5
 test/data/register-a-birth-questions-and-responses.yml: d43385aee50bc3d3fa5550faf761a0ae
 test/data/register-a-birth-responses-and-expected-results.yml: c04b7ff4d2b3f05c04b4175fb5e50b2c

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/register-a-death.rb: d18144dfb97bcbd600ef0433a56e512f
+lib/smart_answer_flows/register-a-death.rb: 7dfecc0c75610535c6eb5ac80c04ca56
 lib/smart_answer_flows/locales/en/register-a-death.yml: 5f5da5068c2f0cdf1dbc80985fda3511
 test/data/register-a-death-questions-and-responses.yml: 18aba16b4f569a17fbb81374dceaf265
 test/data/register-a-death-responses-and-expected-results.yml: 1d818139ced9c5e20262d144489bf090

--- a/test/data/report-a-lost-or-stolen-passport-files.yml
+++ b/test/data/report-a-lost-or-stolen-passport-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb: 8313ba13aa54c9403dcceb8ba46abab2
+lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb: 6451dcf9cd6a29df60f3d272ce20d808
 lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml: 8bb218f43294aa0267418047f18038a6
 test/data/report-a-lost-or-stolen-passport-questions-and-responses.yml: cb7d64407b737eeb4924389f3bd335c6
 test/data/report-a-lost-or-stolen-passport-responses-and-expected-results.yml: 2ef8837f76907e72aadb198636a62078

--- a/test/data/simplified-expenses-checker-files.yml
+++ b/test/data/simplified-expenses-checker-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/simplified-expenses-checker.rb: 4c48ace98519ddb46b2dd8c58bb5337a
+lib/smart_answer_flows/simplified-expenses-checker.rb: 9f175300a38da904bee8bfacb26af032
 lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml: 92dcc0726b8a8fc148ab3aefeed6689e
 test/data/simplified-expenses-checker-questions-and-responses.yml: 6b1c358b3730897b6cbefa9477ada15b
 test/data/simplified-expenses-checker-responses-and-expected-results.yml: 983e72657f76697beafb2dcbe4018bee

--- a/test/data/state-pension-through-partner-files.yml
+++ b/test/data/state-pension-through-partner-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/state-pension-through-partner.rb: 91f52777732a5150028cb5006e54be12
+lib/smart_answer_flows/state-pension-through-partner.rb: 56b1c10c0fa72ec69689a3311ef2a814
 lib/smart_answer_flows/locales/en/state-pension-through-partner.yml: dfdbbb39e4d2582046a61a98e9c4ba1c
 test/data/state-pension-through-partner-questions-and-responses.yml: 34f2b5f7ac286bb3eea690564339051b
 test/data/state-pension-through-partner-responses-and-expected-results.yml: 7886f7591361df671b51ad857265cf6a

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/state-pension-topup.rb: 7d2c521d1096afeecaf8873f7f7acc27
+lib/smart_answer_flows/state-pension-topup.rb: f590dcbd74287b46a193c82e41045008
 lib/smart_answer_flows/locales/en/state-pension-topup.yml: f0cce2956d82d6709935014ddba367bb
 test/data/state-pension-topup-questions-and-responses.yml: d3997e715e206c38ea8a0783b07b2350
 test/data/state-pension-topup-responses-and-expected-results.yml: caa7a2bc7d84f16cf78583a97192e29b

--- a/test/data/student-finance-calculator-files.yml
+++ b/test/data/student-finance-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/student-finance-calculator.rb: 50373e5766e6469df7110fde0fbcfc35
+lib/smart_answer_flows/student-finance-calculator.rb: dcee811c9e0415909e23d3b15f6223d3
 lib/smart_answer_flows/locales/en/student-finance-calculator.yml: df63642e80cd83574b64c2034279cafd
 test/data/student-finance-calculator-questions-and-responses.yml: 7f7a6293dd5c37756c89ea6b075ffd45
 test/data/student-finance-calculator-responses-and-expected-results.yml: f4588ab6828397faa8f1fc4dce005398

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/student-finance-forms.rb: c8d2a9f40a8052633b021da6cd075c12
+lib/smart_answer_flows/student-finance-forms.rb: ba440a386aa4ebdf717e5a67f95869f2
 lib/smart_answer_flows/locales/en/student-finance-forms.yml: c171e62957dbe94cca7f6bb4aceb3b91
 test/data/student-finance-forms-questions-and-responses.yml: ec2ad38a9df75dd2606b9f979afd5066
 test/data/student-finance-forms-responses-and-expected-results.yml: fb765941838abb1e05b2d874049c7db1

--- a/test/data/towing-rules-files.yml
+++ b/test/data/towing-rules-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/towing-rules.rb: 4fcc7ee211ff791f0101dc4aa81f4a8a
+lib/smart_answer_flows/towing-rules.rb: 960a76bbcd812f8c20deecbc7779e1e1
 lib/smart_answer_flows/locales/en/towing-rules.yml: 5d8f677a11eeffe99c2a7fe3b2e54f9c
 test/data/towing-rules-questions-and-responses.yml: 09c8f43d5353fa6248658a27982ea5a2
 test/data/towing-rules-responses-and-expected-results.yml: ab907e6d438f7f2f6fc76bb1b219e6d7

--- a/test/data/uk-benefits-abroad-files.yml
+++ b/test/data/uk-benefits-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/uk-benefits-abroad.rb: 6712aa83839cfa1d94b69dbb03d78506
+lib/smart_answer_flows/uk-benefits-abroad.rb: 86c9d302a080b228a042abe87b059cbd
 lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml: 440f9eeaf47a6ea75ae1c0cc578078ed
 test/data/uk-benefits-abroad-questions-and-responses.yml: 17973c7c16f38d7988ff1a5b76d3261a
 test/data/uk-benefits-abroad-responses-and-expected-results.yml: 37bfb8e7982e15f0f907881bf1130ce3

--- a/test/data/vat-payment-deadlines-files.yml
+++ b/test/data/vat-payment-deadlines-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/vat-payment-deadlines.rb: 7764d8e7fd71a171157e8538cf5e360d
+lib/smart_answer_flows/vat-payment-deadlines.rb: 7e60429631663fcf48d13ec48aeb7bb4
 lib/smart_answer_flows/locales/en/vat-payment-deadlines.yml: d961b540b085e5d42ad9b4d624d58be4
 test/data/vat-payment-deadlines-questions-and-responses.yml: a9c89cff2686881257fe52b750032268
 test/data/vat-payment-deadlines-responses-and-expected-results.yml: 88f5a54e78f8b5006265a8005cdd15fe

--- a/test/fixtures/flow-sample.rb
+++ b/test/fixtures/flow-sample.rb
@@ -3,6 +3,7 @@ module SmartAnswer
     def define
       name 'flow-sample'
       satisfies_need 4242
+      content_id "f26e566e-2557-4921-b944-9373c32255f1"
 
       multiple_choice :hotter_or_colder? do
         option hotter: :hot

--- a/test/fixtures/smartdown_flows/animal-example-simple/animal-example-simple.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/animal-example-simple.txt
@@ -2,6 +2,7 @@
 meta_description: Animals eh?
 satisfies_need: 100982
 status: draft
+content_id: 5bb6964b-3147-4423-aab3-b87e1cb8b838
 ---
 
 # A simple example of smartdown

--- a/test/unit/flow_registration_presenter_test.rb
+++ b/test/unit/flow_registration_presenter_test.rb
@@ -29,6 +29,12 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
     end
   end
 
+  context "content_id" do
+    should "use the flow content_id" do
+      assert_equal "f26e566e-2557-4921-b944-9373c32255f1", @presenter.content_id
+    end
+  end
+
   context "title" do
     should "should use the title translation" do
       assert_equal "FLOW_TITLE", @presenter.title

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -11,6 +11,14 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal "sweet-or-savoury", s.name
   end
 
+  test "Can set the content_id" do
+    s = SmartAnswer::Flow.new do
+      content_id "587920ff-b854-4adb-9334-451b45652467"
+    end
+
+    assert_equal "587920ff-b854-4adb-9334-451b45652467", s.content_id
+  end
+
   test "Can build outcome nodes" do
     s = SmartAnswer::Flow.new do
       outcome :you_dont_have_a_sweet_tooth

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -12,6 +12,27 @@ class PanopticonRegistererTest < ActiveSupport::TestCase
     assert_requested(request, times: 2)
   end
 
+  def test_sending_correct_data_to_panopticon
+    stub_request(:put, "http://panopticon.dev.gov.uk/artefacts/a-smart-answer.json").
+      with(body: {
+        slug: "a-smart-answer",
+        owning_app: "smartanswers",
+        kind: "smart-answer",
+        name: "The Smart Answer.",
+        description: nil,
+        state: nil,
+    })
+
+    registerable = OpenStruct.new(
+      slug: 'a-smart-answer',
+      title: 'The Smart Answer.',
+    )
+
+    silence_logging do
+      PanopticonRegisterer.new([registerable]).register
+    end
+  end
+
 private
 
   # The registerer is quite noisy.

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -3,9 +3,10 @@ require 'test_helper'
 class PanopticonRegistererTest < ActiveSupport::TestCase
   def test_sending_item_to_panopticon
     request = stub_request(:put, %r[http://panopticon.dev.gov.uk/])
+    registerables = [OpenStruct.new, OpenStruct.new]
 
-    PanopticonRegisterer.new.register
+    PanopticonRegisterer.new(registerables).register
 
-    assert_requested(request, times: 42)
+    assert_requested(request, times: 2)
   end
 end

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -13,16 +13,7 @@ class PanopticonRegistererTest < ActiveSupport::TestCase
   end
 
   def test_sending_correct_data_to_panopticon
-    stub_request(:put, "http://panopticon.dev.gov.uk/artefacts/a-smart-answer.json").
-      with(body: {
-        slug: "a-smart-answer",
-        content_id: 'be9adf07-ce73-468e-be81-31716b4492f2',
-        owning_app: "smartanswers",
-        kind: "smart-answer",
-        name: "The Smart Answer.",
-        description: nil,
-        state: nil,
-    })
+    stub_request(:put, "http://panopticon.dev.gov.uk/artefacts/a-smart-answer.json")
 
     registerable = OpenStruct.new(
       slug: 'a-smart-answer',
@@ -33,6 +24,20 @@ class PanopticonRegistererTest < ActiveSupport::TestCase
     silence_logging do
       PanopticonRegisterer.new([registerable]).register
     end
+
+    assert_requested(
+      :put,
+      "http://panopticon.dev.gov.uk/artefacts/a-smart-answer.json",
+      body: {
+        slug: "a-smart-answer",
+        content_id: 'be9adf07-ce73-468e-be81-31716b4492f2',
+        owning_app: "smartanswers",
+        kind: "smart-answer",
+        name: "The Smart Answer.",
+        description: nil,
+        state: nil,
+      }
+    )
   end
 
 private

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -5,8 +5,21 @@ class PanopticonRegistererTest < ActiveSupport::TestCase
     request = stub_request(:put, %r[http://panopticon.dev.gov.uk/])
     registerables = [OpenStruct.new, OpenStruct.new]
 
-    PanopticonRegisterer.new(registerables).register
+    silence_logging do
+      PanopticonRegisterer.new(registerables).register
+    end
 
     assert_requested(request, times: 2)
+  end
+
+private
+
+  # The registerer is quite noisy.
+  def silence_logging
+    silence_stream $stdout do
+      silence_stream $stderr do
+        yield
+      end
+    end
   end
 end

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -16,6 +16,7 @@ class PanopticonRegistererTest < ActiveSupport::TestCase
     stub_request(:put, "http://panopticon.dev.gov.uk/artefacts/a-smart-answer.json").
       with(body: {
         slug: "a-smart-answer",
+        content_id: 'be9adf07-ce73-468e-be81-31716b4492f2',
         owning_app: "smartanswers",
         kind: "smart-answer",
         name: "The Smart Answer.",
@@ -26,6 +27,7 @@ class PanopticonRegistererTest < ActiveSupport::TestCase
     registerable = OpenStruct.new(
       slug: 'a-smart-answer',
       title: 'The Smart Answer.',
+      content_id: 'be9adf07-ce73-468e-be81-31716b4492f2',
     )
 
     silence_logging do

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class PanopticonRegistererTest < ActiveSupport::TestCase
+  def test_sending_item_to_panopticon
+    request = stub_request(:put, %r[http://panopticon.dev.gov.uk/])
+
+    PanopticonRegisterer.new.register
+
+    assert_requested(request, times: 42)
+  end
+end

--- a/test/unit/services/registerable_smart_answers_test.rb
+++ b/test/unit/services/registerable_smart_answers_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class RegisterableSmartAnswersTest < ActiveSupport::TestCase
+  def test_unique_smart_answers
+    registerables = RegisterableSmartAnswers.new.unique_registerables
+
+    assert registerables.size > 30
+  end
+end

--- a/test/unit/services/registerable_smart_answers_test.rb
+++ b/test/unit/services/registerable_smart_answers_test.rb
@@ -1,9 +1,30 @@
 require 'test_helper'
 
 class RegisterableSmartAnswersTest < ActiveSupport::TestCase
-  def test_unique_smart_answers
+  def test_merging_smart_answers_and_smartdown
+    SmartAnswer::FlowRegistry.any_instance.stubs(flows: [stub('a flow', name: 'A SmartAnswer')])
+    SmartdownAdapter::Registry.instance.stubs(flows: [stub('a flow', name: 'A SmartDown')])
+
     registerables = RegisterableSmartAnswers.new.unique_registerables
 
-    assert registerables.size > 30
+    assert_equal 2, registerables.size
+  end
+
+  def test_decoration_of_smartanswers
+    SmartAnswer::FlowRegistry.any_instance.stubs(flows: [stub('a flow', name: 'A SmartAnswer')])
+    SmartdownAdapter::Registry.instance.stubs(flows: [])
+
+    registerables = RegisterableSmartAnswers.new.unique_registerables
+
+    assert registerables.first.is_a?(FlowRegistrationPresenter)
+  end
+
+  def test_decoration_of_smartdowns
+    SmartAnswer::FlowRegistry.any_instance.stubs(flows: [])
+    SmartdownAdapter::Registry.instance.stubs(flows: [stub('a flow', name: 'A SmartDown')])
+
+    registerables = RegisterableSmartAnswers.new.unique_registerables
+
+    assert registerables.first.is_a?(SmartdownAdapter::FlowRegistrationPresenter)
   end
 end

--- a/test/unit/smartdown_adapter/flow_registration_presenter_test.rb
+++ b/test/unit/smartdown_adapter/flow_registration_presenter_test.rb
@@ -4,11 +4,19 @@ module SmartdownAdapter
   class FlowRegistrationPresenterTest < ActiveSupport::TestCase
     context "content_id" do
       should "use the flow content_id" do
-        flow = SmartdownAdapter::Registry.instance.find('pay-leave-for-parents')
+        SmartdownAdapter::Registry.reset_instance
+        flow_registry_options = {
+          show_drafts: true,
+          preload_flows: true,
+          smartdown_load_path: Rails.root.join('test', 'fixtures', 'smartdown_flows')
+        }
+        flow = SmartdownAdapter::Registry.instance(flow_registry_options).find("animal-example-simple")
 
         presenter = SmartdownAdapter::FlowRegistrationPresenter.new(flow)
 
-        assert_equal "1f6b4ecc-ce2c-488a-b9c7-b78b3bba5598", presenter.content_id
+        assert_equal "5bb6964b-3147-4423-aab3-b87e1cb8b838", presenter.content_id
+
+        SmartdownAdapter::Registry.reset_instance
       end
     end
   end

--- a/test/unit/smartdown_adapter/flow_registration_presenter_test.rb
+++ b/test/unit/smartdown_adapter/flow_registration_presenter_test.rb
@@ -1,0 +1,15 @@
+require_relative "../../test_helper"
+
+module SmartdownAdapter
+  class FlowRegistrationPresenterTest < ActiveSupport::TestCase
+    context "content_id" do
+      should "use the flow content_id" do
+        flow = SmartdownAdapter::Registry.instance.find('pay-leave-for-parents')
+
+        presenter = SmartdownAdapter::FlowRegistrationPresenter.new(flow)
+
+        assert_equal "1f6b4ecc-ce2c-488a-b9c7-b78b3bba5598", presenter.content_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are building a new tagging infrastructure. The API for tagging will work by content-id.  Therefore, every piece of content needs to have a content-id in the content store, in order for it to be able to be tagged.

This PR ensures that we all smart-answers have a `content_id` and that we are sending it to panopticon (when running `rake panopticon:register`). This will aid us in the transition.

A PR to send smart-answers to content-store will be next.

Best reviewed per-commit.

Trello: https://trello.com/c/K87fWrYx (part of https://trello.com/c/ReoZKx9S).

Previous PR on smartdown: https://github.com/alphagov/smartdown/pull/147

