### PR TITLE
Avoid rescuing argument error in next node blocks

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -125,7 +125,7 @@ module SmartAnswer
         begin
           state = node(state.current_node).transition(state, response)
           node(state.current_node).evaluate_precalculations(state)
-        rescue ArgumentError, InvalidResponse => e
+        rescue InvalidResponse => e
           state.dup.tap do |new_state|
             new_state.error = e.message
             new_state.freeze

--- a/lib/smart_answer/question/value.rb
+++ b/lib/smart_answer/question/value.rb
@@ -10,7 +10,7 @@ module SmartAnswer
         if Integer == @parse
           begin
             Integer(raw_input)
-          rescue TypeError
+          rescue TypeError, ArgumentError
             raise InvalidResponse
           end
         elsif :to_i == @parse

--- a/lib/smart_answer/question/value.rb
+++ b/lib/smart_answer/question/value.rb
@@ -18,7 +18,7 @@ module SmartAnswer
         elsif Float == @parse
           begin
             Float(raw_input)
-          rescue TypeError
+          rescue TypeError, ArgumentError
             raise InvalidResponse
           end
         elsif :to_f == @parse

--- a/test/unit/value_question_test.rb
+++ b/test/unit/value_question_test.rb
@@ -31,12 +31,12 @@ module SmartAnswer
         assert_equal 123, new_state.myval
       end
 
-      should "raise ArgumentError for non-integer value" do
-        assert_raises(ArgumentError) { @q.transition(@initial_state, "1.5") }
+      should "raise InvalidResponse for non-integer value" do
+        assert_raises(InvalidResponse) { @q.transition(@initial_state, "1.5") }
       end
 
-      should "raise ArgumentError for blank value" do
-        assert_raises(ArgumentError) { @q.transition(@initial_state, "") }
+      should "raise InvalidResponse for blank value" do
+        assert_raises(InvalidResponse) { @q.transition(@initial_state, "") }
       end
 
       should "raise InvalidResponse for nil value" do

--- a/test/unit/value_question_test.rb
+++ b/test/unit/value_question_test.rb
@@ -81,12 +81,12 @@ module SmartAnswer
         assert_equal 1.23, new_state.myval
       end
 
-      should "raise ArgumentError for non-float value" do
-        assert_raises(ArgumentError) { @q.transition(@initial_state, "not-a-float") }
+      should "raise InvalidResponse for non-float value" do
+        assert_raises(InvalidResponse) { @q.transition(@initial_state, "not-a-float") }
       end
 
-      should "raise ArgumentError for blank value" do
-        assert_raises(ArgumentError) { @q.transition(@initial_state, "") }
+      should "raise InvalidResponse for blank value" do
+        assert_raises(InvalidResponse) { @q.transition(@initial_state, "") }
       end
 
       should "raise InvalidResponse for nil value" do


### PR DESCRIPTION
I don't think it's a good idea to rescue from such a generic exception in our
`next_node` blocks. It hides real problems in our Ruby code and makes them look
as though the user has entered invalid data in the Smart Answer.

The rescuing of ArgumentError caused me problems twice recently. Once when I was
comparing a Date with a String and once when I was calling a method with
incorrect arguments. This change will mean that errors such as this cause the
application to fail fast.

    >> Date.today < '2016-01-01'
    ArgumentError: comparison of Date with String failed

    >> def foo(arg); end
    => :foo
    >> foo()
    ArgumentError: wrong number of arguments (0 for 1)

The first two commits ("Raise InvalidResponse when parsing Integers in
Value#parse_input" and "Raise InvalidResponse when parsing Floats in
Value#parse_input") should have removed the only places where we were raising
an `ArgumentError` in response to bad user input.

We're still raising an `ArgumentError` from `SmartAnswer::Calculators::VatPaymentDeadlines#last_payment_date` and `#funds_recevied_by`. I haven't changed these because I don't believe this error will ever be raised by code in a `next_node` block. The error can only be raised by `#last_payment_date` and `#funds_received_by` if an option other than one of those listed in the `multiple_choice` options for the `:how_do_you_want_to_pay?` question is entered, and in that case the `SmartAnswer::Question::MultipleChoice#parse_input` method will raise an `InvalidResponse` exception first.

I ran all the regression tests locally against this change and didn't see any errors. That's no guarantee that we won't see problems if/when this is deployed to production.
