### PR TITLE
Add instructions for how to apply for State Pension Top-up

### DIFF
--- a/lib/smart_answer_flows/state-pension-topup/outcome_topup_calculations.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-topup/outcome_topup_calculations.govspeak.erb
@@ -16,5 +16,21 @@
 
   The contribution amount is an estimate.
 
-  To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+  ##Apply
+
+  You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+  - proof of your identity, eg your P60 or the last 4 digits of your bank account
+  - your National Insurance number (if you know it)
+
+  You can also apply over the phone.
+
+  $C
+  **State Pension top up**\\
+  Telephone: 0345 600 4270\\
+  Textphone: 0300 200 3519\\
+  Monday to Friday, 8am to 8pm\\
+  Saturday, 8am to 4pm\\
+  [Find out about call charges](/call-charges)
+  $C
 <% end %>

--- a/test/artefacts/state-pension-topup/1912-10-12/female/20.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/female/20.txt
@@ -11,5 +11,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1912-10-12/female/7.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/female/7.txt
@@ -11,5 +11,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1912-10-12/male/20.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/male/20.txt
@@ -11,5 +11,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1912-10-12/male/7.txt
+++ b/test/artefacts/state-pension-topup/1912-10-12/male/7.txt
@@ -11,5 +11,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1951-04-05/female/20.txt
+++ b/test/artefacts/state-pension-topup/1951-04-05/female/20.txt
@@ -12,5 +12,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1951-04-05/female/7.txt
+++ b/test/artefacts/state-pension-topup/1951-04-05/female/7.txt
@@ -12,5 +12,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1951-04-05/male/20.txt
+++ b/test/artefacts/state-pension-topup/1951-04-05/male/20.txt
@@ -11,5 +11,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1951-04-05/male/7.txt
+++ b/test/artefacts/state-pension-topup/1951-04-05/male/7.txt
@@ -11,5 +11,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1951-04-06/female/20.txt
+++ b/test/artefacts/state-pension-topup/1951-04-06/female/20.txt
@@ -11,5 +11,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1951-04-06/female/7.txt
+++ b/test/artefacts/state-pension-topup/1951-04-06/female/7.txt
@@ -11,5 +11,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1953-04-05/female/20.txt
+++ b/test/artefacts/state-pension-topup/1953-04-05/female/20.txt
@@ -12,5 +12,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/artefacts/state-pension-topup/1953-04-05/female/7.txt
+++ b/test/artefacts/state-pension-topup/1953-04-05/female/7.txt
@@ -12,5 +12,21 @@ You should get [financial advice](/plan-retirement-income/get-financial-advice) 
 
 The contribution amount is an estimate.
 
-To register your interest in the scheme and to get updates, email <statepension.topup@dwp.gsi.gov.uk>.
+##Apply
+
+You can [apply online](https://www.tax.service.gov.uk/forms/form/State-Pension-Top-Up-Request/new). You need:
+
+- proof of your identity, eg your P60 or the last 4 digits of your bank account
+- your National Insurance number (if you know it)
+
+You can also apply over the phone.
+
+$C
+**State Pension top up**\\
+Telephone: 0345 600 4270\\
+Textphone: 0300 200 3519\\
+Monday to Friday, 8am to 8pm\\
+Saturday, 8am to 4pm\\
+[Find out about call charges](/call-charges)
+$C
 

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -4,7 +4,7 @@ lib/smart_answer_flows/locales/en/state-pension-topup.yml: 9d00fb1541a4b42b5489d
 test/data/state-pension-topup-questions-and-responses.yml: f4f609a6e989f166616a05435c6993aa
 test/data/state-pension-topup-responses-and-expected-results.yml: 1207c6118839a3b13810038c57a20d4a
 lib/smart_answer_flows/state-pension-topup/outcome_pension_age_not_reached.govspeak.erb: 558d49584fe1ece4d36427740d381273
-lib/smart_answer_flows/state-pension-topup/outcome_topup_calculations.govspeak.erb: 0d9167ba311e5693a57423e773b21531
+lib/smart_answer_flows/state-pension-topup/outcome_topup_calculations.govspeak.erb: 421d026a06ca1c7dcb56e2712189211a
 lib/smart_answer_flows/state-pension-topup/state_pension_topup.govspeak.erb: 519a1c6174840e90d2ce509aff91d7be
 lib/smart_answer/calculators/state_pension_topup_calculator.rb: f03d5ababde67182513daf834b85a1db
 lib/smart_answer/calculators/state_pension_topup_data_query.rb: d18c0d8df71ac858809f11a0b5fb0e63


### PR DESCRIPTION
The State Pension Top-up scheme is launched today (12 Oct).

Users will be able to apply from this date, where previously they were only able
to register interest.