### PR TITLE
Allow Smartdown flows to be rendered as text

### DIFF
--- a/lib/smartdown_adapter/node_presenter.rb
+++ b/lib/smartdown_adapter/node_presenter.rb
@@ -12,8 +12,8 @@ module SmartdownAdapter
       render(@smartdown_node.body, html: html)
     end
 
-    def post_body
-      @smartdown_node.post_body && markdown_to_html(@smartdown_node.post_body)
+    def post_body(html: true)
+      render(@smartdown_node.post_body, html: html)
     end
 
     def next_steps(html: true)

--- a/lib/smartdown_adapter/presenter.rb
+++ b/lib/smartdown_adapter/presenter.rb
@@ -108,7 +108,7 @@ module SmartdownAdapter
     end
 
     def render_txt?
-      false
+      finished? || !started?
     end
 
     private

--- a/test/fixtures/smartdown_flows/smartdown-example/outcomes/outcome.txt
+++ b/test/fixtures/smartdown_flows/smartdown-example/outcomes/outcome.txt
@@ -1,0 +1,7 @@
+# Outcome title
+
+Outcome body
+
+[next_steps]
+Outcome next steps
+[end_next_steps]

--- a/test/fixtures/smartdown_flows/smartdown-example/questions/question.txt
+++ b/test/fixtures/smartdown_flows/smartdown-example/questions/question.txt
@@ -1,0 +1,13 @@
+# Question page title
+
+# Question title
+
+Question body
+
+[choice: question_1]
+* yes: Yes
+* no: No
+
+Question post body
+
+* otherwise => outcome

--- a/test/fixtures/smartdown_flows/smartdown-example/smartdown-example.txt
+++ b/test/fixtures/smartdown_flows/smartdown-example/smartdown-example.txt
@@ -1,0 +1,11 @@
+---
+meta_description: Smartdown example
+satisfies_need: 100999
+status: draft
+---
+
+# Landing page title
+
+Landing page body
+
+[start: question]

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -1,5 +1,6 @@
 require_relative '../test_helper'
 require_relative '../helpers/i18n_test_helper'
+require_relative '../helpers/test_fixtures_helper'
 require 'gds_api/test_helpers/content_api'
 
 class SmartAnswersControllerTest < ActionController::TestCase
@@ -523,5 +524,43 @@ class SmartAnswersControllerTest < ActionController::TestCase
     Rails.configuration.set_http_cache_control_expiry_time = true
     block.call
     Rails.configuration.set_http_cache_control_expiry_time = original_value
+  end
+end
+
+class SmartAnswersControllerForSmartdownFlowsTest < ActionController::TestCase
+  include TestFixturesHelper
+  include GdsApi::TestHelpers::ContentApi
+
+  tests SmartAnswersController
+
+  def setup
+    use_test_smartdown_flow_fixtures
+    stub_content_api_default_artefact
+  end
+
+  def teardown
+    stop_using_test_smartdown_flow_fixtures
+  end
+
+  context "format=txt" do
+    should "render outcome node as text" do
+      get :show, id: 'smartdown-example', started: 'y', responses: "yes", format: "txt"
+
+      assert_match /Outcome title/, response.body
+      assert_match /Outcome body/, response.body
+      assert_match /Outcome next steps/, response.body
+    end
+
+    should "render the landing page as text" do
+      get :show, id: 'smartdown-example', format: 'txt'
+
+      assert response.body.start_with?("Landing page title")
+    end
+
+    should "render not found for a question node" do
+      get :show, id: 'smartdown-example', started: 'y', format: "txt"
+
+      assert_response :missing
+    end
   end
 end


### PR DESCRIPTION
This allows us to render Smartdown landing pages and outcomes as text. This
mirrors the functionality of Smart Answers and allows us to generate regression
tests for Smartdown flows.

* Add the new SmartAnswersControllerForSmartdownFlowsTest test class and copied
  the three main tests from the "format=txt" context from the
  SmartAnswersControllerTest test.

* Add a new Smartdown test fixture named "smartdown-example". I started out by
  re-using one of the existing fixtures but found that the assertions in the
  "render outcome node as text" test weren't as descriptive as I wanted.

* Modify `SmartdownAdapter::NodePresenter#post_body` to accept the `html`
  parameter and mirror the behaviour of `#body` and `#next_steps`.

* Modify `SmartdownAdapter::Presenter#render_txt?` to mirror the behaviour of
  `SmartAnswerPresenter#render_txt?`.