### PR TITLE
over55_result.govspeak.erb

### DIFF
--- a/lib/smart_answer_flows/calculate-state-pension/over55_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-state-pension/over55_result.govspeak.erb
@@ -1,14 +1,11 @@
 <% content_for :title do %>
-  You’ll reach State Pension age on <%= formatted_state_pension_date %>.
+  Your State Pension estimate
 
 <% end %>
 
 <% content_for :body do %>
-  Your State Pension age is <%= state_pension_age %>.
-
-  ^The State Pension will change on 6 April 2016. You will claim the [new State Pension](/new-state-pension) when you reach your State Pension age.^
-
-  You’ll have to contact the Future Pension Centre to get an estimate of your pension calculated under the new State Pension rules.
+ 
+  You’ll have to contact the Future Pension Centre to get an estimate of your pension. This is because the State Pension will change on 6 April 2016.
 
   ##Contact the Future Pension Centre
 
@@ -32,4 +29,13 @@
   Textphone: +44 (0)191 218 2051 <br />
   Monday to Friday, 8am to 6pm <br />
   $C
+  
+  ##Your State Pension age
+  
+  You’ll reach State Pension age on <%= formatted_state_pension_date %>.
+  
+  Your State Pension age is <%= state_pension_age %>. You can claim the [new State Pension](/new-state-pension) when you reach your State Pension age.
+  
+
+  
 <% end %>


### PR DESCRIPTION
Based on Feedex, people are confused why they aren't getting an estimate.

This change is to emphasise that they can't get it because the state pension is changing.

Moved state pension age and date to the bottom of the page with new heading