### PR TITLE
Make test definitions consistent

### DIFF
--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class ContentItemPublisherTest < ActiveSupport::TestCase
-  def test_sending_item_to_content_store
+  test 'sending item to content store' do
     request = stub_request(:put, "http://publishing-api.dev.gov.uk/content/a-flow-name")
     presenter = FlowRegistrationPresenter.new(stub('flow', name: 'a-flow-name', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685'))
 

--- a/test/unit/services/panopticon_registerer_test.rb
+++ b/test/unit/services/panopticon_registerer_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class PanopticonRegistererTest < ActiveSupport::TestCase
-  def test_sending_item_to_panopticon
+  test 'sending item to panopticon' do
     request = stub_request(:put, %r[http://panopticon.dev.gov.uk/])
     flow_presenters = [OpenStruct.new, OpenStruct.new]
 
@@ -12,7 +12,7 @@ class PanopticonRegistererTest < ActiveSupport::TestCase
     assert_requested(request, times: 2)
   end
 
-  def test_sending_correct_data_to_panopticon
+  test 'sending correct data to panopticon' do
     stub_request(:put, "http://panopticon.dev.gov.uk/artefacts/a-smart-answer.json")
 
     registerable = OpenStruct.new(

--- a/test/unit/services/registerable_smart_answers_test.rb
+++ b/test/unit/services/registerable_smart_answers_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class RegisterableSmartAnswersTest < ActiveSupport::TestCase
-  def test_merging_flow_presenters_and_smartdown
+  test 'merging flow presenters and smartdown' do
     SmartAnswer::FlowRegistry.any_instance.stubs(flows: [stub('a flow', name: 'A SmartAnswer')])
     SmartdownAdapter::Registry.instance.stubs(flows: [stub('a flow', name: 'A SmartDown')])
 
@@ -10,7 +10,7 @@ class RegisterableSmartAnswersTest < ActiveSupport::TestCase
     assert_equal 2, flow_presenters.size
   end
 
-  def test_decoration_of_smartanswers
+  test 'decoration of smartanswers' do
     SmartAnswer::FlowRegistry.any_instance.stubs(flows: [stub('a flow', name: 'A SmartAnswer')])
     SmartdownAdapter::Registry.instance.stubs(flows: [])
 
@@ -19,7 +19,7 @@ class RegisterableSmartAnswersTest < ActiveSupport::TestCase
     assert flow_presenters.first.is_a?(FlowRegistrationPresenter)
   end
 
-  def test_decoration_of_smartdowns
+  test 'decoration of smartdowns' do
     SmartAnswer::FlowRegistry.any_instance.stubs(flows: [])
     SmartdownAdapter::Registry.instance.stubs(flows: [stub('a flow', name: 'A SmartDown')])
 


### PR DESCRIPTION
We're using `test 'name' do ... end` in all other tests, so let's make these ones consistent.

/cc @tijmen