### PR TITLE
Update relative links in docs

### DIFF
--- a/doc/archiving.md
+++ b/doc/archiving.md
@@ -1,6 +1,6 @@
 # How to archive a Smart Answer
 
-To prevent a Smart Answer being [registered with Panopticon](../blob/master/lib/tasks/panopticon.rake) you will need to change the status of the Smart Answer flow, or remove the Smart Answer flow entirely.
+To prevent a Smart Answer being [registered with Panopticon](../lib/tasks/panopticon.rake) you will need to change the status of the Smart Answer flow, or remove the Smart Answer flow entirely.
 
 As archiving tends not to be temporary, it's preferable to remove the flow entirely - and it can always be recovered from `git` history.
 

--- a/doc/merging-content-prs.md
+++ b/doc/merging-content-prs.md
@@ -3,7 +3,7 @@
 ### Introduction
 
 Members of the Content Team do not have permission to contribute directly to the canonical repository, so when they want to make a change, they create a pull request using a fork of the repository. Also since they don't usually have a Ruby environment setup on their local machine, they will not be able to update
-files relating to the regression tests e.g. file checksums, Govspeak artefacts, etc. See documentation about [adding regression tests](#adding-regression-tests-to-smart-answers) for more information.
+files relating to the regression tests e.g. file checksums, Govspeak artefacts, etc. See documentation about [adding regression tests](adding-new-regression-tests.md) for more information.
 
 ## Instructions
 

--- a/doc/merging-content-prs.md
+++ b/doc/merging-content-prs.md
@@ -41,4 +41,4 @@ files relating to the regression tests e.g. file checksums, Govspeak artefacts, 
 
         $ git push origin <branch-on-local-repo>
 
-See documentation on [regression tests](doc/regression-tests.md) for further details.
+See documentation on [regression tests](regression-tests.md) for further details.

--- a/doc/regression-tests.md
+++ b/doc/regression-tests.md
@@ -35,7 +35,7 @@ The regression test fails if any of the following is true:
 * not all nodes are exercised by the test data
 * the checksum data is out-of-date (see below)
 
-If you've added extra questions, responses or outcomes, then you should change the `test/data` files to exercise the new paths through the flow. See the instructions for [adding new regression tests](doc/adding-new-regression-tests.md)
+If you've added extra questions, responses or outcomes, then you should change the `test/data` files to exercise the new paths through the flow. See the instructions for [adding new regression tests](adding-new-regression-tests.md)
 
 If there's a difference in the artefacts, you need to carefully review the changes to the artefacts to make sure they all relate to the changes you have made before committing them.
 

--- a/doc/smart-answer-flows.md
+++ b/doc/smart-answer-flows.md
@@ -260,4 +260,4 @@ This is how we were previously writing integration tests for Smart Answer flows.
 
 ### Adding regression tests to Smart Answers
 
-We're not imagining introducing new regression tests but I think [these instructions](doc/adding-new-regression-tests.md) are still useful while we still have them in the project.
+We're not imagining introducing new regression tests but I think [these instructions](adding-new-regression-tests.md) are still useful while we still have them in the project.

--- a/doc/smart-answer-flows.md
+++ b/doc/smart-answer-flows.md
@@ -67,7 +67,7 @@ next_node(:red)
 
 The `responded_with` function actually returns a [predicate](http://en.wikipedia.org/wiki/Predicate_%28mathematical_logic%29) which will be invoked during processing. If the predicate returns `true` then the `:green` node will be next, otherwise the next rule will be evaluated. In this case the next rule says `:red` is the next node with no condition.
 
-See [Smart Answer predicates](./smart-answers-predicates.md) for more detailed information about this style.
+See [Smart Answer predicates](smart-answers-predicates.md) for more detailed information about this style.
 
 #### DEPRECATED: Using Multiple Choice shortcut
 


### PR DESCRIPTION
Fixes a set of broken links and anchors in the markdown docs, and removes a couple of unnecessary elements in relative paths linking various documents and files.