### PR TITLE
Fix I18n::MissingTranslationData exception for checkbox 'none' option

### DIFF
--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -1,7 +1,11 @@
 class CheckboxQuestionPresenter < QuestionPresenter
   def response_labels(values)
     values.split(',').map do |value|
-      translate_option(value)
+      if value == SmartAnswer::Question::Checkbox::NONE_OPTION
+        value.to_s
+      else
+        translate_option(value)
+      end
     end
   end
 

--- a/test/fixtures/smart_answer_flows/locales/en/checkbox-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/checkbox-sample.yml
@@ -8,4 +8,3 @@ en-GB:
           peppers: "Peppers"
           ice_cream: "Ice Cream!!!"
           pepperoni: "Pepperoni"
-          none: "None"

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -59,7 +59,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
           within 'td.previous-question-title' do
             assert_page_has_content "What do you want on your pizza?"
           end
-          within('td.previous-question-body') { assert_page_has_content "None" }
+          within('td.previous-question-body') { assert_page_has_content "none" }
           within('.link-right') { assert page.has_link?("Change", href: "/checkbox-sample/y?previous_response=none") }
         end
       end


### PR DESCRIPTION
This has been a problem since #2005, but it only came to light after a
production deployment. Here are couple of examples of the exceptions
we saw:

* https://errbit.publishing.service.gov.uk/apps/533c35ae0da1159384044f5f/problems/561f85d56578634c6add1000
* https://errbit.publishing.service.gov.uk/apps/533c35ae0da1159384044f5f/problems/561f83c76578634c6a341000

Checkbox questions have an implicit 'none' response if the user doesn't select
any of the checkboxes. `CheckboxQuestionPresenter#response_labels` translates
the options for display in the 'Previous answers' section at the bottom of the
page.

When the translation fallbacks were removed in #2005, a
`I18n::MissingTranslationData` was being raised when the user did not select
any checkboxes.

Unfortunately, [this commit][1] added a translation for the 'none' option even
though the [`CheckboxSampleFlow`][2] didn't have an explicit `:none` option.
Note also that the `assert_page_has_content` was changed to check for 'None'
instead of 'none'.

In this commit, I've removed the translation for the 'none' option which gave
me a failing test which replicated the problem we'd seen in production.

I've fixed the failing test by adding an `if/else` statement to
`CheckboxQuestionPresenter#response_labels` which effectively reintroduces
the translation fallback in this very specific case.

I'm not totally happy with this solution, but hopefully it'll do for now.

You can see that the problem is fixed by visiting these two example URLs:

* https://www.gov.uk/calculate-statutory-sick-pay/y/none
* https://www.gov.uk/student-finance-calculator/y/2016-2017/uk-full-time/9000.0/away-outside-london/25000.0/none

There should be no exception and you should see "none" in the previous answers.

[1]: https://github.com/alphagov/smart-answers/commit/f50ec82cee41eabb035a592cd15ba7d54b0ae62d
[2]: https://github.com/alphagov/smart-answers/blob/master/test/fixtures/smart_answer_flows/checkbox-sample.rb