### PR TITLE
Always use explicit question specific options in i18n YAML

### DIFF
--- a/lib/smart_answer/i18n_renderer.rb
+++ b/lib/smart_answer/i18n_renderer.rb
@@ -15,16 +15,13 @@ module SmartAnswer
     end
 
     def translate_option(option)
-      translate!("options.#{option}") || begin
-        I18n.translate!("#{@i18n_prefix}.options.#{option}", @state.to_hash)
-      rescue I18n::MissingTranslationData
-        option
-      end
+      translate!("options.#{option}", rescue_exception: false)
     end
 
-    def translate!(subkey)
+    def translate!(subkey, rescue_exception: true)
       I18n.translate!("#{i18n_node_prefix}.#{subkey}", state_for_interpolation)
-    rescue I18n::MissingTranslationData
+    rescue I18n::MissingTranslationData => e
+      raise e unless rescue_exception
       nil
     end
 

--- a/lib/smart_answer/i18n_renderer.rb
+++ b/lib/smart_answer/i18n_renderer.rb
@@ -16,6 +16,7 @@ module SmartAnswer
 
     def translate_option(option)
       translate!("options.#{option}") || begin
+        puts "\nMissing translation: #{i18n_node_prefix}.options.#{option}"
         I18n.translate!("#{@i18n_prefix}.options.#{option}", @state.to_hash)
       rescue I18n::MissingTranslationData
         option

--- a/lib/smart_answer/i18n_renderer.rb
+++ b/lib/smart_answer/i18n_renderer.rb
@@ -16,7 +16,6 @@ module SmartAnswer
 
     def translate_option(option)
       translate!("options.#{option}") || begin
-        puts "\nMissing translation: #{i18n_node_prefix}.options.#{option}"
         I18n.translate!("#{@i18n_prefix}.options.#{option}", @state.to_hash)
       rescue I18n::MissingTranslationData
         option

--- a/lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml
+++ b/lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml
@@ -2,7 +2,6 @@ en-GB:
   flow:
     am-i-getting-minimum-wage:
       options:
-        "yes": "Yes"
         "no": "No"
 
       # Q1

--- a/lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml
+++ b/lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml
@@ -1,9 +1,6 @@
 en-GB:
   flow:
     am-i-getting-minimum-wage:
-      options:
-        "no": "No"
-
       # Q1
       what_would_you_like_to_check?:
         title: "What would you like to check?"
@@ -35,6 +32,7 @@ en-GB:
       were_you_an_apprentice?:
         title: "Were you an apprentice at the time?"
         options:
+          "no": "No"
           apprentice_under_19: "Apprentice under 19"
           apprentice_over_19: "Apprentice aged 19 and over and in your first year"
       # Q3
@@ -119,12 +117,14 @@ en-GB:
       is_provided_with_accommodation?:
         title: "Does your employer provide you with accommodation?"
         options:
+          "no": "No"
           yes_free: "Yes, the accommodation is free"
           yes_charged: "Yes, the accommodation is charged for"
       # Q9 Past
       was_provided_with_accommodation?:
         title: "Did your employer provide you with accommodation?"
         options:
+          "no": "No"
           yes_free: "Yes, the accommodation was free"
           yes_charged: "Yes, the accommodation was charged for"
       # Q10

--- a/lib/smart_answer_flows/locales/en/benefit-cap-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/benefit-cap-calculator.yml
@@ -1,18 +1,21 @@
 en-GB:
   flow:
     benefit-cap-calculator:
-      options:
-        "yes": "Yes"
-        "no": "No"
 
 # Q1
       receive_housing_benefit?:
         title: Do you receive Housing Benefit?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q2
       working_tax_credit?:
         title: Do you qualify for Working Tax Credit?
         hint: You don't need to be getting Working Tax Credit, only qualify for it.
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q3
       receiving_exemption_benefits?:
@@ -26,6 +29,9 @@ en-GB:
           - War Widow’s or War Widower’s Pension
           - Armed Forces Compensation Scheme
           - Armed Forces Independence Payment
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q4
       receiving_non_exemption_benefits?:

--- a/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
@@ -2,18 +2,21 @@ en-GB:
   flow:
     calculate-married-couples-allowance:
       section_name: Money and tax
-      options:
-        "no": "No"
-        "yes": "Yes"
 #Q1
       were_you_or_your_partner_born_on_or_before_6_april_1935?:
         title: Were you or your partner born before 6 April 1935?
         hint: You must be married or in a civil partnership to qualify.
+        options:
+          "no": "No"
+          "yes": "Yes"
         error_message: Please choose 'Yes' or 'No'
 #Q2
       did_you_marry_or_civil_partner_before_5_december_2005?:
         title: Did you marry before 5 December 2005?
         hint: Before this date the husband's income is used to work out your allowance, after this date it's the income of the highest earner.
+        options:
+          "no": "No"
+          "yes": "Yes"
         error_message: Please choose 'Yes' or 'No'
 #Q3
       whats_the_husbands_date_of_birth?:
@@ -39,6 +42,9 @@ en-GB:
 #Q7
       paying_into_a_pension?:
         title: Are you paying into a pension?
+        options:
+          "no": "No"
+          "yes": "Yes"
 #Q8
       how_much_expected_contributions_before_tax?:
         title: How much do you expect to pay into a pension where your contributions are made before tax is taken away?

--- a/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
@@ -1,9 +1,6 @@
 en-GB:
   flow:
     calculate-state-pension:
-      options:
-        "yes": "Yes"
-        "no": "No"
       phrases:
         carers_allowance_women_hint: Don’t count years when you opted for the reduced National Insurance rate for married women and widows.
         carers_allowance_women_ni_reduced_years_before_2010: Don’t count years before April 2010 when you opted for the reduced National Insurance rate for married women and widows.
@@ -38,6 +35,9 @@ en-GB:
         title: Have you ever opted to pay the reduced National Insurance rate for married women and widows (also known as the married woman’s stamp)?
         hint: |
           Opting to pay the reduced rate means you chose to pay a lower rate of National Insurance while you were employed or you chose not to pay Class 2 contributions while you were self-employed.
+        options:
+          "yes": "Yes"
+          "no": "No"
       ## Q4
       years_paid_ni?:
         title: How many years have you worked and paid National Insurance contributions from the age of 19?
@@ -57,6 +57,9 @@ en-GB:
       ## Q6
       received_child_benefit?:
         title: Have you ever claimed Child Benefit, cared for someone sick or disabled or worked as a registered foster carer?
+        options:
+          "yes": "Yes"
+          "no": "No"
       ## Q7
       years_of_benefit?:
         title: "Before 6 April 2010 how many years did any of the following apply:"
@@ -94,3 +97,6 @@ en-GB:
       ## Q11
       lived_or_worked_outside_uk?:
         title: Have you lived or worked outside the UK?
+        options:
+          "yes": "Yes"
+          "no": "No"

--- a/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
@@ -4,7 +4,6 @@ en-GB:
       options:
         "yes": "Yes"
         "no": "No"
