### PR TITLE
Updated link in energy-grants-calculator

### DIFF
--- a/lib/smart_answer_flows/energy-grants-calculator/_opt_solid_wall_insulation.govspeak.erb
+++ b/lib/smart_answer_flows/energy-grants-calculator/_opt_solid_wall_insulation.govspeak.erb
@@ -1,1 +1,1 @@
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -14,7 +14,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -10,7 +10,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -10,7 +10,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -10,7 +10,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -10,7 +10,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -10,7 +10,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -10,7 +10,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/ground_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/top_floor/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/house/none.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/ground_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/top_floor/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/house/none.txt
@@ -8,7 +8,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 ###Heating
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 ###Heating
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 ###Heating
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 ###Heating
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 ###Heating
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 ###Heating
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 ###Heating
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 ###Heating
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -4,7 +4,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - Room in roof insulation
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/top_floor/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house/none.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - [Cavity wall insulation](http://www.energysavingtrust.org.uk/Insulation/Cavity-wall-insulation)
 
-- [Solid Wall insulation](http://www.energysavingtrust.org.uk/Insulation/Solid-wall-insulation)
+- [Solid Wall insulation](http://www.energysavingtrust.org.uk/domestic/solid-wall)
 
 - [Draught proofing](http://www.energysavingtrust.org.uk/Insulation/Draught-proofing)
 

--- a/test/data/energy-grants-calculator-files.yml
+++ b/test/data/energy-grants-calculator-files.yml
@@ -23,7 +23,7 @@ lib/smart_answer_flows/energy-grants-calculator/_opt_renewal_heat.govspeak.erb: 
 lib/smart_answer_flows/energy-grants-calculator/_opt_replacement_glazing.govspeak.erb: 13d44716247ae0eb783ab5c562edb698
 lib/smart_answer_flows/energy-grants-calculator/_opt_room_roof_insulation.govspeak.erb: 00d83472ec34da0364ce117cf4aab222
 lib/smart_answer_flows/energy-grants-calculator/_opt_solar_water_heating.govspeak.erb: eccb3d37a65218addd0f52bb14e3b2d3
-lib/smart_answer_flows/energy-grants-calculator/_opt_solid_wall_insulation.govspeak.erb: 75a61520589f9df020dc54bc41ebb6d3
+lib/smart_answer_flows/energy-grants-calculator/_opt_solid_wall_insulation.govspeak.erb: b6924cf0e1f26de60f39a43c2516a7fa
 lib/smart_answer_flows/energy-grants-calculator/_opt_under_floor_insulation.govspeak.erb: 6b7be77c07dc9d402f8b34b2b4cdc6e7
 lib/smart_answer_flows/energy-grants-calculator/_smartmeters.govspeak.erb: ece378f76cd33027e7e26a8900d8ddf4
 lib/smart_answer_flows/energy-grants-calculator/_title_energy_supplier.govspeak.erb: 5749970f07beeb4d78aea03018fbdbe3


### PR DESCRIPTION
Supersedes #1993.

Updated link in energy-grants-calculator

https://govuk.zendesk.com/agent/tickets/1163441

A redirect at the destination meant this was going to the cavity wall page.

Note from @floehopper:

* Regression test artefacts updated & checked
* Regression test checksums updated
* These changes were committed separately, because a lot of files had changed and I thought it was clearer to do this rather than amend the original commit.
