### PR TITLE
Avoid potential bug in StatutorySickPayCalculator

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -139,7 +139,7 @@ module SmartAnswer::Calculators
 
     def init_payable_days
       # copy not to modify the instance variable we need to keep
-      payable_days_temp = @normal_workdays_missed
+      payable_days_temp = @normal_workdays_missed.dup
       ## 1. remove up to 3 first dates from the array if there are waiting days in this period
       payable_days_temp.shift(@waiting_days)
       ## 2. return only the first days_that_can_be_paid_for_this_period

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -12,6 +12,6 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/must_be_sick_for_4_days.govs
 lib/smart_answer_flows/calculate-statutory-sick-pay/not_earned_enough.govspeak.erb: 1e5cd1c6d99b6bd3145578416d62e7c5
 lib/smart_answer_flows/calculate-statutory-sick-pay/not_entitled_3_days_not_paid.govspeak.erb: 98dc338280df70b2b6032a7a9dcba428
 lib/smart_answer_flows/calculate-statutory-sick-pay/not_regular_schedule.govspeak.erb: 98b6f0d902fabae8fda39c1859cd2a46
-lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 21f6f90dac027eacd80a58ba29e04cd1
+lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 29e8a5cabc4f5271330b6595faabcdba
 lib/smart_answer/calculators/rates_query.rb: c9568eac2742cad26f93458ed2276876
 lib/data/rates/statutory_sick_pay.yml: de2d34118e3016d1137c394745d33280


### PR DESCRIPTION
This line in the `#init_payable_days` method doesn't accurately reflect the
intent expressed in the comment in the line above it, presumably due to a
misunderstanding about how references to objects work in Ruby.

`@normal_workdays_missed` is an `Array` of `Date` objects. It looks as if the
intention of assigning the instance variable to a local variable was to avoid
the calls to `Array#shift` mutating the underlying `Array`. However, the
local variable still referenced the same `Array` and the underlying `Array`
**was** in fact mutated.

This was not actually causing a problem, because the only other use of the
the instance variable was in the assignment of `@normal_workdays` in the
calculator constructor. Since this happens **before** the `Array` is mutated,
no harm is done. However, it seems sensible to fix this in case someone makes
use of the instance variable somewhere else.

I have fixed the potential problem by using `Object#dup` to make a copy of the
underlying `Array`.

There are lots of other improvements that could be made to this code, but we
have other priorities at the moment.