### PR TITLE
Remove unused code from pay-leave-for-parents

### DIFF
--- a/lib/smartdown_flows/pay-leave-for-parents/snippets/both-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents/snippets/both-shared-pay.txt
@@ -4,12 +4,6 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-$IF range_in_2013_2014_fin_year?(due_date)
-
-Mother’s shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
-$ENDIF
-
 $IF range_in_2014_2015_fin_year?(due_date)
 
 Mother’s shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
@@ -22,15 +16,9 @@ Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.5
 
 $ENDIF
 
-$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+$IF NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
 Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
-$ENDIF
-
-$IF range_in_2013_2014_fin_year?(due_date)
-
-Partner's shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
@@ -46,7 +34,7 @@ Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58
 
 $ENDIF
 
-$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+$IF NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
 Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 

--- a/lib/smartdown_flows/pay-leave-for-parents/snippets/mat-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents/snippets/mat-shared-pay.txt
@@ -4,12 +4,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-$IF range_in_2013_2014_fin_year?(due_date)
-
-Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
-$ENDIF
-
 $IF range_in_2014_2015_fin_year?(due_date)
 
 Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
@@ -22,7 +16,7 @@ Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week 
 
 $ENDIF
 
-$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+$IF NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 

--- a/lib/smartdown_flows/pay-leave-for-parents/snippets/pat-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents/snippets/pat-shared-pay.txt
@@ -4,12 +4,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-$IF range_in_2013_2014_fin_year?(due_date)
-
-Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
-$ENDIF
-
 $IF range_in_2014_2015_fin_year?(due_date)
 
 Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
@@ -22,7 +16,7 @@ Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week 
 
 $ENDIF
 
-$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+$IF NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 


### PR DESCRIPTION
I came across this unused code while adding regression tests for pay-leave-for-parents.

I think it makes sense to remove it before converting pay-leave-for-parents to a Ruby Smart Answer.