-        none: "None of the above"
       phrases:
         carers_allowance_women_hint: Don’t count years when you opted for the reduced National Insurance rate for married women and widows.
         carers_allowance_women_ni_reduced_years_before_2010: Don’t count years before April 2010 when you opted for the reduced National Insurance rate for married women and widows.

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -9,33 +9,30 @@ en-GB:
             [Download ‘Form SSP1, employee not entitled to SSP’ (PDF, 130KB)](http://www.dwp.gov.uk/advisers/claimforms/ssp1.pdf)
           $D
 
-      options:
-        "yes": "Yes"
-        "no": "No"
-        statutory_maternity_pay: Statutory Maternity Pay
-        maternity_allowance: Maternity Allowance
-        ordinary_statutory_paternity_pay: Ordinary Statutory Paternity Pay
-        statutory_adoption_pay: Statutory Adoption Pay
-        additional_statutory_paternity_pay: Additional Statutory Paternity Pay
-
-        weekly: Weekly
-        fortnightly: Every 2 weeks
-        every_4_weeks: Every 4 weeks
-        monthly: Monthly - eg last day or Friday of a month
-        irregularly: Irregularly
-
       # Q1
       is_your_employee_getting?:
         title: Is your employee getting any of the following?
         hint: If none apply just click ‘Next step’
+        options:
+          statutory_maternity_pay: Statutory Maternity Pay
+          maternity_allowance: Maternity Allowance
+          ordinary_statutory_paternity_pay: Ordinary Statutory Paternity Pay
+          statutory_adoption_pay: Statutory Adoption Pay
+          additional_statutory_paternity_pay: Additional Statutory Paternity Pay
 
       # Question 2
       employee_tell_within_limit?:
         title: Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Question 3
       employee_work_different_days?:
         title: Does your employee routinely work different days of the week?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Question 4
       first_sick_day?:
@@ -55,6 +52,9 @@ en-GB:
           These are called ‘linked Periods of Incapacity for Work (PIW)’. Check if an employee’s [PIW links to a previous one.](/government/publications/statutory-sick-pay-tables-for-linking-periods-of-incapacity-for-work)
 
           *[PIW]: Period of Incapacity for Work
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Question 6.1
       linked_sickness_start_date?:
@@ -78,6 +78,12 @@ en-GB:
       # Q7.2
       how_often_pay_employee_pay_patterns?:
         title: How often do you pay the employee?
+        options:
+          weekly: Weekly
+          fortnightly: Every 2 weeks
+          every_4_weeks: Every 4 weeks
+          monthly: Monthly - eg last day or Friday of a month
+          irregularly: Irregularly
 
       # Question 8
       last_payday_before_sickness?:

--- a/lib/smart_answer_flows/locales/en/calculate-your-child-maintenance.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-your-child-maintenance.yml
@@ -16,10 +16,6 @@ en-GB:
         pay_how_many_nights: On average, how many nights a year do the children stay over with you?
         receive_how_many_nights: On average, how many nights a year do the children stay over with the parent paying child maintenance?
 
-      options:
-        "yes": "Yes"
-        "no": "No"
-
       ## Q1
       are_you_paying_or_receiving?:
         title: Will you be paying or receiving child maintenance payments?
@@ -61,6 +57,9 @@ en-GB:
           - Widow’s pension
           - Universal Credit with no earned income
         hint: "In Scotland, this also includes: Skillseekers training, War Widow’s, Widower’s or Surviving Civil Partner’s Pension"
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       ## Q4
       gross_income_of_payee?:

--- a/lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml
@@ -21,10 +21,6 @@ en-GB:
         "starting": "for someone starting part way through a leave year"
         "leaving": "for someone leaving part way through a leave year"
         "starting-and-leaving": "for someone starting and leaving part way through a leave year"
-        "5-days": "5 days per week"
-        "6-days": "6 days per week"
-        "6-or-7-days": "6 or 7 days per week"
-        "7-days": "7 days per week"
 
       # Q1
       basis_of_calculation?:

--- a/lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml
@@ -10,26 +10,28 @@ en-GB:
           * can give more paid holiday - this will be in the employment contract and is called 'contractual leave entitlement'
           * must provide [holiday pay](/holiday-entitlement-rights/holiday-pay-the-basics "Holiday pay") during the statutory leave
 
-      options:
-        "days-worked-per-week": "days worked per week"
-        "hours-worked-per-week": "hours worked per week"
-        "casual-or-irregular-hours": "casual or irregular hours"
-        "annualised-hours": "annualised hours"
-        "compressed-hours": "compressed hours"
-        "shift-worker": "shifts"
-        "full-year": "for a full leave year"
-        "starting": "for someone starting part way through a leave year"
-        "leaving": "for someone leaving part way through a leave year"
-        "starting-and-leaving": "for someone starting and leaving part way through a leave year"
-
       # Q1
       basis_of_calculation?:
         title: "Is the holiday entitlement based on:"
         hint: |
           Check the employment contract if you’re not sure about the holiday entitlement.
+        options:
+          "days-worked-per-week": "days worked per week"
+          "hours-worked-per-week": "hours worked per week"
+          "casual-or-irregular-hours": "casual or irregular hours"
+          "annualised-hours": "annualised hours"
+          "compressed-hours": "compressed hours"
+          "shift-worker": "shifts"
+
       # Q2
       calculation_period?:
         title: "Do you want to work out holiday:"
+        options:
+          "full-year": "for a full leave year"
+          "starting": "for someone starting part way through a leave year"
+          "leaving": "for someone leaving part way through a leave year"
+          "starting-and-leaving": "for someone starting and leaving part way through a leave year"
+
       # Q3
       how_many_days_per_week?:
         title: Number of days worked per week?
@@ -74,6 +76,11 @@ en-GB:
       # Q15
       shift_worker_basis?:
         title: "Do you want to calculate the holiday:"
+        options:
+          "full-year": "for a full leave year"
+          "starting": "for someone starting part way through a leave year"
+          "leaving": "for someone leaving part way through a leave year"
+          "starting-and-leaving": "for someone starting and leaving part way through a leave year"
 
       shift_worker_hours_per_shift?:
         title: How many hours in each shift?

--- a/lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml
+++ b/lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml
@@ -1,18 +1,13 @@
 en-GB:
   flow:
     childcare-costs-for-tax-credits:
-      options:
-        "yes": "Yes"
-        "no": "No"
-        weekly_same_amount: "Weekly, and I always pay the same amount"
-        weekly_diff_amount: "Weekly, and the amount I pay varies"
-        monthly_same_amount: "Monthly, and I always pay the same amount"
-        monthly_diff_amount: "Monthly, and the amount I pay varies"
-        other: "Other"
 
       #Q1
       currently_claiming?:
         title: "Are you currently claiming tax credits for childcare costs?"
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       #Q2
       how_often_use_childcare?:
@@ -25,14 +20,29 @@ en-GB:
       #Q3
       have_costs_changed?:
         title: "Have the costs of your childcare changed since you last made your claim?"
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       #Q4
       how_often_pay_1?:
         title: "How often do you pay your childcare provider(s)?"
+        options:
+          weekly_same_amount: "Weekly, and I always pay the same amount"
+          weekly_diff_amount: "Weekly, and the amount I pay varies"
+          monthly_same_amount: "Monthly, and I always pay the same amount"
+          monthly_diff_amount: "Monthly, and the amount I pay varies"
+          other: "Other"
 
       #Q5
       how_often_pay_2?:
         title: "How often do you pay your childcare provider(s)?"
+        options:
+          weekly_same_amount: "Weekly, and I always pay the same amount"
+          weekly_diff_amount: "Weekly, and the amount I pay varies"
+          monthly_same_amount: "Monthly, and I always pay the same amount"
+          monthly_diff_amount: "Monthly, and the amount I pay varies"
+          other: "Other"
 
       #Q6
       how_much_12_months_1?:
@@ -64,6 +74,9 @@ en-GB:
 
           - you regularly use childcare, but pay more during school holidays than you do at term time
           - the hours you use childcare change from week to week or month to month
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       #Q12
       how_often_pay_providers?:
@@ -75,6 +88,7 @@ en-GB:
           every_month: "Every calendar month"
           termly: "Termly"
           yearly: "Yearly"
+          other: "Other"
 
       #Q13
       how_much_fortnightly?:

--- a/lib/smart_answer_flows/locales/en/inherits-someone-dies-without-will.yml
+++ b/lib/smart_answer_flows/locales/en/inherits-someone-dies-without-will.yml
@@ -1,9 +1,6 @@
 en-GB:
   flow:
     inherits-someone-dies-without-will:
-      options:
-        "yes": "Yes"
-        "no": "No"
       # Q1
       region?:
         title: Where did the deceased live?
@@ -16,45 +13,75 @@ en-GB:
       partner?:
         title: Is there a living husband, wife or civil partner?
         hint: A surviving partner who wasn't married or in a civil partnership with the deceased has no automatic right to inherit.
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Q3
       estate_over_250000?:
         title: Is the estate likely to be worth more than £250,000?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Q4
       children?:
         title: Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?
         hint: Children include legally-adopted sons or daughters (but not stepchildren) and any children where the deceased had a parental role.
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Q5
       parents?:
         title: Are there any living parents?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Q6
       siblings?:
         title: Did the deceased have any brothers or sisters?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Q61
       siblings_including_mixed_parents?:
         title: Did the deceased have any brothers or sisters?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Q7
       grandparents?:
         title: Are there any living grandparents?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Q8
       aunts_or_uncles?:
         title: Did the deceased have any aunts or uncles?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # England and wales questions ###
 
       # Q20
       half_siblings?:
         title: Did the deceased have any half-brothers or half-sisters?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Q21
       half_aunts_or_uncles?:
         title: Did the deceased have any half-aunts or half-uncles?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Scotland questions ###
 
@@ -62,9 +89,15 @@ en-GB:
       great_aunts_or_uncles?:
         title: Are there any living great aunts or great uncles?
         hint: Great aunts and great uncles are brothers or sisters of the grandparents of the deceased.
+        options:
+          "yes": "Yes"
+          "no": "No"
 
       # Northern Ireland questions ###
 
       # Q60
       more_than_one_child?:
         title: Did they have more than one child?
+        options:
+          "yes": "Yes"
+          "no": "No"

--- a/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
@@ -92,6 +92,14 @@ en-GB:
       ## QM12
       what_particular_day_of_the_month_is_the_employee_paid?:
         title: What particular day of the month is the employee paid?
+        options:
+          Sunday: "Sunday"
+          Monday: "Monday"
+          Tuesday: "Tuesday"
+          Wednesday: "Wednesday"
+          Thursday: "Thursday"
+          Friday: "Friday"
+          Saturday: "Saturday"
       ## QM13
       which_week_in_month_is_the_employee_paid?:
         title: Is the employee paid on the 1st, 2nd, 3rd, 4th or last %{pay_day_in_week}?

--- a/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
@@ -1,21 +1,22 @@
 en-GB:
   flow:
     maternity-paternity-calculator:
-      options:
-        "no": "No"
-        "yes": "Yes"
-        "maternity": "Maternity"
-        "paternity": "Paternity"
-        "adoption": "Adoption"
       ## Q1
       what_type_of_leave?:
         title: What do you want to check?
+        options:
+          "maternity": "Maternity"
+          "paternity": "Paternity"
+          "adoption": "Adoption"
       ## QM1
       baby_due_date_maternity?:
         title: What is the baby’s due date?
       ## QM2
       employment_contract?:
         title: Does the employee have an employment contract with you?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QM3
       date_leave_starts?:
         title: When does the employee want to start their leave?
@@ -24,9 +25,15 @@ en-GB:
       ## QM4
       did_the_employee_work_for_you?:
         title: Did the employee work for you on or before %{employment_start}?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QM5
       is_the_employee_on_your_payroll?:
         title: Is the employee on your payroll?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QM5.2
       last_normal_payday?:
         title: What was the last normal payday on or before %{to_saturday_formatted}?
@@ -98,6 +105,9 @@ en-GB:
       ## QP0
       leave_or_pay_for_adoption?:
         title: Is the paternity leave or pay for an adoption?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QP1
       baby_due_date_paternity?:
         title: What is the baby’s due date?
@@ -108,18 +118,33 @@ en-GB:
       ## QP3
       employee_responsible_for_upbringing?:
         title: Is the employee responsible for the child’s upbringing and either the biological father or the mother’s husband or partner?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QP4
       employee_work_before_employment_start?:
         title: Did the employee work for you on or before %{employment_start}?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QP5
       employee_has_contract_paternity?:
         title: Does the employee have an employment contract with you?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QP6
       employee_on_payroll_paternity?:
         title: Is the employee on your payroll?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QP7
       employee_still_employed_on_birth_date?:
         title: Will the employee still be employed by you on %{still_employed_date}?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QP8
       employee_start_paternity?:
         title: When does the employee want to start their paternity leave?
@@ -218,11 +243,17 @@ en-GB:
       ## QAP3
       padoption_employee_responsible_for_upbringing?:
         title: Is the employee responsible for the child's upbringing and the husband or partner of the adopter or the child's adopter?
+        options:
+          "no": "No"
+          "yes": "Yes"
 
       ## Adoption
       ## QA0
       taking_paternity_leave_for_adoption?:
         title: Is the employee taking paternity leave to adopt a child?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QA1
       date_of_adoption_match?:
         title: When was the child matched with the employee?
@@ -235,12 +266,21 @@ en-GB:
       ## QA3
       adoption_did_the_employee_work_for_you?:
         title: Did the employee work for you on or before %{employment_start}?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QA4
       adoption_employment_contract?:
         title: Does the employee have an employment contract with you?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QA5
       adoption_is_the_employee_on_your_payroll?:
         title: Is the employee on your payroll?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## QA6
       adoption_date_leave_starts?:
         title: When does the employee want to start their leave?

--- a/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
@@ -7,9 +7,6 @@ en-GB:
         "maternity": "Maternity"
         "paternity": "Paternity"
         "adoption": "Adoption"
-        "one_week": "One Week"
-        "two_weeks": "Two Weeks"
-        "weekly": "Weekly"
       ## Q1
       what_type_of_leave?:
         title: What do you want to check?

--- a/lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml
+++ b/lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml
@@ -2,7 +2,6 @@ en-GB:
   flow:
     minimum-wage-calculator-employers:
       options:
-        "yes": "Yes"
         "no": "No"
 
       # Q1

--- a/lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml
+++ b/lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml
@@ -1,9 +1,6 @@
 en-GB:
   flow:
     minimum-wage-calculator-employers:
-      options:
-        "no": "No"
-
       # Q1
       what_would_you_like_to_check?:
         title: "What would you like to check?"
@@ -38,6 +35,7 @@ en-GB:
       were_you_an_apprentice?:
         title: "Was the worker an apprentice at the time?"
         options:
+          "no": "No"
           apprentice_under_19: "Apprentice under 19"
           apprentice_over_19: "Apprentice aged 19 and over and in their first year"
       # Q3
@@ -122,12 +120,14 @@ en-GB:
       is_provided_with_accommodation?:
         title: "Do you provide accommodation?"
         options:
+          "no": "No"
           yes_free: "Yes, the accommodation is free"
           yes_charged: "Yes, the accommodation is charged for"
       # Q9 Past
       was_provided_with_accommodation?:
         title: "Did you provide accommodation?"
         options:
+          "no": "No"
           yes_free: "Yes, the accommodation was free"
           yes_charged: "Yes, the accommodation was charged for"
       # Q10

--- a/lib/smart_answer_flows/locales/en/pip-checker.yml
+++ b/lib/smart_answer_flows/locales/en/pip-checker.yml
@@ -1,13 +1,12 @@
 en-GB:
   flow:
     pip-checker:
-      options:
-        "no": "No"
-        "yes": "Yes"
-
       ## Q1
       are_you_getting_dla?:
         title: "Are you getting Disability Living Allowance?"
+        options:
+          "no": "No"
+          "yes": "Yes"
 
       ## Q2
       what_is_your_dob?:

--- a/lib/smart_answer_flows/locales/en/register-a-birth.yml
+++ b/lib/smart_answer_flows/locales/en/register-a-birth.yml
@@ -1,9 +1,6 @@
 en-GB:
   flow:
     register-a-birth:
-      options:
-        "yes": "Yes"
-        "no": "No"
       have_you_adopted_the_child?:
         title: Have you adopted the child?
       who_has_british_nationality?:
@@ -19,6 +16,9 @@ en-GB:
         title: Which country was the child born in?
       married_couple_or_civil_partnership?:
         title: Were you married to the other parent when your child was born?
+        options:
+          "yes": "Yes"
+          "no": "No"
       childs_date_of_birth?:
         title: What is your child’s date of birth?
       where_are_you_now?:

--- a/lib/smart_answer_flows/locales/en/register-a-death.yml
+++ b/lib/smart_answer_flows/locales/en/register-a-death.yml
@@ -1,9 +1,6 @@
 en-GB:
   flow:
     register-a-death:
-      options:
-        "yes": "Yes"
-        "no": "No"
       where_did_the_death_happen?:
         title: Where did the death happen?
         options:
@@ -18,6 +15,9 @@ en-GB:
           elsewhere: "Elsewhere"
       was_death_expected?:
         title: Was the death expected?
+        options:
+          "yes": "Yes"
+          "no": "No"
       which_country?:
         title: Which country did the death happen in?
       where_are_you_now?:

--- a/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml
+++ b/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml
@@ -1,10 +1,9 @@
 en-GB:
   flow:
     report-a-lost-or-stolen-passport:
-      options:
-        in_the_uk: "In the UK"
-        abroad: "Abroad"
-
       where_was_the_passport_lost_or_stolen?:
+        options:
+          in_the_uk: "In the UK"
+          abroad: "Abroad"
       which_country?:
         title: In which country?

--- a/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml
+++ b/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml
@@ -5,5 +5,6 @@ en-GB:
         in_the_uk: "In the UK"
         abroad: "Abroad"
 
+      where_was_the_passport_lost_or_stolen?:
       which_country?:
         title: In which country?

--- a/lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml
+++ b/lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml
@@ -1,12 +1,12 @@
 en-GB:
   flow:
     simplified-expenses-checker:
-      options:
-        "yes": "Yes"
-        "no": "No"
 #Q1
       claimed_expenses_for_current_business?:
         title: Have you claimed expenses for your current business before?
+        options:
+          "no": "No"
+          "yes": "Yes"
         hint: If you’re a new business you won’t have claimed expenses before.
 #Q2
       type_of_expense?:
@@ -21,9 +21,15 @@ en-GB:
 #Q3
       buying_new_vehicle?:
         title: Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?
+        options:
+          "yes": "Yes"
+          "no": "No"
 #Q4
       capital_allowances?:
         title: Have you claimed Capital Allowances for your existing car, van or motorcycle before?
+        options:
+          "yes": "Yes"
+          "no": "No"
 #Q5
       how_much_expect_to_claim?:
         title: |
@@ -32,6 +38,9 @@ en-GB:
 #Q6
       is_vehicle_green?:
         title: Is the vehicle you're buying green, ie a low emission vehicle?
+        options:
+          "yes": "Yes"
+          "no": "No"
 #Q7
       price_of_vehicle?:
         title: How much is the car, van or motorcycle you’re buying?

--- a/lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml
+++ b/lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml
@@ -7,9 +7,6 @@ en-GB:
 #Q1
       claimed_expenses_for_current_business?:
         title: Have you claimed expenses for your current business before?
-        options:
-          no: No
-          yes: Yes
         hint: If you’re a new business you won’t have claimed expenses before.
 #Q2
       type_of_expense?:

--- a/lib/smart_answer_flows/locales/en/state-pension-topup.yml
+++ b/lib/smart_answer_flows/locales/en/state-pension-topup.yml
@@ -1,9 +1,6 @@
 en-GB:
   flow:
     state-pension-topup:
-      options:
-        "yes": "Yes"
-        "no": "No"
 #Q1
       dob_age?:
         title: What is your date of birth?

--- a/lib/smart_answer_flows/locales/en/towing-rules.yml
+++ b/lib/smart_answer_flows/locales/en/towing-rules.yml
@@ -1,10 +1,6 @@
 en-GB:
   flow:
     towing-rules:
-      options:
-        "no": "No"
-        "yes": "Yes"
-
       ## Q1
       towing_vehicle_type?:
         title: What kind of vehicle do you want to tow with?
@@ -22,6 +18,9 @@ en-GB:
           - C+E (towing with a large vehicle)
           - D1+E (towing with a minibus)
           - D+E (towing with a bus)
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## Q2A
       how_long_entitlements?:
         title: When did you get this entitlement on your licence?
@@ -38,6 +37,9 @@ en-GB:
       ## Q8
       medium_sized_vehicle_licenceholder?:
         title: Do you already have a C1 medium-sized vehicle licence?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## Q9
       how_old_are_you_msv?:
         title: How old are you?
@@ -47,6 +49,9 @@ en-GB:
       ## Q12
       existing_large_vehicle_towing_entitlements?:
         title: Do you already have a driving licence with the C+E towing with a large vehicle entitlement on it?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## Q14
       date_licence_was_issued_msv?:
         title: When was your driving licence issued?
@@ -63,6 +68,9 @@ en-GB:
       ## Q20
       existing_large_vehicle_licence?:
         title: Do you already have a category C large vehicle licence?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## Q22
       how_old_are_you_lv?:
         title: How old are you?
@@ -72,12 +80,21 @@ en-GB:
       ## Q25
       car_licence_before_jan_1997?:
         title: Did you pass your test before 1 January 1997?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## Q27
       do_you_have_lv_or_bus_towing_entitlement?:
         title: Do you have a full category D+E towing with a bus licence?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## Q29
       full_minibus_licence?:
         title: Do you have a full category D1 minibus licence?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## Q31
       how_old_are_you_minibus?:
         title: How old are you?
@@ -87,6 +104,9 @@ en-GB:
       ## Q36
       bus_licenceholder?:
         title: Do you already have a full category D bus licence?
+        options:
+          "no": "No"
+          "yes": "Yes"
       ## Q38
       how_old_are_you_bus?:
         title: How old are you?

--- a/lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml
@@ -1,10 +1,6 @@
 en-GB:
   flow:
     uk-benefits-abroad:
-      options:
-        "yes": "Yes"
-        "no": "No"
-
       phrases:
         going_abroad_country_question_title: Which country are you moving to?
         already_abroad_country_question_title: Which country are you living in?
@@ -48,16 +44,25 @@ en-GB:
           Are you working for a UK employer and paying Class 1 National Insurance Contributions?
         body: |
           If you're unsure you can read our [National Insurance Guide](/national-insurance/how-much-national-insurance-you-pay).
+        options:
+          "yes": "Yes"
+          "no": "No"
 # Q9 going_abroad and Q8 already_abroad
       eligible_for_smp?:
         title: Are you eligible for Statutory Maternity Pay?
         body: |
           If you're unsure you can read our [Maternity pay and leave guide](/statutory-maternity-pay#eligibility)
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q10, Q11, Q16 going_abroad and Q9, Q10, Q15 already_abroad
       employer_paying_ni?:
         title: |
           Is your employer paying National Insurance contributions for you?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q13 going_abroad and Q12 already_abroad
       do_either_of_the_following_apply?:
@@ -71,11 +76,16 @@ en-GB:
           - Incapacity Benefit
           - Industrial Injuries Disablement Benefit
           - State Pension
-
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q15 going_abroad and Q14 already_abroad
       working_for_uk_employer_ssp?:
         title: Are you working for a UK employer?
+        options:
+          "yes": "Yes"
+          "no": "No"
 # Q17 going_abroad Q16 already_abroad
       eligible_for_tax_credits?:
         title: Are you or your partner one of the following?
@@ -91,6 +101,9 @@ en-GB:
 # Q19 going_abroad and Q18 already_abroad
       tax_credits_children?:
         title: Do you have any children?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q20 already_abroad
       tax_credits_currently_claiming?:
@@ -102,6 +115,9 @@ en-GB:
           - Industrial Injuries Disablement Benefit
           - contribution-based Employment and Support Allowance
           - Severe Disablement Allowance
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q23 going_abroad and Q22 already_abroad
       tax_credits_why_going_abroad?:
@@ -114,11 +130,17 @@ en-GB:
 # Q26 going_abroad Q25 already_abroad
       iidb_already_claiming?:
         title: Are you currently receiving Industrial Injuries Disablement Benefit?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q30 going_abroad and Q29 already_abroad
       db_claiming_benefits?:
         title: |
           Are you or a family member getting State Pension, Industrial Injuries Benefit, ESA (contributory) or bereavement benefits?
+        options:
+          "yes": "Yes"
+          "no": "No"
 # Q33 going_abroad
       is_claiming_benefits?:
         title: |
@@ -130,17 +152,26 @@ en-GB:
           - [Severe Disability premium](/disability-premiums-income-support/eligibility)
         hint: |
           Your partner must be getting the premium, not you.
+        options:
+          "yes": "Yes"
+          "no": "No"
 # Q34 going_abroad
       is_either_of_the_following?:
         title: "Are you getting Income Support while either:"
         body: |
           - getting [Statutory Sick Pay](/statutory-sick-pay/)
           - incapable of work, but being treated as capable of work because you are temporarily disqualified from receiving Income Support
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q35 going_abroad
       is_abroad_for_treatment?:
         title: |
           Are you going abroad to get medical treatment for the illness or disability that prevents you from working?
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q36 going_abroad
       is_work_or_sick_pay?:
@@ -149,6 +180,9 @@ en-GB:
         body: |
           - 364 days
           - 196 days if you're terminally ill, or getting the highest rate of Disability Living Allowance (care component) or the enhanced rate of Personal Independence Payment (daily living component)
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Q37 going_abroad
       is_any_of_the_following_apply?:
@@ -157,6 +191,9 @@ en-GB:
           - affected by a trades dispute (eg on strike)
           - age 16 to 19 and in full-time secondary education
           - appealing against a decision about your ability to work
+        options:
+          "yes": "Yes"
+          "no": "No"
 
 # Going abroad questions
 # Going abroad Q3 going_abroad

--- a/test/data/am-i-getting-minimum-wage-files.yml
+++ b/test/data/am-i-getting-minimum-wage-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/am-i-getting-minimum-wage.rb: 09d171f02c640624e59c6e520a10d4c4
-lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml: 11597a21c17b30c6ac48377f24be7dc7
+lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml: 83514f81c5403a4c493605e0a422e346
 test/data/am-i-getting-minimum-wage-questions-and-responses.yml: ddadb3fc5fc1d82d77f53fbc90752d89
 test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml: 3f047b0007e3432a77ea4e896ea763ea
 lib/smart_answer_flows/am-i-getting-minimum-wage/am_i_getting_minimum_wage.govspeak.erb: 28fb978cb4744e739d38bc1927f31d9e

--- a/test/data/am-i-getting-minimum-wage-files.yml
+++ b/test/data/am-i-getting-minimum-wage-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/am-i-getting-minimum-wage.rb: 09d171f02c640624e59c6e520a10d4c4
-lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml: d39839ccffd1c7e30695139f5fb91cea
+lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml: 11597a21c17b30c6ac48377f24be7dc7
 test/data/am-i-getting-minimum-wage-questions-and-responses.yml: ddadb3fc5fc1d82d77f53fbc90752d89
 test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml: 3f047b0007e3432a77ea4e896ea763ea
 lib/smart_answer_flows/am-i-getting-minimum-wage/am_i_getting_minimum_wage.govspeak.erb: 28fb978cb4744e739d38bc1927f31d9e

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/benefit-cap-calculator.rb: acc7833e5ea23ff3349753991fb6bb1e
-lib/smart_answer_flows/locales/en/benefit-cap-calculator.yml: 841fddf2c76ca5f8856979716488f9b7
+lib/smart_answer_flows/locales/en/benefit-cap-calculator.yml: f529cf71d32a7e802454eb79244a0a36
 test/data/benefit-cap-calculator-questions-and-responses.yml: 460336f2cf1f2acc62729ef5d831f25e
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 19c0bc207cde0d94c76b769b0da5d0bd
 lib/smart_answer_flows/benefit-cap-calculator/_dwp_contact_details.govspeak.erb: e562518b1b0289ec3e21c3174e9dab9c

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/calculate-married-couples-allowance.rb: 3d7bce5378b53ef23680c2f84c2a3459
-lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml: 4d69826e7196274c5e4f87001c441262
+lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml: d3000af873a9c53b2f62719b3d72e91d
 test/data/calculate-married-couples-allowance-questions-and-responses.yml: 1bbef5f2f30d470433bbb63f029881cd
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3bb53e4211718b8b1b7dacfaa52f3f49
 lib/smart_answer_flows/calculate-married-couples-allowance/_done_body.govspeak.erb: cb025369e07d6cdbedbfe7d54df39eee

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/calculate-state-pension.rb: a67c7e878b421309f2ed1e56de34c73a
-lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 80767794dcf1a1557b7d141cc66338bf
+lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 7fc5b03b5c96f178bcc86e1dd1178de6
 test/data/calculate-state-pension-questions-and-responses.yml: 8fe4d28d6b90ff1030ed15470d5b458f
 test/data/calculate-state-pension-responses-and-expected-results.yml: 61e8ccba31841f6616cf8b26f3da6ff9
 lib/smart_answer_flows/calculate-state-pension/_bus_pass_age.govspeak.erb: 5f1f77ef0e25bd24b4b8c6b4e30d4e92

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/calculate-state-pension.rb: a67c7e878b421309f2ed1e56de34c73a
-lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 7fc5b03b5c96f178bcc86e1dd1178de6
+lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 59b2577b5bd537db695a998d82264e7e
 test/data/calculate-state-pension-questions-and-responses.yml: 8fe4d28d6b90ff1030ed15470d5b458f
 test/data/calculate-state-pension-responses-and-expected-results.yml: 61e8ccba31841f6616cf8b26f3da6ff9
 lib/smart_answer_flows/calculate-state-pension/_bus_pass_age.govspeak.erb: 5f1f77ef0e25bd24b4b8c6b4e30d4e92

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/calculate-statutory-sick-pay.rb: 05819aff08d85a6a47bb78eaa3e0f008
-lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml: b59d7198145ce14376e12cf34e4a3c2b
+lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml: 8ae46a0e5f093bfb0378fff757f06ff5
 test/data/calculate-statutory-sick-pay-questions-and-responses.yml: 225bf0303e9d1c7fa1a929c24b543db3
 test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: 171dcf9d94ad17c5c64d6e776c73c69b
 lib/smart_answer_flows/calculate-statutory-sick-pay/_esa.govspeak.erb: 660031398fda690ed7b3e2186ba64060

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/calculate-your-child-maintenance.rb: 2dcb25a6f88c10ba535eb2279d4d9af6
-lib/smart_answer_flows/locales/en/calculate-your-child-maintenance.yml: 4fd50e1cfd937e338258643ff94fbb1b
+lib/smart_answer_flows/locales/en/calculate-your-child-maintenance.yml: dec73c1424c87441761d30d342a6a962
 test/data/calculate-your-child-maintenance-questions-and-responses.yml: 5e6e6e5307c1d385da9abfeb18900c51
 test/data/calculate-your-child-maintenance-responses-and-expected-results.yml: 30457fdf39035ab0333e3e9ad9fedec9
 lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: db4b69fb1cc09b84be5cd2b9d274a306

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/calculate-your-holiday-entitlement.rb: 6eec1440f4fc73734fb4d5a40861fbea
-lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml: 077bcd2fa3dbbb37d18e6a176fa18d8b
+lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml: 00d89a39772b13782cd22ab77cb4dc70
 test/data/calculate-your-holiday-entitlement-questions-and-responses.yml: a5d687911e6173e74f2b70af6a5ff7bd
 test/data/calculate-your-holiday-entitlement-responses-and-expected-results.yml: b7d4735ae33ef0dceeeb97c12019db84
 lib/smart_answer_flows/calculate-your-holiday-entitlement/_your_employer_with_rounding.govspeak.erb: 968b6d15a99334328227528f3feea6ba

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/calculate-your-holiday-entitlement.rb: 6eec1440f4fc73734fb4d5a40861fbea
-lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml: 00d89a39772b13782cd22ab77cb4dc70
+lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml: 0e0af2f45c9cca757b9d5fcb6fd3cc6d
 test/data/calculate-your-holiday-entitlement-questions-and-responses.yml: a5d687911e6173e74f2b70af6a5ff7bd
 test/data/calculate-your-holiday-entitlement-responses-and-expected-results.yml: b7d4735ae33ef0dceeeb97c12019db84
 lib/smart_answer_flows/calculate-your-holiday-entitlement/_your_employer_with_rounding.govspeak.erb: 968b6d15a99334328227528f3feea6ba

--- a/test/data/childcare-costs-for-tax-credits-files.yml
+++ b/test/data/childcare-costs-for-tax-credits-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: 2c5d3e00ecce939574dfa9663bf478f8
-lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml: d55246739a411a6e0142b32c47e905b5
+lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml: 1f9c5671b17aa97b6ea2472634481997
 test/data/childcare-costs-for-tax-credits-questions-and-responses.yml: 136aea3591662aa753c3c630546e68ad
 test/data/childcare-costs-for-tax-credits-responses-and-expected-results.yml: 7d90f3446d1e2c9551d7d363fbc4d639
 lib/smart_answer_flows/childcare-costs-for-tax-credits/call_helpline_detailed.govspeak.erb: f0026510aee646518b8f0a0ea1fffb99

--- a/test/data/inherits-someone-dies-without-will-files.yml
+++ b/test/data/inherits-someone-dies-without-will-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/inherits-someone-dies-without-will.rb: 9aa3d7ab45969c37401bf1cb5e341d6d
-lib/smart_answer_flows/locales/en/inherits-someone-dies-without-will.yml: 2de30f10cf713318638ef7cb8e7067b8
+lib/smart_answer_flows/locales/en/inherits-someone-dies-without-will.yml: e235c39f104b9d5502ccf4fcd0279c87
 test/data/inherits-someone-dies-without-will-questions-and-responses.yml: e2e1ed6d7bb7c839f6ae34db9697dbbd
 test/data/inherits-someone-dies-without-will-responses-and-expected-results.yml: df21c3f65db333e619238f3baa3e9859
 lib/smart_answer_flows/inherits-someone-dies-without-will/_next_step_links.govspeak.erb: 627d6f5ff3fc43ee3252f917437b5bdd

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/maternity-paternity-calculator.rb: 423c26577066ed7c7e70dcba85b60178
-lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: b31c9da8a6300bf40d18a74d4af9c294
+lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: fd41f943a23dc8641c1af9ca184e155d
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 0907253765bf7e265a2399281f2b6cc5
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: a59f6821dd5b949861ab6261840e58e4
 lib/smart_answer_flows/maternity-paternity-calculator/_must_be_on_payroll.govspeak.erb: e79accc3a0b6e9060fb3fbf9dd5848ad

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/maternity-paternity-calculator.rb: 423c26577066ed7c7e70dcba85b60178
-lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: f2f0a62274b2da95314a679437edfc1e
+lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: b31c9da8a6300bf40d18a74d4af9c294
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 0907253765bf7e265a2399281f2b6cc5
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: a59f6821dd5b949861ab6261840e58e4
 lib/smart_answer_flows/maternity-paternity-calculator/_must_be_on_payroll.govspeak.erb: e79accc3a0b6e9060fb3fbf9dd5848ad

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/maternity-paternity-calculator.rb: 423c26577066ed7c7e70dcba85b60178
-lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: fd41f943a23dc8641c1af9ca184e155d
+lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: 015accb15b39db02dc2763e63bb6071f
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 0907253765bf7e265a2399281f2b6cc5
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: a59f6821dd5b949861ab6261840e58e4
 lib/smart_answer_flows/maternity-paternity-calculator/_must_be_on_payroll.govspeak.erb: e79accc3a0b6e9060fb3fbf9dd5848ad

--- a/test/data/minimum-wage-calculator-employers-files.yml
+++ b/test/data/minimum-wage-calculator-employers-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/minimum-wage-calculator-employers.rb: 3acdd42973737a9c09ffa017cce5066c
-lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml: e062f4b64fb2c7dcf77eb23b66a4dbb8
+lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml: 367723aac57d3068c53e4cd6350fd8ff
 test/data/minimum-wage-calculator-employers-questions-and-responses.yml: ddadb3fc5fc1d82d77f53fbc90752d89
 test/data/minimum-wage-calculator-employers-responses-and-expected-results.yml: 3f047b0007e3432a77ea4e896ea763ea
 lib/smart_answer_flows/minimum-wage-calculator-employers/current_payment_above.govspeak.erb: ee8b1753fd772f0288d637d7b2732275

--- a/test/data/minimum-wage-calculator-employers-files.yml
+++ b/test/data/minimum-wage-calculator-employers-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/minimum-wage-calculator-employers.rb: 3acdd42973737a9c09ffa017cce5066c
-lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml: 367723aac57d3068c53e4cd6350fd8ff
+lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml: abcbe5ad62d6d13747de1426db6fe828
 test/data/minimum-wage-calculator-employers-questions-and-responses.yml: ddadb3fc5fc1d82d77f53fbc90752d89
 test/data/minimum-wage-calculator-employers-responses-and-expected-results.yml: 3f047b0007e3432a77ea4e896ea763ea
 lib/smart_answer_flows/minimum-wage-calculator-employers/current_payment_above.govspeak.erb: ee8b1753fd772f0288d637d7b2732275

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/pip-checker.rb: d1e6a1262d11e9413a43f4173462a174
-lib/smart_answer_flows/locales/en/pip-checker.yml: 985bc50d508bf8922e9de6e0703087b6
+lib/smart_answer_flows/locales/en/pip-checker.yml: 726e0dd42e3505341c9bfc7e4888d4a5
 test/data/pip-checker-questions-and-responses.yml: b1d68ebfb76a9e2793705c55b82294f5
 test/data/pip-checker-responses-and-expected-results.yml: a2c772b69a493d1844cfa32681057796
 lib/smart_answer_flows/pip-checker/_scheme_postcodes.govspeak.erb: c8c884fbd4111d7cc3b015cb2be57b5a

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/register-a-birth.rb: f0ce6a625e63f48a45b9a0bae2a7e4e0
-lib/smart_answer_flows/locales/en/register-a-birth.yml: dbee291f6049354e1e397d0ca74929a5
+lib/smart_answer_flows/locales/en/register-a-birth.yml: 30bf7c48f1cd56a55142f3844b348633
 test/data/register-a-birth-questions-and-responses.yml: d43385aee50bc3d3fa5550faf761a0ae
 test/data/register-a-birth-responses-and-expected-results.yml: c04b7ff4d2b3f05c04b4175fb5e50b2c
 lib/smart_answer_flows/register-a-birth/commonwealth_result.govspeak.erb: a7c70e3191f23f7e747cb45587e4825f

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/register-a-death.rb: 7dfecc0c75610535c6eb5ac80c04ca56
-lib/smart_answer_flows/locales/en/register-a-death.yml: 5f5da5068c2f0cdf1dbc80985fda3511
+lib/smart_answer_flows/locales/en/register-a-death.yml: ffcc2f13d596b97a34affddec1e50d60
 test/data/register-a-death-questions-and-responses.yml: 18aba16b4f569a17fbb81374dceaf265
 test/data/register-a-death-responses-and-expected-results.yml: 1d818139ced9c5e20262d144489bf090
 lib/smart_answer_flows/register-a-death/_footnote_oru_variants.govspeak.erb: 30e012cdde5aa7f4de5856a5db47a54c

--- a/test/data/report-a-lost-or-stolen-passport-files.yml
+++ b/test/data/report-a-lost-or-stolen-passport-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb: 6451dcf9cd6a29df60f3d272ce20d808
-lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml: 8bb218f43294aa0267418047f18038a6
+lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml: a4ea836942ec810fda031a8cc005a67a
 test/data/report-a-lost-or-stolen-passport-questions-and-responses.yml: cb7d64407b737eeb4924389f3bd335c6
 test/data/report-a-lost-or-stolen-passport-responses-and-expected-results.yml: 2ef8837f76907e72aadb198636a62078
 lib/smart_answer_flows/report-a-lost-or-stolen-passport/complete_LS01_form.govspeak.erb: 558860c7ddf7b7612af2bf793767f7dc

--- a/test/data/report-a-lost-or-stolen-passport-files.yml
+++ b/test/data/report-a-lost-or-stolen-passport-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb: 6451dcf9cd6a29df60f3d272ce20d808
-lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml: a4ea836942ec810fda031a8cc005a67a
+lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml: b3b8d31d025f554b1589e8c33fdd8c15
 test/data/report-a-lost-or-stolen-passport-questions-and-responses.yml: cb7d64407b737eeb4924389f3bd335c6
 test/data/report-a-lost-or-stolen-passport-responses-and-expected-results.yml: 2ef8837f76907e72aadb198636a62078
 lib/smart_answer_flows/report-a-lost-or-stolen-passport/complete_LS01_form.govspeak.erb: 558860c7ddf7b7612af2bf793767f7dc

--- a/test/data/simplified-expenses-checker-files.yml
+++ b/test/data/simplified-expenses-checker-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/simplified-expenses-checker.rb: 9f175300a38da904bee8bfacb26af032
-lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml: 92dcc0726b8a8fc148ab3aefeed6689e
+lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml: 0d33319472a914e79ddf4e2a73d97e3a
 test/data/simplified-expenses-checker-questions-and-responses.yml: 6b1c358b3730897b6cbefa9477ada15b
 test/data/simplified-expenses-checker-responses-and-expected-results.yml: 983e72657f76697beafb2dcbe4018bee
 lib/smart_answer_flows/simplified-expenses-checker/capital_allowance_result.govspeak.erb: 0f738efb15d8d63ebb9f824eb4010744

--- a/test/data/simplified-expenses-checker-files.yml
+++ b/test/data/simplified-expenses-checker-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/simplified-expenses-checker.rb: 9f175300a38da904bee8bfacb26af032
-lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml: 0d33319472a914e79ddf4e2a73d97e3a
+lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml: ae340f0f515377411d8710468afa4962
 test/data/simplified-expenses-checker-questions-and-responses.yml: 6b1c358b3730897b6cbefa9477ada15b
 test/data/simplified-expenses-checker-responses-and-expected-results.yml: 983e72657f76697beafb2dcbe4018bee
 lib/smart_answer_flows/simplified-expenses-checker/capital_allowance_result.govspeak.erb: 0f738efb15d8d63ebb9f824eb4010744

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/state-pension-topup.rb: 8abc41fb69e3af250612832a8b5a9999
-lib/smart_answer_flows/locales/en/state-pension-topup.yml: 9d00fb1541a4b42b5489d6d5291b8846
+lib/smart_answer_flows/locales/en/state-pension-topup.yml: 723be2cd9151b43de550a4972b36f862
 test/data/state-pension-topup-questions-and-responses.yml: f4f609a6e989f166616a05435c6993aa
 test/data/state-pension-topup-responses-and-expected-results.yml: 1207c6118839a3b13810038c57a20d4a
 lib/smart_answer_flows/state-pension-topup/outcome_pension_age_not_reached.govspeak.erb: 558d49584fe1ece4d36427740d381273

--- a/test/data/towing-rules-files.yml
+++ b/test/data/towing-rules-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/towing-rules.rb: 960a76bbcd812f8c20deecbc7779e1e1
-lib/smart_answer_flows/locales/en/towing-rules.yml: 5d8f677a11eeffe99c2a7fe3b2e54f9c
+lib/smart_answer_flows/locales/en/towing-rules.yml: 3c95f8e64ea39d727386928e8becc8f5
 test/data/towing-rules-questions-and-responses.yml: 09c8f43d5353fa6248658a27982ea5a2
 test/data/towing-rules-responses-and-expected-results.yml: ab907e6d438f7f2f6fc76bb1b219e6d7
 lib/smart_answer_flows/towing-rules/apply_for_provisional_bus.govspeak.erb: 7e9f6d62486894f8537e09ea07b07a43

--- a/test/data/uk-benefits-abroad-files.yml
+++ b/test/data/uk-benefits-abroad-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/uk-benefits-abroad.rb: 86c9d302a080b228a042abe87b059cbd
-lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml: 440f9eeaf47a6ea75ae1c0cc578078ed
+lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml: 3883941cbccbef17e1d93a456777bc08
 test/data/uk-benefits-abroad-questions-and-responses.yml: 17973c7c16f38d7988ff1a5b76d3261a
 test/data/uk-benefits-abroad-responses-and-expected-results.yml: 37bfb8e7982e15f0f907881bf1130ce3
 lib/smart_answer_flows/uk-benefits-abroad/_tax_credits_already_abroad_helpline.govspeak.erb: d79b1b09c2fe01c66cdda028a7679b8b

--- a/test/fixtures/smart_answer_flows/locales/en/checkbox-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/checkbox-sample.yml
@@ -8,3 +8,4 @@ en-GB:
           peppers: "Peppers"
           ice_cream: "Ice Cream!!!"
           pepperoni: "Pepperoni"
+          none: "None"

--- a/test/fixtures/smart_answer_flows/locales/en/data-partial-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/data-partial-sample.yml
@@ -1,3 +1,7 @@
 en-GB:
   flow:
     data-partial-sample:
+      what_are_you_testing?:
+        options:
+          data_partial_with_scalar: 'Data partial with scalar'
+          data_partial_with_array: 'Data partial with array'

--- a/test/fixtures/smart_answers_controller_test/cheese.yml
+++ b/test/fixtures/smart_answers_controller_test/cheese.yml
@@ -1,0 +1,6 @@
+en-GB:
+  flow:
+    cheese:
+      what?:
+        options:
+          "cheese": "Cheese"

--- a/test/fixtures/smart_answers_controller_test/sample.yml
+++ b/test/fixtures/smart_answers_controller_test/sample.yml
@@ -1,0 +1,11 @@
+en-GB:
+  flow:
+    sample:
+      do_you_like_chocolate?:
+        options:
+          "yes": "Yes"
+          "no": "No"
+      do_you_like_jam?:
+        options:
+          "yes": "Yes"
+          "no": "No"

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -107,19 +107,25 @@ class SmartAnswersControllerTest < ActionController::TestCase
     end
 
     should "display first question after starting" do
-      get :show, id: 'sample', started: 'y'
+      using_translation_file(fixture_file('smart_answers_controller_test/sample.yml')) do
+        get :show, id: 'sample', started: 'y'
+      end
       assert_select ".step.current h2", /Do you like chocolate\?/
       assert_select "input[name=response][value=yes]"
       assert_select "input[name=response][value=no]"
     end
 
     should "show outcome when smart answer is complete so that 'smartanswerOutcome' JS event is fired" do
-      get :show, id: 'sample', started: 'y', responses: 'yes'
+      using_translation_file(fixture_file('smart_answers_controller_test/sample.yml')) do
+        get :show, id: 'sample', started: 'y', responses: 'yes'
+      end
       assert_select ".outcome"
     end
 
     should "have meta robots noindex on question pages" do
-      get :show, id: 'sample', started: 'y'
+      using_translation_file(fixture_file('smart_answers_controller_test/sample.yml')) do
+        get :show, id: 'sample', started: 'y'
+      end
       assert_select "head meta[name=robots][content=noindex]"
     end
 
@@ -404,7 +410,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
     context "multiple choice question" do
       setup do
         @flow = SmartAnswer::Flow.new do
-          name "sample"
+          name "cheese"
           multiple_choice :what? do
             option cheese: :done
           end
@@ -416,7 +422,9 @@ class SmartAnswersControllerTest < ActionController::TestCase
       context "format=json" do
         context "no response given" do
           should "show an error message" do
-            submit_json_response(nil)
+            using_translation_file(fixture_file('smart_answers_controller_test/cheese.yml')) do
+              submit_json_response(nil)
+            end
             data = JSON.parse(response.body)
             doc = Nokogiri::HTML(data['html_fragment'])
             assert doc.css('.error').size > 0, "#{data['html_fragment']} should contain .error"
@@ -431,10 +439,14 @@ class SmartAnswersControllerTest < ActionController::TestCase
     end
 
     context "a response has been accepted" do
-      setup { get :show, id: 'sample', started: 'y', responses: "no" }
+      setup do
+        using_translation_file(fixture_file('smart_answers_controller_test/sample.yml')) do
+          get :show, id: 'sample', started: 'y', responses: "no"
+        end
+      end
 
       should "show response summary" do
-        assert_select ".done-questions", /Do you like chocolate\?\s+no/
+        assert_select ".done-questions", /Do you like chocolate\?\s+No/
       end
 
       should "show the next question" do
@@ -450,7 +462,9 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     context "format=json" do
       should "render content without layout" do
-        get :show, id: 'sample', started: 'y', responses: "no", format: "json"
+        using_translation_file(fixture_file('smart_answers_controller_test/sample.yml')) do
+          get :show, id: 'sample', started: 'y', responses: "no", format: "json"
+        end
         data = JSON.parse(response.body)
         assert_equal '/sample/y/no', data['url']
         doc = Nokogiri::HTML(data['html_fragment'])
@@ -503,14 +517,18 @@ class SmartAnswersControllerTest < ActionController::TestCase
     context "debugging" do
       should "render debug information on the page when enabled" do
         @controller.stubs(:debug?).returns(true)
-        get :show, id: 'sample', started: 'y', responses: "no", debug: "1"
+        using_translation_file(fixture_file('smart_answers_controller_test/sample.yml')) do
+          get :show, id: 'sample', started: 'y', responses: "no", debug: "1"
+        end
 
         assert_select "pre.debug"
       end
 
       should "not render debug information on the page when not enabled" do
         @controller.stubs(:debug?).returns(false)
-        get :show, id: 'sample', started: 'y', responses: "no", debug: nil
+        using_translation_file(fixture_file('smart_answers_controller_test/sample.yml')) do
+          get :show, id: 'sample', started: 'y', responses: "no", debug: nil
+        end
 
         assert_select "pre.debug", false, "The page should not render debug information"
       end

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -59,7 +59,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
           within 'td.previous-question-title' do
             assert_page_has_content "What do you want on your pizza?"
           end
-          within('td.previous-question-body') { assert_page_has_content "none" }
+          within('td.previous-question-body') { assert_page_has_content "None" }
           within('.link-right') { assert page.has_link?("Change", href: "/checkbox-sample/y?previous_response=none") }
         end
       end

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -160,7 +160,7 @@ module SmartAnswer
       assert_equal 'response', presenter.to_response('answer-text')
     end
 
-    test "Options can be looked up from translation file" do
+    test "Options are looked up from translation file" do
       question = Question::MultipleChoice.new(nil, :example_question?)
       question.option yes: :yay
       question.option no: :nay
@@ -172,20 +172,13 @@ module SmartAnswer
       assert_equal "no", presenter.options[1].value
     end
 
-    test "Options can be looked up from default values in translation file" do
+    test "Exception is raised if option translation is missing" do
       question = Question::MultipleChoice.new(nil, :example_question?)
-      question.option maybe: :mumble
+      question.option :missing
       presenter = QuestionPresenter.new("flow.test", question)
 
-      assert_equal "Mebbe", presenter.options[0].label
-    end
-
-    test "Options label falls back to option value" do
-      question = Question::MultipleChoice.new(nil, :example_question?)
-      question.option something: :mumble
-      presenter = QuestionPresenter.new("flow.test", question)
-
-      assert_equal "something", presenter.options[0].label
+      e = assert_raises(I18n::MissingTranslationData) { presenter.options[0].label }
+      assert_equal "translation missing: en-GB.flow.test.example_question?.options.missing", e.message
     end
 
     test "Avoids displaying the year for a date question when the year is 0" do


### PR DESCRIPTION
Previously if an option for a question was not specified at the question-level in the YAML file, the code would first fallback to flow-level options and, failing that, to the string version of the option key.

The first fallback seems to have been used to DRY up the YAML files, but I think the way it works is a bit surprising and definitely confusing in places e.g. when some options are defined at the question level, but others are defined at the flow level. The reduction in duplication is minimal and I think there are probably better ways to DRY up the code (if it's even a good idea).

The second fallback is hardly used and strikes me as being a bit dangerous. Where it's done intentionally, it leaks presentation details into non-presentation code. And where it's done accidentally (i.e. because someone forgot to define the option text), the page will render without error, but probably with unexpected option text.

I seems a lot better and simpler to require that all question options are defined explicitly at the question level and if one is not then to fail fast with an exception. This PR makes that change and updates all the question option definitions accordingly.

Another advantage of this change is that it makes the content for each question more self-contained, which should make it easier if we decide to split the content for each question into its own file.

Although this includes a lot of commits, they are all small and many of the are very similar.
