### PR TITLE
Avoid displaying question page titles for Smartdown flows

### DIFF
--- a/lib/smartdown_adapter/presenter.rb
+++ b/lib/smartdown_adapter/presenter.rb
@@ -36,7 +36,6 @@ module SmartdownAdapter
     end
 
     def page_title
-      current_node.title
     end
 
     def current_node

--- a/lib/smartdown_adapter/previous_question_page_presenter.rb
+++ b/lib/smartdown_adapter/previous_question_page_presenter.rb
@@ -11,7 +11,6 @@ module SmartdownAdapter
     end
 
     def title
-      @smartdown_previous_question_page.title
     end
   end
 end

--- a/test/artefacts/pay-leave-for-parents/y.html
+++ b/test/artefacts/pay-leave-for-parents/y.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Your circumstances</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Due date</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes.html
@@ -133,23 +133,16 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Employment status</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01.html
@@ -93,42 +93,28 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee.html
@@ -93,61 +93,40 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Employment statuses</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee.html
@@ -79,80 +79,52 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Mother’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Mother’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes.html
@@ -79,99 +79,64 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Mother’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes.html
@@ -79,118 +79,76 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year.html
@@ -79,137 +79,88 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Mother’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Mother’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no.html
@@ -81,156 +81,100 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=no">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?</td>
       <td class="previous-question-body">
       No</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes.html
@@ -81,175 +81,112 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=no">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?</td>
       <td class="previous-question-body">
       No</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/no?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother work (or will she have worked) for at least 26 weeks between 24 October 2010 and 28 January 2012?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/no?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother work (or will she have worked) for at least 26 weeks between 24 October 2010 and 28 January 2012?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Mother’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes/yes.html
@@ -77,194 +77,124 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=no">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?</td>
       <td class="previous-question-body">
       No</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/no?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother work (or will she have worked) for at least 26 weeks between 24 October 2010 and 28 January 2012?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/no?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother work (or will she have worked) for at least 26 weeks between 24 October 2010 and 28 January 2012?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother earn (or will she have earned) a total of £390 or more in any 13 weeks between 24 October 2010 and 28 January 2012?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother earn (or will she have earned) a total of £390 or more in any 13 weeks between 24 October 2010 and 28 January 2012?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes/yes.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Mother’s salary details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/no/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes.html
