### PR TITLE
Add qualifying week to maternity, paternity and adoption

### DIFF
--- a/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
@@ -30,7 +30,7 @@ en-GB:
           "yes": "Yes"
       ## QM5
       is_the_employee_on_your_payroll?:
-        title: Is the employee on your payroll?
+        title: Was the employee (or will they be) on your payroll on %{qualifying_week_start}?
         options:
           "no": "No"
           "yes": "Yes"
@@ -143,7 +143,7 @@ en-GB:
           "yes": "Yes"
       ## QP6
       employee_on_payroll_paternity?:
-        title: Is the employee on your payroll?
+        title: Was the employee (or will they be) on your payroll on %{qualifying_week_start}?
         options:
           "no": "No"
           "yes": "Yes"
@@ -285,7 +285,7 @@ en-GB:
           "yes": "Yes"
       ## QA5
       adoption_is_the_employee_on_your_payroll?:
-        title: Is the employee on your payroll?
+        title: Was the employee (or will they be) on your payroll on %{qualifying_week_start}?
         options:
           "no": "No"
           "yes": "Yes"

--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
@@ -3,14 +3,13 @@
 <% end %>
 
 <% content_for :meta_description do %>
-  Calculate an employee’s maternity pay (SMP), paternity or adoption pay, qualifying week, relevant period and average weekly earnings
+  Calculate an employee’s maternity pay (SMP), paternity or adoption pay, relevant period and average weekly earnings
 <% end %>
 
 <% content_for :body do %>
   Calculate your employee’s:
 
   + statutory maternity pay (SMP), paternity pay, adoption pay
-  + qualifying week
   + relevant employment period and average weekly earnings
   + leave period
 <% end %>

--- a/lib/smart_answer_flows/shared_logic/adoption-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/adoption-calculator.rb
@@ -36,6 +36,11 @@ date_question :date_of_adoption_placement? do
   calculate :employment_start do
     calculator.a_employment_start
   end
+
+  calculate :qualifying_week_start do
+    calculator.qualifying_week.first
+  end
+
   next_node :adoption_did_the_employee_work_for_you?
 end
 

--- a/lib/smart_answer_flows/shared_logic/maternity-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/maternity-calculator.rb
@@ -57,6 +57,9 @@ date_question :date_leave_starts? do
   calculate :employment_start do
     calculator.employment_start
   end
+  calculate :qualifying_week_start do
+    calculator.qualifying_week.first
+  end
   calculate :ssp_stop do
     calculator.ssp_stop
   end

--- a/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
@@ -107,6 +107,10 @@ multiple_choice :padoption_employee_responsible_for_upbringing? do
   calculate :employment_end do
     matched_date
   end
+
+  calculate :qualifying_week_start do
+    calculator.qualifying_week.first
+  end
 end
 
 ## QP4 - Shared flow onwards

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes.html
@@ -32,7 +32,7 @@
         <div class="current-question" id="current-question">
             <div class="question">
   <h2>
-    Is the employee on your payroll?
+    Was the employee (or will they be) on your payroll on 21 December 2014?
   </h2>
   <div class="question-body">
     

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes.html
@@ -206,13 +206,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 21 December 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06.html
@@ -205,13 +205,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 21 December 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01.html
@@ -205,13 +205,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 21 December 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01.html
@@ -164,13 +164,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 21 December 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly.html
@@ -139,13 +139,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 21 December 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly/3000.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly/3000.html
@@ -151,13 +151,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 21 December 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/adoption/no/2015-04-05/2015-04-06/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 21 December 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity-paternity-calculator.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity-paternity-calculator.txt
@@ -3,7 +3,6 @@ Maternity and paternity calculator for employers
 Calculate your employee’s:
 
 + statutory maternity pay (SMP), paternity pay, adoption pay
-+ qualifying week
 + relevant employment period and average weekly earnings
 + leave period
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes.html
@@ -32,7 +32,7 @@
         <div class="current-question" id="current-question">
             <div class="question">
   <h2>
-    Is the employee on your payroll?
+    Was the employee (or will they be) on your payroll on 14 September 2014?
   </h2>
   <div class="question-body">
     

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes.html
@@ -193,13 +193,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19.html
@@ -193,13 +193,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24.html
@@ -152,13 +152,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates.html
@@ -158,13 +158,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month.html
@@ -169,13 +169,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday.html
@@ -157,13 +157,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month.html
@@ -169,13 +169,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/specific_date_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/specific_date_each_month.html
@@ -127,13 +127,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly.html
@@ -127,13 +127,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.0/usual_paydates.html
@@ -193,13 +193,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.html
@@ -139,13 +139,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/maternity/2015-01-01/yes/2015-01-01/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes.html
@@ -32,7 +32,7 @@
         <div class="current-question" id="current-question">
             <div class="question">
   <h2>
-    Is the employee on your payroll?
+    Was the employee (or will they be) on your payroll on 14 September 2014?
   </h2>
   <div class="question-body">
     

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes.html
@@ -163,13 +163,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes.html
@@ -218,13 +218,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01.html
@@ -163,13 +163,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week.html
@@ -217,13 +217,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01.html
@@ -217,13 +217,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01.html
@@ -176,13 +176,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates.html
@@ -182,13 +182,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month.html
@@ -193,13 +193,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0.html
@@ -181,13 +181,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month.html
@@ -193,13 +193,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/specific_date_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/specific_date_each_month.html
@@ -151,13 +151,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly.html
@@ -151,13 +151,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.0/usual_paydates.html
@@ -217,13 +217,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.html
@@ -163,13 +163,13 @@
 
               
     <tr class="section">
