### PR TITLE
Send smart answers to the content-store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ else
   gem 'gds-api-adapters', '~> 24.4.0'
 end
 
+gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
+
 gem 'htmlentities', '~> 4'
 
 gem 'extlib', '0.9.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
+    govuk-content-schema-test-helpers (1.3.0)
+      json-schema (~> 2.5.1)
     govuk-lint (0.3.0)
       rubocop (~> 0.32)
     govuk_frontend_toolkit (3.1.0)
@@ -115,6 +117,8 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
+    json-schema (2.5.1)
+      addressable (~> 2.3.7)
     jwt (1.4.1)
     kgio (2.9.3)
     kramdown (1.4.2)
@@ -301,6 +305,7 @@ DEPENDENCIES
   gds-api-adapters (~> 24.4.0)
   google-api-client
   govspeak (~> 3.3.0)
+  govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
   govuk_frontend_toolkit (= 3.1.0)
   htmlentities (~> 4)

--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -1,0 +1,27 @@
+class FlowContentItem
+  attr_reader :flow_presenter
+
+  def initialize(flow_presenter)
+    @flow_presenter = flow_presenter
+  end
+
+  def payload
+    {
+      title: flow_presenter.title,
+      content_id: flow_presenter.content_id,
+      format: 'placeholder_smart_answer',
+      publishing_app: 'smartanswers',
+      rendering_app: 'smartanswers',
+      update_type: 'minor',
+      locale: 'en',
+      public_updated_at: Time.now.iso8601,
+      routes: [
+        { type: 'exact', path: base_path }
+      ]
+    }
+  end
+
+  def base_path
+    '/' + flow_presenter.slug
+  end
+end

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -1,0 +1,8 @@
+class ContentItemPublisher
+  def publish(flow_presenters)
+    flow_presenters.each do |smart_answer|
+      content_item = FlowContentItem.new(smart_answer)
+      Services.publishing_api.put_content_item(content_item.base_path, content_item.payload)
+    end
+  end
+end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -8,6 +8,16 @@ set -e
 git merge --no-commit origin/master || git merge --abort
 
 git clean -fdx
+
+# Clone govuk-content-schemas depedency for contract tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+(
+  cd tmp/govuk-content-schemas
+  git checkout ${SCHEMA_GIT_COMMIT:-"master"}
+)
+export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
+
 bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment
 export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_ASSET_HOST=http://static.dev.gov.uk

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,7 @@
+require 'gds_api/publishing_api'
+
+module Services
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,0 +1,7 @@
+namespace :publishing_api do
+  desc "Publish smart answers to the content-store"
+  task :publish => [:environment] do
+    flow_presenters = RegisterableSmartAnswers.new.flow_presenters
+    ContentItemPublisher.new.publish(flow_presenters)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,3 +35,10 @@ require_relative 'support/fixture_methods'
 class ActiveSupport::TestCase
   include FixtureMethods
 end
+
+require 'govuk-content-schema-test-helpers/test_unit'
+
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = 'publisher'
+  config.project_root = Rails.root
+end

--- a/test/unit/flow_content_item_test.rb
+++ b/test/unit/flow_content_item_test.rb
@@ -1,0 +1,25 @@
+require_relative '../test_helper'
+
+module SmartAnswer
+  class FlowContentItemTest < ActiveSupport::TestCase
+    include GovukContentSchemaTestHelpers::TestUnit
+
+    test '#payload returns a valid content-item' do
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'a-flow-name', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685'))
+      content_item = FlowContentItem.new(presenter)
+
+      payload = content_item.payload
+
+      assert_valid_against_schema(payload, 'placeholder')
+    end
+
+    test '#base_path is the name of the flow' do
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'a-flow-name'))
+      content_item = FlowContentItem.new(presenter)
+
+      base_path = content_item.base_path
+
+      assert_equal "/a-flow-name", base_path
+    end
+  end
+end

--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class ContentItemPublisherTest < ActiveSupport::TestCase
+  def test_sending_item_to_content_store
+    request = stub_request(:put, "http://publishing-api.dev.gov.uk/content/a-flow-name")
+    presenter = FlowRegistrationPresenter.new(stub('flow', name: 'a-flow-name', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685'))
+
+    ContentItemPublisher.new.publish([presenter])
+
+    assert_requested request
+  end
+end


### PR DESCRIPTION
Team Finding Things is on a mission to tag all content on GOV.UK. Part of that mission is a new tagging architecture, to allow for much more flexible tagging. The core idea is to move the "source of truth" for tagging into a central place, and allow tags to be applied to all formats in a uniform way (from the [wiki](https://gov-uk.atlassian.net/wiki/display/FS/Tagging+Architecture)). For that, we need all content in the content-store.

This PR adds the rake task `rake publishing_api:publish` that will be run after every deploy, similar to `panopticon:register`. The rake task will send the smart answers to the content-store via the publishing-api.

Trello: https://trello.com/b/Kg3JL5Cd/finding-things
Previously: https://github.com/alphagov/smart-answers/pull/1956 https://github.com/alphagov/smart-answers/pull/1963