@@ -79,156 +79,100 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Partner’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes.html
@@ -79,175 +79,112 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother’s partner start their current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother’s partner start their current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Partner’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Partner’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes.html
@@ -79,194 +79,124 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother’s partner start their current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother’s partner start their current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother’s partner (or will they be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother’s partner (or will they be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Partner’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year.html
@@ -79,213 +79,136 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       1 February 2012</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2012-2-1">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother’s partner start their current or most recent job before 30 April 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother’s partner start their current or most recent job before 30 April 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother’s partner (or will they be) still working in that job on 16 October 2011?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother’s partner (or will they be) still working in that job on 16 October 2011?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother’s partner earn (or did they earn, if they’ve left their job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2012-2-1/employee/employee/yes/yes/10000-year/yes/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother’s partner earn (or did they earn, if they’ve left their job)?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Partner’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">

--- a/test/artefacts/pay-leave-for-parents/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no.html
@@ -81,232 +81,148 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2015-4-5">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       5 April 2015</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2015-4-5">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 5 July 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 5 July 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 21 December 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother earned (or will she have earned) more than £111 per week between 1 November 2014 and 27 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Has the mother earned (or will she have earned) more than £111 per week between 1 November 2014 and 27 December 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother’s partner start their current or most recent job before 5 July 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother’s partner start their current or most recent job before 5 July 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother’s partner (or will they be) still working in that job on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother’s partner (or will they be) still working in that job on 21 December 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother’s partner earn (or did they earn, if they’ve left their job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother’s partner earn (or did they earn, if they’ve left their job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year?previous_response=no">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother’s partner earned (or will they have earned) more than £111 per week between 1 November 2014 and 27 December 2014?</td>
       <td class="previous-question-body">
       No</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Has the mother’s partner earned (or will they have earned) more than £111 per week between 1 November 2014 and 27 December 2014?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no/yes.html
@@ -81,251 +81,160 @@
           <a class="start-right" href="/pay-leave-for-parents">Start again</a>
         <table>
           <tbody>
-                <tr class="section">
-    <td class="section-title">
-      Your circumstances
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Your circumstances"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Will you care for the child with a partner?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Will you care for the child with a partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Due date
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes?previous_response=2015-4-5">
-          Change<span class="visuallyhidden"> answer to "Due date"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">When is the baby due?</td>
       <td class="previous-question-body">
       5 April 2015</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes?previous_response=2015-4-5">
+            Change<span class="visuallyhidden"> answer to "When is the baby due?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment status
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment status"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Employment statuses
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee?previous_response=employee">
-          Change<span class="visuallyhidden"> answer to "Employment statuses"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">What’s the employment status of the mother’s partner?</td>
       <td class="previous-question-body">
       Employee</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee?previous_response=employee">
+            Change<span class="visuallyhidden"> answer to "What’s the employment status of the mother’s partner?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother start her current or most recent job before 5 July 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother start her current or most recent job before 5 July 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother (or will she be) still working in that job on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother (or will she be) still working in that job on 21 December 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother earn (or did she earn, if she’s left her job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother earn (or did she earn, if she’s left her job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Mother’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Mother’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother earned (or will she have earned) more than £111 per week between 1 November 2014 and 27 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Has the mother earned (or will she have earned) more than £111 per week between 1 November 2014 and 27 December 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother’s partner start their current or most recent job before 5 July 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother’s partner start their current or most recent job before 5 July 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Was the mother’s partner (or will they be) still working in that job on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Was the mother’s partner (or will they be) still working in that job on 21 December 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes?previous_response=10000-year">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">How much does the mother’s partner earn (or did they earn, if they’ve left their job)?</td>
       <td class="previous-question-body">
       £10,000 per year</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes?previous_response=10000-year">
+            Change<span class="visuallyhidden"> answer to "How much does the mother’s partner earn (or did they earn, if they’ve left their job)?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year?previous_response=no">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Has the mother’s partner earned (or will they have earned) more than £111 per week between 1 November 2014 and 27 December 2014?</td>
       <td class="previous-question-body">
       No</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Has the mother’s partner earned (or will they have earned) more than £111 per week between 1 November 2014 and 27 December 2014?"</span>
+</a>      </td>
   </tr>
 
-                <tr class="section">
-    <td class="section-title">
-      Partner’s employment details
-    </td>
-    <td>
-    </td>
-    <td class="link-right">
-        <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no?previous_response=yes">
-          Change<span class="visuallyhidden"> answer to "Partner’s employment details"</span>
-</a>    </td>
-  </tr>
-
-    <tr>
+              
+    <tr class="section">
     <td class="previous-question-title">Did the mother’s partner work (or will they have worked) for at least 26 weeks between 29 December 2013 and 4 April 2015?</td>
       <td class="previous-question-body">
       Yes</td>
 
+      <td class="link-right">
+          <a href="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no?previous_response=yes">
+            Change<span class="visuallyhidden"> answer to "Did the mother’s partner work (or will they have worked) for at least 26 weeks between 29 December 2013 and 4 April 2015?"</span>
+</a>      </td>
   </tr>
 
           </tbody>

--- a/test/artefacts/pay-leave-for-parents/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no/yes.html
@@ -27,7 +27,6 @@
     </div>
   </header>
 
-      <h2 class="page-title">Partner’s employment details</h2>
     <div class="step current" data-step="employment-status">
       <form action="/pay-leave-for-parents/y/yes/2015-4-5/employee/employee/yes/yes/10000-year/yes/yes/yes/10000-year/no/yes" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">


### PR DESCRIPTION
I'm hoping this'll make it easier to convert pay-leave-for-parents from Smartdown to a Ruby Smart Answer.

By not displaying question page titles for Smartdown flows (pay-leave-for-parents is the only Smartdown flow left) I hope we have a set of regression test artefacts that remain constant after the conversion to Ruby.

I think it's OK to remove these question page titles as I don't think they've been adding much value since we converted the last remaining Smartdown flow with multiple questions per page to use single questions per page.

