### PR TITLE
Update calculate-state-pension over 55 result

### DIFF
--- a/lib/smart_answer_flows/calculate-state-pension/over55_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-state-pension/over55_result.govspeak.erb
@@ -1,14 +1,11 @@
 <% content_for :title do %>
-  You’ll reach State Pension age on <%= formatted_state_pension_date %>.
+  Your State Pension estimate
 
 <% end %>
 
 <% content_for :body do %>
-  Your State Pension age is <%= state_pension_age %>.
-
-  ^The State Pension will change on 6 April 2016. You will claim the [new State Pension](/new-state-pension) when you reach your State Pension age.^
-
-  You’ll have to contact the Future Pension Centre to get an estimate of your pension calculated under the new State Pension rules.
+ 
+  You’ll have to contact the Future Pension Centre to get an estimate of your pension. This is because the State Pension will change on 6 April 2016.
 
   ##Contact the Future Pension Centre
 
@@ -32,4 +29,13 @@
   Textphone: +44 (0)191 218 2051 <br />
   Monday to Friday, 8am to 6pm <br />
   $C
+  
+  ##Your State Pension age
+  
+  You’ll reach State Pension age on <%= formatted_state_pension_date %>.
+  
+  Your State Pension age is <%= state_pension_age %>. You can claim the [new State Pension](/new-state-pension) when you reach your State Pension age.
+  
+
+  
 <% end %>

--- a/test/artefacts/calculate-state-pension/amount/female/1954-01-01.txt
+++ b/test/artefacts/calculate-state-pension/amount/female/1954-01-01.txt
@@ -1,10 +1,7 @@
-You’ll reach State Pension age on  6 March 2019.
+Your State Pension estimate
 
-Your State Pension age is 65 years, 2 months, 5 days.
 
-^The State Pension will change on 6 April 2016. You will claim the [new State Pension](/new-state-pension) when you reach your State Pension age.^
-
-You’ll have to contact the Future Pension Centre to get an estimate of your pension calculated under the new State Pension rules.
+You’ll have to contact the Future Pension Centre to get an estimate of your pension. This is because the State Pension will change on 6 April 2016.
 
 ##Contact the Future Pension Centre
 
@@ -28,4 +25,10 @@ Telephone: +44 (0)191 218 3600 <br />
 Textphone: +44 (0)191 218 2051 <br />
 Monday to Friday, 8am to 6pm <br />
 $C
+
+##Your State Pension age
+
+You’ll reach State Pension age on  6 March 2019.
+
+Your State Pension age is 65 years, 2 months, 5 days. You can claim the [new State Pension](/new-state-pension) when you reach your State Pension age.
 

--- a/test/artefacts/calculate-state-pension/amount/male/1951-06-01.txt
+++ b/test/artefacts/calculate-state-pension/amount/male/1951-06-01.txt
@@ -1,10 +1,7 @@
-You’ll reach State Pension age on  1 June 2016.
+Your State Pension estimate
 
-Your State Pension age is 65 years.
 
-^The State Pension will change on 6 April 2016. You will claim the [new State Pension](/new-state-pension) when you reach your State Pension age.^
-
-You’ll have to contact the Future Pension Centre to get an estimate of your pension calculated under the new State Pension rules.
+You’ll have to contact the Future Pension Centre to get an estimate of your pension. This is because the State Pension will change on 6 April 2016.
 
 ##Contact the Future Pension Centre
 
@@ -28,4 +25,10 @@ Telephone: +44 (0)191 218 3600 <br />
 Textphone: +44 (0)191 218 2051 <br />
 Monday to Friday, 8am to 6pm <br />
 $C
+
+##Your State Pension age
+
+You’ll reach State Pension age on  1 June 2016.
+
+Your State Pension age is 65 years. You can claim the [new State Pension](/new-state-pension) when you reach your State Pension age.
 

