### PR TITLE
Don't set `GdsApi::Base.logger`

### DIFF
--- a/app/services/panopticon_registerer.rb
+++ b/app/services/panopticon_registerer.rb
@@ -7,8 +7,8 @@ class PanopticonRegisterer
 
   def register
     require 'gds_api/panopticon'
-    logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
-    logger.info "Registering with panopticon..."
+
+    puts "Registering with panopticon..."
     registerer = GdsApi::Panopticon::Registerer.new(owning_app: "smartanswers", kind: "smart-answer")
 
     puts "Looking up flows, with options: #{FLOW_REGISTRY_OPTIONS}"

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -45,9 +45,7 @@ private
   # The registerer is quite noisy.
   def silence_logging
     silence_stream $stdout do
-      silence_stream $stderr do
-        yield
-      end
+      yield
     end
   end
 end


### PR DESCRIPTION
We're currently setting `GdsApi::Base.logger` when sending something to panopticon. There's no real reason to use this. This code with extra logging was presumably copied from another repo - we don't need it here.

We still need the `puts` statements to log the output of the panopticon registration.

Removing the logger prevents noisy output during the tests and cleans up some special casing in the tests.