### PR TITLE
Improve naming of `unique_registerables` concept

### DIFF
--- a/app/services/panopticon_registerer.rb
+++ b/app/services/panopticon_registerer.rb
@@ -1,8 +1,8 @@
 class PanopticonRegisterer
-  attr_reader :unique_registerables
+  attr_reader :flow_presenters
 
-  def initialize(unique_registerables)
-    @unique_registerables = unique_registerables
+  def initialize(flow_presenters)
+    @flow_presenters = flow_presenters
   end
 
   def register
@@ -13,7 +13,7 @@ class PanopticonRegisterer
 
     puts "Looking up flows, with options: #{FLOW_REGISTRY_OPTIONS}"
 
-    unique_registerables.each { |registerable|
+    flow_presenters.each { |registerable|
       puts "Registering flow: #{registerable.slug} => #{registerable.title}"
       registerer.register(registerable)
     }

--- a/app/services/registerable_smart_answers.rb
+++ b/app/services/registerable_smart_answers.rb
@@ -1,5 +1,5 @@
 class RegisterableSmartAnswers
-  def unique_registerables
+  def flow_presenters
     smart_answer_registrables + smartdown_registrables
   end
 

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -3,7 +3,7 @@ require 'ostruct'
 namespace :panopticon do
   desc "Register application metadata with panopticon"
   task register: :environment do
-    registerables = RegisterableSmartAnswers.new.unique_registerables
-    PanopticonRegisterer.new(registerables).register
+    flow_presenters = RegisterableSmartAnswers.new.flow_presenters
+    PanopticonRegisterer.new(flow_presenters).register
   end
 end

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 class PanopticonRegistererTest < ActiveSupport::TestCase
   def test_sending_item_to_panopticon
     request = stub_request(:put, %r[http://panopticon.dev.gov.uk/])
-    registerables = [OpenStruct.new, OpenStruct.new]
+    flow_presenters = [OpenStruct.new, OpenStruct.new]
 
     silence_logging do
-      PanopticonRegisterer.new(registerables).register
+      PanopticonRegisterer.new(flow_presenters).register
     end
 
     assert_requested(request, times: 2)

--- a/test/unit/services/registerable_smart_answers_test.rb
+++ b/test/unit/services/registerable_smart_answers_test.rb
@@ -1,30 +1,30 @@
 require 'test_helper'
 
 class RegisterableSmartAnswersTest < ActiveSupport::TestCase
-  def test_merging_smart_answers_and_smartdown
+  def test_merging_flow_presenters_and_smartdown
     SmartAnswer::FlowRegistry.any_instance.stubs(flows: [stub('a flow', name: 'A SmartAnswer')])
     SmartdownAdapter::Registry.instance.stubs(flows: [stub('a flow', name: 'A SmartDown')])
 
-    registerables = RegisterableSmartAnswers.new.unique_registerables
+    flow_presenters = RegisterableSmartAnswers.new.flow_presenters
 
-    assert_equal 2, registerables.size
+    assert_equal 2, flow_presenters.size
   end
 
   def test_decoration_of_smartanswers
     SmartAnswer::FlowRegistry.any_instance.stubs(flows: [stub('a flow', name: 'A SmartAnswer')])
     SmartdownAdapter::Registry.instance.stubs(flows: [])
 
-    registerables = RegisterableSmartAnswers.new.unique_registerables
+    flow_presenters = RegisterableSmartAnswers.new.flow_presenters
 
-    assert registerables.first.is_a?(FlowRegistrationPresenter)
+    assert flow_presenters.first.is_a?(FlowRegistrationPresenter)
   end
 
   def test_decoration_of_smartdowns
     SmartAnswer::FlowRegistry.any_instance.stubs(flows: [])
     SmartdownAdapter::Registry.instance.stubs(flows: [stub('a flow', name: 'A SmartDown')])
 
-    registerables = RegisterableSmartAnswers.new.unique_registerables
+    flow_presenters = RegisterableSmartAnswers.new.flow_presenters
 
-    assert registerables.first.is_a?(SmartdownAdapter::FlowRegistrationPresenter)
+    assert flow_presenters.first.is_a?(SmartdownAdapter::FlowRegistrationPresenter)
   end
 end


### PR DESCRIPTION
`flow_presenters` is a much more descriptive name than `unique_registerables` or `registerables`.

Refactor in preparation of https://trello.com/c/K87fWrYx