### PR TITLE
Freeze time in am_i_getting_minimum_wage_test.rb

### DIFF
--- a/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
@@ -7,6 +7,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
+    Timecop.freeze(Date.parse('2015-01-01'))
     setup_for_testing_flow SmartAnswer::AmIGettingMinimumWageFlow
   end
 


### PR DESCRIPTION
Two tests in this file started failing today (Thurs 1 Oct 2015):

1. "when checking current pay answered 'apprentice over 19 on second year or
onwards' to 'are you an apprentice?' treat the user as a non apprentice' should
show current minimum wage rate"

2. "when checking current pay answered 'no' to 'are you an apprentice?' 25 year
old should make outcome calculations"

This is because the new rates defined in minimum_wage_data.yml come into effect
today.

Freezing the date to 1 Jan 2015 allows us to continue asserting against the pre
1 Oct 2015 rates. An alternative solution would've been to update the tests to
assert against the new rates.

Neither of these feel ideal but I think it's probably OK for now.