### PR TITLE
Add step to apply for an overseas passport for child in Afghanistan

### DIFF
--- a/lib/smart_answer_flows/overseas-passports/outcomes/_how_to_apply.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/outcomes/_how_to_apply.govspeak.erb
@@ -6,7 +6,7 @@
   3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
   4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
 
-  <% if %w(bangladesh india pakistan).include?(current_location) && child_or_adult == 'child' && application_action == 'applying' %>
+  <% if %w(afghanistan bangladesh india pakistan).include?(current_location) && child_or_adult == 'child' && application_action == 'applying' %>
     5. Fill in the [parent contact details form](/government/publications/parents-contact-details-for-a-childs-first-british-passport) if either of the child's parents live in a different country to the child.
   <% end %>
 

--- a/test/artefacts/overseas-passports/afghanistan/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/afghanistan/applying/adult/afghanistan.txt
@@ -1,0 +1,78 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 months from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £106.01  |
+| Adult jumbo 48-page passport | £91.00 | £114.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/afghanistan/applying/adult/south-africa.txt
@@ -1,0 +1,80 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 months from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £106.01  |
+| Adult jumbo 48-page passport | £91.00 | £114.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-2)^
+
+^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/afghanistan/applying/child/afghanistan.txt
@@ -1,0 +1,79 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 months from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £76.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+5. Fill in the [parent contact details form](/government/publications/parents-contact-details-for-a-childs-first-british-passport) if either of the child's parents live in a different country to the child.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/afghanistan/applying/child/south-africa.txt
@@ -1,0 +1,81 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 months from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £76.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+5. Fill in the [parent contact details form](/government/publications/parents-contact-details-for-a-childs-first-british-passport) if either of the child's parents live in a different country to the child.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-2)^
+
+^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_new/adult.txt
@@ -1,0 +1,82 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £106.01  |
+| Adult jumbo 48-page passport | £91.00 | £114.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You must also bring your current passport with you when you apply, and a full colour photocopy of the entire passport (every page including blank pages).
+
+You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring your existing passport as photo ID.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_new/child.txt
@@ -1,0 +1,81 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £76.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You must also bring your current passport with you when you apply, and a full colour photocopy of the entire passport (every page including blank pages).
+
+You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring your existing passport as photo ID.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_old/adult/afghanistan.txt
@@ -1,0 +1,78 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 months from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £106.01  |
+| Adult jumbo 48-page passport | £91.00 | £114.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_old/adult/south-africa.txt
@@ -1,0 +1,80 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 months from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £106.01  |
+| Adult jumbo 48-page passport | £91.00 | £114.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-2)^
+
+^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_old/child/afghanistan.txt
@@ -1,0 +1,77 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 months from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £76.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/afghanistan/renewing_old/child/south-africa.txt
@@ -1,0 +1,79 @@
+
+
+## How long it takes
+
+Your application will take **at least** 6 months from when it’s received by Her Majesty’s Passport Office in the UK.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £76.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-2)^
+
+^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/afghanistan/replacing/adult.txt
@@ -1,0 +1,80 @@
+
+
+## How long it takes
+
+Your application will take **at least** 14 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+If you haven’t already reported the loss or theft, you must include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your passport application.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Adult standard 32-page passport | £83.00 | £106.01  |
+| Adult jumbo 48-page passport | £91.00 | £114.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/artefacts/overseas-passports/afghanistan/replacing/child.txt
+++ b/test/artefacts/overseas-passports/afghanistan/replacing/child.txt
@@ -1,0 +1,79 @@
+
+
+## How long it takes
+
+Your application will take **at least** 14 weeks from when it’s received by Her Majesty’s Passport Office in the UK.
+
+If you haven’t already reported the loss or theft, you must include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your passport application.
+
+You may have to attend an interview.
+
+Applications will take longer if:
+
+- Her Majesty’s Passport Office needs to ask you for more information or documents
+- the photographs you send are rejected
+
+Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+## Cost
+
+You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+| Passport type | Passport fee | Total to pay (including courier fee) |
+|---------------|--------------|--------------------------------------|
+| Child passport | £53.00 | £76.01 |
+
+Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+## How to apply
+
+1. Download the application form.
+2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
+
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
+
+## Making your application
+
+You must apply in person. If you’re unable to, someone else can go on your behalf.
+You must bring photo ID with you.
+
+Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+$A
+UK Visa Application Centre
+14-B, Sadiq Plaza G-9 Markaz
+Islamabad
+Pakistan
+$A
+$C
+Email: <islamabad.hmpo@gerrys.com.pk>
+$C
+
+## Getting your passport
+
+Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+
+They will contact you - using the details on your application form - when your passport is ready to collect.
+
+You must bring photo ID with you.
+
+##Contact the Passport Adviceline
+
+$C
+Telephone: +44 (0) 300 222 0000\\
+Monday to Friday, 8am to 8pm (UK time)\\
+Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+$C
+
+[Find out about call charges](/call-charges)
+

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,12 +1,12 @@
 ---
 lib/smart_answer_flows/overseas-passports.rb: 613a11e9f07f779dab45b83adb392ff6
 lib/smart_answer_flows/locales/en/overseas-passports.yml: e3c7aa9bb85ea0e1f34a562f9954e5cd
