### PR TITLE
Add documentation about deploying

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Read more in [a blog post](https://gds.blog.gov.uk/2012/02/16/smart-answers-are-
 * Process
   * [Archiving a Smart Answer](doc/archiving.md)
   * [Deploying changes for Factcheck](doc/factcheck.md)
+  * [Deploying to production](doc/deploying.md)
   * [Merging pull requests from the content team](doc/merging-content-prs.md)
 * Development
   * Adding [content-ids](doc/content-ids.md) to Smart Answers.

--- a/doc/deploying.md
+++ b/doc/deploying.md
@@ -1,0 +1,53 @@
+## Create the Release in GitHub
+
+### 1. Find the latest release
+
+Open the [list of releases][smart-answers-releases] and make a note of the name of the most recent release (referred to as `$RELEASE-TAG` below).
+
+#### NOTE. Jenkins and releases
+
+After a successful build of the master branch on Jenkins:
+
+* Jenkins updates the `release` branch to point at HEAD
+* Jenkins creates a `release_nnnn` tag pointing at HEAD
+
+
+### 2. Review the changes waiting to be deployed to production
+
+Open "https://github.com/alphagov/smart-answers/compare/deployed-to-production...$RELEASE-TAG".
+
+Open each of the merged Pull Requests that are waiting to be deployed and ensure that the description contains details of the expected changes.
+
+
+### 3. Update the latest release on GitHub
+
+Open "https://github.com/alphagov/smart-answers/releases/tag/$RELEASE-TAG".
+
+Click "Edit release".
+
+Leave the "Release title" blank.
+
+Set the description to:
+
+```
+## Changes to deploy
+
+https://github.com/alphagov/smart-answers/compare/deployed-to-production...$RELEASE-TAG
+
+## Main changes
+
+TODO: List each of the Pull Requests that contain user facing changes here, for example:
+
+* https://github.com/alphagov/smart-answers/pull/nnn - <title-of-pull-request>
+```
+
+## Create the deployment calendar event
+
+1. Add an event to the "GOVUK Release Calender"
+
+  * Title: "Smart Answers (2nd line required)"
+  * Time: <The time you'd like to deploy>
+  * Duration: 30 minutes
+  * Description: https://github.com/alphagov/smart-answers/releases/tag/$RELEASE-TAG
+
+[smart-answers-releases]: https://github.com/alphagov/smart-answers/releases


### PR DESCRIPTION
This is a first stab at documenting the deployment process.

I've made a slight change to the process while writing this document. We would previously add details of the changes to the calendar event itself but it seems more appropriate to use GitHub's releases functionality.
