### PR TITLE
Implement QuestionPresenter#post_body

### DIFF
--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -52,7 +52,7 @@ class QuestionPresenter < NodePresenter
   end
 
   def post_body
-    nil
+    translate_and_render('post_body', html: true)
   end
 
   def options

--- a/test/fixtures/node_presenter_test/example.yml
+++ b/test/fixtures/node_presenter_test/example.yml
@@ -23,6 +23,9 @@ en-GB:
       question_with_default_error_message:
         error_message: default error message
       question_with_no_custom_or_default_error_message:
+      question_with_post_body:
+        post_body: post body for question
+      question_with_no_post_body:
       outcome_with_interpolated_phrase_list:
         title: "All done"
         body: |

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -138,6 +138,20 @@ module SmartAnswer
       assert_equal "The body copy", presenter.body(html: false)
     end
 
+    test "Node post_body looked up from translation file and parsed as govspeak" do
+      question = Question::Date.new(nil, :question_with_post_body)
+      presenter = QuestionPresenter.new("flow.test", question)
+
+      assert_equal "<p>post body for question</p>\n", presenter.post_body
+    end
+
+    test "Node post_body returns nil when key doesn't exist in translation file" do
+      question = Question::Date.new(nil, :question_with_no_post_body)
+      presenter = QuestionPresenter.new("flow.test", question)
+
+      assert_equal nil, presenter.post_body
+    end
+
     test 'delegates #to_response to node' do
       question = stub('question')
       question.stubs(:to_response).returns('response')


### PR DESCRIPTION
This is in preparation for converting Smartdown Smart Answers to Ruby.

Smartdown includes the ability to display a `post_body` (rendered as Govspeak)
after the form on a question page. This is displayed by the
"_current_question.html.erb" partial.

This commit adds support for `post_body` to Ruby Smart Answers.

I'm not expecting any regression test artefacts to change because none of the Ruby Smart Answers have a `post_body` in the YAML files.
