### PR TITLE
Add ability to read the flow name from within a node

### DIFF
--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -53,5 +53,9 @@ module SmartAnswer
       load_path = FlowRegistry.instance.load_path
       Pathname.new(load_path).join(String(@flow.name))
     end
+
+    def flow_name
+      @flow.name
+    end
   end
 end

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -18,5 +18,11 @@ module SmartAnswer
       expected_directory = Pathname.new(@load_path).join('flow-name')
       assert_equal expected_directory, @node.template_directory
     end
+
+    test '#flow_name returns the name of the flow' do
+      @flow.name 'flow-name'
+
+      assert_equal @node.flow_name, @flow.name
+    end
   end
 end


### PR DESCRIPTION
Would allow flow specific logic to be included in otherwise identical shared logic used by multiple flows.