--- a/test/artefacts/calculate-state-pension/amount/male/1952-02-29.txt
+++ b/test/artefacts/calculate-state-pension/amount/male/1952-02-29.txt
@@ -1,10 +1,7 @@
-You’ll reach State Pension age on  1 March 2017.
+Your State Pension estimate
 
-Your State Pension age is 65 years.
 
-^The State Pension will change on 6 April 2016. You will claim the [new State Pension](/new-state-pension) when you reach your State Pension age.^
-
-You’ll have to contact the Future Pension Centre to get an estimate of your pension calculated under the new State Pension rules.
+You’ll have to contact the Future Pension Centre to get an estimate of your pension. This is because the State Pension will change on 6 April 2016.
 
 ##Contact the Future Pension Centre
 
@@ -28,4 +25,10 @@ Telephone: +44 (0)191 218 3600 <br />
 Textphone: +44 (0)191 218 2051 <br />
 Monday to Friday, 8am to 6pm <br />
 $C
+
+##Your State Pension age
+
+You’ll reach State Pension age on  1 March 2017.
+
+Your State Pension age is 65 years. You can claim the [new State Pension](/new-state-pension) when you reach your State Pension age.
 

--- a/test/artefacts/calculate-state-pension/amount/male/1954-01-01.txt
+++ b/test/artefacts/calculate-state-pension/amount/male/1954-01-01.txt
@@ -1,10 +1,7 @@
-You’ll reach State Pension age on  6 March 2019.
+Your State Pension estimate
 
-Your State Pension age is 65 years, 2 months, 5 days.
 
-^The State Pension will change on 6 April 2016. You will claim the [new State Pension](/new-state-pension) when you reach your State Pension age.^
-
-You’ll have to contact the Future Pension Centre to get an estimate of your pension calculated under the new State Pension rules.
+You’ll have to contact the Future Pension Centre to get an estimate of your pension. This is because the State Pension will change on 6 April 2016.
 
 ##Contact the Future Pension Centre
 
@@ -28,4 +25,10 @@ Telephone: +44 (0)191 218 3600 <br />
 Textphone: +44 (0)191 218 2051 <br />
 Monday to Friday, 8am to 6pm <br />
 $C
+
+##Your State Pension age
+
+You’ll reach State Pension age on  6 March 2019.
+
+Your State Pension age is 65 years, 2 months, 5 days. You can claim the [new State Pension](/new-state-pension) when you reach your State Pension age.
 

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/calculate-state-pension/amount_result.govspeak.erb: b4618
 lib/smart_answer_flows/calculate-state-pension/bus_pass_age_result.govspeak.erb: a7253ec4bc72d5ffec14e9b9b7ba2238
 lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb: bd56129956ea4963698db778f12267be
 lib/smart_answer_flows/calculate-state-pension/near_state_pension_age.govspeak.erb: 2cf95f1256106b0c55f9af59c8e9cce1
-lib/smart_answer_flows/calculate-state-pension/over55_result.govspeak.erb: a30aa788e427c1c77840642b9cd6a816
+lib/smart_answer_flows/calculate-state-pension/over55_result.govspeak.erb: 310ea5f0936406d0dba0f5c73dc46f30
 lib/smart_answer_flows/calculate-state-pension/reached_state_pension_age.govspeak.erb: 5aa766ef2e882eccd23bcc8a281dfb4e
 lib/smart_answer_flows/calculate-state-pension/too_young.govspeak.erb: fbdfeb69f91ca8be0fb00c1e6f897f2b
 lib/smart_answer/calculators/state_pension_amount_calculator.rb: dc34ccef222287ea14e4c9c7af164a32


### PR DESCRIPTION
This closes #1973.

Based on Feedex, people are confused why they aren't getting an estimate.

This change is to emphasise that they can't get it because the state pension is changing.

Moved state pension age and date to the bottom of the page with new heading.

## Example URLs that will change after deploying this branch:

* https://www.gov.uk/calculate-state-pension/y/amount/female/1954-01-01
* https://www.gov.uk/calculate-state-pension/y/amount/male/1951-06-01