-    <td class="previous-question-title">Is the employee on your payroll?</td>
+    <td class="previous-question-title">Was the employee (or will they be) on your payroll on 14 September 2014?</td>
       <td class="previous-question-body">
       Yes</td>
 
       <td class="link-right">
           <a href="/maternity-paternity-calculator/y/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes?previous_response=yes">
-            Change<span class="visuallyhidden"> answer to "Is the employee on your payroll?"</span>
+            Change<span class="visuallyhidden"> answer to "Was the employee (or will they be) on your payroll on 14 September 2014?"</span>
 </a>      </td>
   </tr>
 

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/maternity-paternity-calculator.rb: 423c26577066ed7c7e70dcba85b60178
-lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: 015accb15b39db02dc2763e63bb6071f
+lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: cf2abf0778bb38ad017deba521830090
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 1bf0c803cd8e8a091417b0e1e19d2bd2
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: a59f6821dd5b949861ab6261840e58e4
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: 85c29330fa42b84a5eca78bf051a517c
@@ -17,9 +17,9 @@ lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_not_enti
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.govspeak.erb: 35066a095224d56af5153769db91d721
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_leave_and_pay.govspeak.erb: bf1bf8076a8eb171d380e62de057fef2
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_not_entitled_to_leave_or_pay.govspeak.erb: 6909d514cd992d94400407ded6f4a024
-lib/smart_answer_flows/shared_logic/adoption-calculator.rb: 31fea84aa6bd02faab067fc71b51d3f8
-lib/smart_answer_flows/shared_logic/maternity-calculator.rb: ba8f0933b8c424f489661a083071fd47
-lib/smart_answer_flows/shared_logic/paternity-calculator.rb: d4872f2b383a9d8ea42fe7b338a62539
+lib/smart_answer_flows/shared_logic/adoption-calculator.rb: 066a57dc1215f6a822f19b5f05f5615b
+lib/smart_answer_flows/shared_logic/maternity-calculator.rb: 0fd872c802e57790224b35289b7872ce
+lib/smart_answer_flows/shared_logic/paternity-calculator.rb: f3211e89f31182566180a39fa20a239a
 lib/smart_answer/calculators/maternity_paternity_calculator.rb: 24de99189c23e9a7cc048871a817bb3c
 lib/data/rates/maternity_paternity_birth.yml: 3eef956f1020576a9343647fec34dd01
 lib/data/rates/maternity_paternity_adoption.yml: 453c4d90b6fd9ffe1556782665f313fc

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/maternity-paternity-calculator.rb: 423c26577066ed7c7e70dc
 lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: cf2abf0778bb38ad017deba521830090
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 1bf0c803cd8e8a091417b0e1e19d2bd2
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: a59f6821dd5b949861ab6261840e58e4
-lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: 85c29330fa42b84a5eca78bf051a517c
+lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: 912bfe601939f1391d5e54b11c146744
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_must_be_on_payroll.govspeak.erb: e79accc3a0b6e9060fb3fbf9dd5848ad
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_must_earn_over_threshold.govspeak.erb: d2367c7b156a37e88a81061ce890503a
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_not_worked_long_enough.govspeak.erb: 08e6560e8927136f1f2899c4d0b1648f


### PR DESCRIPTION
## Rationale

This change updates the maternity, paternity and adoption smart answer calculators by asking the user if they were, or will be, employed during the qualifying week - rather than the present date when they are completing the questions.

The qualifying week (QW) is, broadly, the 15th week before the expected week of childbirth or adoption. It's worked out by finding the Sunday before the due or match date (or due day itself if it's a Sunday). The QW is 15 Sundays back from there.

For example, if the due date is 1 January 2016, the QW is 13 September.

For further details see:
  https://www.pivotaltracker.com/n/projects/1270592/stories/104083442

## Expected changes

* [Example Maternity URL](https://www.gov.uk/maternity-paternity-calculator/y/maternity/2016-01-01/yes/2015-12-01/yes)
  * Question should be: "Was the employee (or will they be) on your payroll on 13 September 2015?"

<img width="1070" alt="screen shot 2015-10-28 at 4 43 54 pm" src="https://cloud.githubusercontent.com/assets/351763/10795801/52c18f82-7d93-11e5-9af8-a4532638bbd7.png">

* [Example Paternity URL](https://www.gov.uk/maternity-paternity-calculator/y/paternity/yes/2016-01-01/2016-01-01/yes/yes/yes)
  * Question should be: "Was the employee (or will they be) on your payroll on 13 September 2015?"

<img width="1075" alt="screen shot 2015-10-28 at 4 47 43 pm" src="https://cloud.githubusercontent.com/assets/351763/10795888/a4a1d0fa-7d93-11e5-9037-09493359853a.png">

* [Example Adoption URL](https://www.gov.uk/maternity-paternity-calculator/y/adoption/yes/2016-01-01/2016-01-01/yes/yes/yes)
  * Question should be: "Was the employee (or will they be) on your payroll on 13 September 2015?"

<img width="935" alt="screen shot 2015-10-28 at 4 48 56 pm" src="https://cloud.githubusercontent.com/assets/351763/10795922/d3143e0a-7d93-11e5-9224-83a919dfd1b7.png">