-test/data/overseas-passports-questions-and-responses.yml: 491ce868a2637b34ea5ad331d7af61c7
-test/data/overseas-passports-responses-and-expected-results.yml: 37592a439d90761b2cd86823c8bcf220
+test/data/overseas-passports-questions-and-responses.yml: 4c6749fcf0a37deb135fc8c94fa52bc7
+test/data/overseas-passports-responses-and-expected-results.yml: aca0c7e72dfbf84606a47cb7d6d7f758
 lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb: 748ca30b4392d385f1546569cfc949fe
 lib/smart_answer_flows/overseas-passports/outcomes/_getting_your_passport.govspeak.erb: 64f5a79f0445cc546af042f7b52d41b0
 lib/smart_answer_flows/overseas-passports/outcomes/_how_long.govspeak.erb: 2c3894ba2e5d37db57fd27ff20407f1a
-lib/smart_answer_flows/overseas-passports/outcomes/_how_to_apply.govspeak.erb: 4055cc15a683d93cea07bacdc81d1051
+lib/smart_answer_flows/overseas-passports/outcomes/_how_to_apply.govspeak.erb: aa0dbabc3e94b809e94c5d12cde5a590
 lib/smart_answer_flows/overseas-passports/outcomes/_making_your_application.govspeak.erb: 8bc6a8156caa75ef8a6600d50f9404db
 lib/smart_answer_flows/overseas-passports/outcomes/_passport_adviceline_contacts.govspeak.erb: 2e10343ed7a17de7b3a5cd4b64af88b3
 lib/smart_answer_flows/overseas-passports/outcomes/apply_in_neighbouring_country.govspeak.erb: 15cd9b890f53c2158637042249abcf1c

--- a/test/data/overseas-passports-questions-and-responses.yml
+++ b/test/data/overseas-passports-questions-and-responses.yml
@@ -23,6 +23,7 @@
 - north-korea # emergency_travel_help_#{current_location}
 - the-occupied-palestinian-territories # which_opt?
 - hong-kong # hong_kong_id_required
+- afghanistan # renewing_replacing_applying?
 :which_opt?:
 - gaza
 - jerusalem-or-westbank

--- a/test/data/overseas-passports-responses-and-expected-results.yml
+++ b/test/data/overseas-passports-responses-and-expected-results.yml
@@ -3190,3 +3190,152 @@
   - child
   :next_node: :ips_application_result_online
   :outcome_node: true
+- :current_node: :which_country_are_you_in?
+  :responses:
+  - afghanistan
+  :next_node: :renewing_replacing_applying?
+  :outcome_node: false
+- :current_node: :renewing_replacing_applying?
+  :responses:
+  - afghanistan
+  - renewing_new
+  :next_node: :child_or_adult_passport?
+  :outcome_node: false
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - afghanistan
+  - renewing_new
+  - adult
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - afghanistan
+  - renewing_new
+  - child
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :renewing_replacing_applying?
+  :responses:
+  - afghanistan
+  - renewing_old
+  :next_node: :child_or_adult_passport?
+  :outcome_node: false
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - afghanistan
+  - renewing_old
+  - adult
+  :next_node: :country_of_birth?
+  :outcome_node: false
+- :current_node: :country_of_birth?
+  :responses:
+  - afghanistan
+  - renewing_old
+  - adult
+  - afghanistan
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - afghanistan
+  - renewing_old
+  - adult
+  - south-africa
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - afghanistan
+  - renewing_old
+  - child
+  :next_node: :country_of_birth?
+  :outcome_node: false
+- :current_node: :country_of_birth?
+  :responses:
+  - afghanistan
+  - renewing_old
+  - child
+  - afghanistan
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - afghanistan
+  - renewing_old
+  - child
+  - south-africa
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :renewing_replacing_applying?
+  :responses:
+  - afghanistan
+  - applying
+  :next_node: :child_or_adult_passport?
+  :outcome_node: false
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - afghanistan
+  - applying
+  - adult
+  :next_node: :country_of_birth?
+  :outcome_node: false
+- :current_node: :country_of_birth?
+  :responses:
+  - afghanistan
+  - applying
+  - adult
+  - afghanistan
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - afghanistan
+  - applying
+  - adult
+  - south-africa
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - afghanistan
+  - applying
+  - child
+  :next_node: :country_of_birth?
+  :outcome_node: false
+- :current_node: :country_of_birth?
+  :responses:
+  - afghanistan
+  - applying
+  - child
+  - afghanistan
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :country_of_birth?
+  :responses:
+  - afghanistan
+  - applying
+  - child
+  - south-africa
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :renewing_replacing_applying?
+  :responses:
+  - afghanistan
+  - replacing
+  :next_node: :child_or_adult_passport?
+  :outcome_node: false
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - afghanistan
+  - replacing
+  - adult
+  :next_node: :ips_application_result
+  :outcome_node: true
+- :current_node: :child_or_adult_passport?
+  :responses:
+  - afghanistan
+  - replacing
+  - child
+  :next_node: :ips_application_result
+  :outcome_node: true


### PR DESCRIPTION
For further details see:
  https://www.pivotaltracker.com/n/projects/1270592/stories/105008654

## Expected changes

* [Example URL](https://www.gov.uk/overseas-passports/y/afghanistan/applying/child/afghanistan)
  * Under How to Apply, a step # 5 with a link to a parent contact details form appears

<img width="1347" alt="screen shot 2015-10-20 at 4 11 26 pm" src="https://cloud.githubusercontent.com/assets/351763/10611721/45562690-7745-11e5-9315-11f852d346e2.png">

