### PR TITLE
Add missing question option translations for PartYearProfitTaxCreditsFlow

### DIFF
--- a/lib/smart_answer_flows/locales/en/part-year-profit-tax-credits.yml
+++ b/lib/smart_answer_flows/locales/en/part-year-profit-tax-credits.yml
@@ -9,9 +9,15 @@ en-GB:
         title: Have you stopped trading?
         hint: This means you’re no longer running your business.
         error_message: You need to select yes or no to continue.
+        options:
+          "yes": "Yes"
+          "no": "No"
       did_you_start_trading_before_the_relevant_accounting_year?:
         title: Did you start trading before %{accounting_year_begins_on}?
         error_message: You need to select yes or no to continue.
+        options:
+          "yes": "Yes"
+          "no": "No"
       when_did_you_stop_trading?:
         title: When did you stop trading?
         hint:
@@ -26,6 +32,9 @@ en-GB:
       do_your_accounts_cover_a_12_month_period?:
         title: Do your accounts cover the 12 month period up to %{accounting_year_ends_on}?
         error_message: You need to select yes or no to continue.
+        options:
+          "yes": "Yes"
+          "no": "No"
       when_did_you_start_trading?:
         title: "When did you start trading?"
         hint:

--- a/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
+++ b/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
@@ -42,6 +42,10 @@ module SmartAnswer
         @presenter = QuestionPresenter.new(@i18n_prefix, question, @state)
       end
 
+      should 'have options with labels' do
+        assert_equal({ 'yes' => 'Yes', 'no' => 'No' }, values_vs_labels(@presenter.options))
+      end
+
       should 'have a default error message' do
         @state.error = 'error-message'
         assert_equal 'You need to select yes or no to continue.', @presenter.error
@@ -53,6 +57,10 @@ module SmartAnswer
         question = @flow.node(:did_you_start_trading_before_the_relevant_accounting_year?)
         @state = SmartAnswer::State.new(question)
         @presenter = QuestionPresenter.new(@i18n_prefix, question, @state)
+      end
+
+      should 'have options with labels' do
+        assert_equal({ 'yes' => 'Yes', 'no' => 'No' }, values_vs_labels(@presenter.options))
       end
 
       should 'have a default error message' do
@@ -72,6 +80,10 @@ module SmartAnswer
       should 'display title with interpolated basis_period_ends_on' do
         expected = "Do your accounts cover the 12 month period up to  5 April 2016?"
         assert_equal expected, @presenter.title
+      end
+
+      should 'have options with labels' do
+        assert_equal({ 'yes' => 'Yes', 'no' => 'No' }, values_vs_labels(@presenter.options))
       end
 
       should 'have a default error message' do
@@ -218,6 +230,12 @@ module SmartAnswer
           assert_match 'Your business stopped trading on:  5 April 2016', @body
         end
       end
+    end
+
+    private
+
+    def values_vs_labels(options)
+      options.inject({}) { |h, o| h[o.value] = o.label; h }
     end
   end
 end


### PR DESCRIPTION
This flow was relying on the fallback to the option key which was removed
in #2005. The following exception has just occurred in production [1]:

    I18n::MissingTranslationData: translation missing:
      en-GB.flow.part-year-profit-tax-credits.have_you_stopped_trading?.options.yes

This commit adds unit tests which would've picked up the problem and adds
the missing translations.

[1]: https://errbit.publishing.service.gov.uk/apps/533c35ae0da1159384044f5f/problems/56233f4b6578634c6c971600