### PR TITLE
Fix missing question option translations

### DIFF
--- a/lib/smart_answer_flows/locales/en/energy-grants-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/energy-grants-calculator.yml
@@ -23,6 +23,7 @@ en-GB:
           property: You own your property
           permission: You rent privately but have permission from the owner to make energy saving improvements (eg upgrade the boiler)
           social_housing: You’re a social housing tenant
+          none: none
 
 # Q2A
       what_are_your_circumstances_without_bills_help?:
@@ -33,6 +34,7 @@ en-GB:
           benefits: You’re getting benefits
           property: You own your property
           permission: You rent privately but have permission from the owner to install or upgrade the boiler
+          none: none
         body: |
           Social housing tenants should talk to their social housing provider if they want to improve their energy efficiency.
         foot: |

--- a/lib/smart_answer_flows/locales/en/student-finance-forms.yml
+++ b/lib/smart_answer_flows/locales/en/student-finance-forms.yml
@@ -18,7 +18,7 @@ en-GB:
       form_needed_for_1?:
         title: What do you need the form for?
         options:
-          apply-loans_grants: Apply for student loans and grants
+          apply-loans-grants: Apply for student loans and grants
           proof-identity: Send proof of identity
           income-details: Send parent or partner’s income detail - eg PFF2 or CYI
           apply-dsa: Apply for Disabled Students’ Allowances
@@ -47,5 +47,3 @@ en-GB:
         options:
           course-start-before-01092012: 'Yes'
           course-start-after-01092012: 'No'
-
-

--- a/test/artefacts/student-finance-forms/uk-full-time.html
+++ b/test/artefacts/student-finance-forms/uk-full-time.html
@@ -44,7 +44,7 @@
     <li>
         <label for="response_0" class="selectable">
           <input type="radio" name="response" id="response_0" value="apply-loans-grants" />
-          apply-loans-grants
+          Apply for student loans and grants
         </label>
     </li>
     <li>

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants.html
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants.html
@@ -93,7 +93,7 @@
     <tr class="section">
     <td class="previous-question-title">What do you need the form for?</td>
       <td class="previous-question-body">
-      apply-loans-grants</td>
+      Apply for student loans and grants</td>
 
       <td class="link-right">
           <a href="/student-finance-forms/y/uk-full-time?previous_response=apply-loans-grants">

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516.html
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516.html
@@ -94,7 +94,7 @@
     <tr class="section">
     <td class="previous-question-title">What do you need the form for?</td>
       <td class="previous-question-body">
-      apply-loans-grants</td>
+      Apply for student loans and grants</td>
 
       <td class="link-right">
           <a href="/student-finance-forms/y/uk-full-time?previous_response=apply-loans-grants">

--- a/test/data/energy-grants-calculator-files.yml
+++ b/test/data/energy-grants-calculator-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/energy-grants-calculator.rb: 167b1c7372c43f754a91ce0dab85dede
-lib/smart_answer_flows/locales/en/energy-grants-calculator.yml: cd46192351d40f256538061d41689a04
+lib/smart_answer_flows/locales/en/energy-grants-calculator.yml: dd640cd1e93bbdac129b3863552cb554
 test/data/energy-grants-calculator-questions-and-responses.yml: e725aa49320518369f4fdc601cd217b2
 test/data/energy-grants-calculator-responses-and-expected-results.yml: 7700bd72da2da267ae960e5d7eac91c2
 lib/smart_answer_flows/energy-grants-calculator/_cold_weather_payment.govspeak.erb: 9976373a42df06bdb65e902166fb1d49

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/student-finance-forms.rb: ba440a386aa4ebdf717e5a67f95869f2
-lib/smart_answer_flows/locales/en/student-finance-forms.yml: c171e62957dbe94cca7f6bb4aceb3b91
+lib/smart_answer_flows/locales/en/student-finance-forms.yml: 2ea8adb5e2808a8a3de5d95ac18f1326
 test/data/student-finance-forms-questions-and-responses.yml: ec2ad38a9df75dd2606b9f979afd5066
 test/data/student-finance-forms-responses-and-expected-results.yml: fb765941838abb1e05b2d874049c7db1
 lib/smart_answer_flows/student-finance-forms/_circumstances_changed_co2_form.govspeak.erb: 236d81f3660a1958bb0dd3a8f229baf4


### PR DESCRIPTION
These changes should've been made in #2005. They should fix the [broken regression test build](https://ci-new.alphagov.co.uk/job/govuk_smart_answers_regressions/1187).