### PR TITLE
Calculate state pension start page amendments

### DIFF
--- a/lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb
@@ -7,15 +7,18 @@
 <% end %>
 
 <% content_for :body do %>
-  Calculate when you’ll reach State Pension age or Pension Credit qualifying age and how much you may get in today’s money for your basic State Pension.
+  Calculate when you’ll reach State Pension age, Pension Credit qualifying age or fine out when you'll be eligible for free bus travel.
 
-  %Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if you're 55 or over and making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/).%
+  Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if:
+  
+  - you're 55 or over
+  - you're making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/)
 <% end %>
 
 <% content_for :post_body do %>
   ##What you need to know:
 
-  This calculator gives an estimate of your basic State pension and information about the [new State Pension](/new-state-pension) if you reach State Pension age on or after 6 April 2016.
+  This calculator gives an estimate of your basic State pension and information about the [new State Pension](/new-state-pension).
 
   It doesn’t estimate any [Additional State Pension.](/additional-state-pension)
 

--- a/lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb
@@ -7,18 +7,18 @@
 <% end %>
 
 <% content_for :body do %>
-  Calculate when you’ll reach State Pension age, Pension Credit qualifying age or fine out when you'll be eligible for free bus travel.
+  Calculate when you’ll reach State Pension age, Pension Credit qualifying age or find out when you’ll be eligible for free bus travel.
 
   Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if:
-  
-  - you're 55 or over
-  - you're making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/)
+
+  - you’re 55 or over
+  - you’re making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/)
 <% end %>
 
 <% content_for :post_body do %>
   ##What you need to know:
 
-  This calculator gives an estimate of your basic State pension and information about the [new State Pension](/new-state-pension).
+  This calculator gives an estimate of your basic State Pension and information about the [new State Pension](/new-state-pension).
 
   It doesn’t estimate any [Additional State Pension.](/additional-state-pension)
 

--- a/lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb
@@ -9,6 +9,8 @@
 <% content_for :body do %>
   Calculate when you’ll reach State Pension age, Pension Credit qualifying age or find out when you’ll be eligible for free bus travel.
 
+  If you're under 55 you can also find out how much you may get in today's money for your basic State Pension.
+
   Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if:
 
   - you’re 55 or over
@@ -16,7 +18,7 @@
 <% end %>
 
 <% content_for :post_body do %>
-  ##What you need to know:
+  ##If you're under 55:
 
   This calculator gives an estimate of your basic State Pension and information about the [new State Pension](/new-state-pension).
 

--- a/test/artefacts/calculate-state-pension/calculate-state-pension.txt
+++ b/test/artefacts/calculate-state-pension/calculate-state-pension.txt
@@ -1,12 +1,17 @@
 State Pension calculator
 
-Calculate when you’ll reach State Pension age or Pension Credit qualifying age and how much you may get in today’s money for your basic State Pension.
+Calculate when you’ll reach State Pension age, Pension Credit qualifying age or find out when you’ll be eligible for free bus travel.
 
-%Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if you're 55 or over and making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/).%
+If you're under 55 you can also find out how much you may get in today's money for your basic State Pension.
 
-##What you need to know:
+Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if:
 
-This calculator gives an estimate of your basic State pension and information about the [new State Pension](/new-state-pension) if you reach State Pension age on or after 6 April 2016.
+- you’re 55 or over
+- you’re making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/)
+
+##If you're under 55:
+
+This calculator gives an estimate of your basic State Pension and information about the [new State Pension](/new-state-pension).
 
 It doesn’t estimate any [Additional State Pension.](/additional-state-pension)
 

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -7,7 +7,7 @@ lib/smart_answer_flows/calculate-state-pension/_bus_pass_age.govspeak.erb: 5f1f7
 lib/smart_answer_flows/calculate-state-pension/age_result.govspeak.erb: 8b5d360fd6ef72d4f53a2592d8d7671f
 lib/smart_answer_flows/calculate-state-pension/amount_result.govspeak.erb: b46187c00300132102d7e5c214385b0d
 lib/smart_answer_flows/calculate-state-pension/bus_pass_age_result.govspeak.erb: a7253ec4bc72d5ffec14e9b9b7ba2238
-lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb: bd56129956ea4963698db778f12267be
+lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb: 44e4a3aeaf295ddc7e987e987afd23fc
 lib/smart_answer_flows/calculate-state-pension/near_state_pension_age.govspeak.erb: 86a2fde236290c6a0305440bc1315f7c
 lib/smart_answer_flows/calculate-state-pension/over55_result.govspeak.erb: 310ea5f0936406d0dba0f5c73dc46f30
 lib/smart_answer_flows/calculate-state-pension/reached_state_pension_age.govspeak.erb: 5aa766ef2e882eccd23bcc8a281dfb4e


### PR DESCRIPTION
This replaces #1991.

I created a new branch because I was struggling to rebase the old branch on master. I kept losing the first commit ("Amend Calculate State Pension start page to reflect 55 years + outcomes"). My best guess is that this is because it had been merged to master and then reverted, although I can't be sure about that.
