### PR TITLE
Updates date_of_year function to calculate differences between dates

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -107,12 +107,10 @@ module SmartAnswer::Calculators
 
     def leave_year_start_end
       if self.leave_year_start_date
-        date_leave_year_start_date = leave_year_start_date
-
-        needs_offset = date_calc >= date_of_year(date_leave_year_start_date, date_calc.year)
+        needs_offset = date_calc >= date_of_year(leave_year_start_date, date_calc.year)
         number_years = date_calc.year - (needs_offset ? 0 : 1)
 
-        leave_year_start = date_of_year(date_leave_year_start_date, number_years)
+        leave_year_start = date_of_year(leave_year_start_date, number_years)
         leave_year_end = leave_year_start + 1.years - 1.days
       else
         leave_year_start = date_calc.beginning_of_year
@@ -153,10 +151,7 @@ module SmartAnswer::Calculators
     end
 
     def date_of_year(date, year)
-      return date if date.year == year
-
-      years_offset = date.year - year
-      date - years_offset.years
+      date.advance(years: year - date.year)
     end
 
     def days_cap

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -81,6 +81,10 @@ module SmartAnswer::Calculators
       format_number(fraction_of_year, dp)
     end
 
+    def date_of_year(date, year)
+      date.advance(years: year - date.year)
+    end
+
     def strip_zeros(number)
       number.to_s.sub(/\.0+$/, '')
     end
@@ -148,10 +152,6 @@ module SmartAnswer::Calculators
     def format_number(number, dp = 1)
       str = sprintf("%.#{dp}f", number)
       strip_zeros(str)
-    end
-
-    def date_of_year(date, year)
-      date.advance(years: year - date.year)
     end
 
     def days_cap

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -153,7 +153,10 @@ module SmartAnswer::Calculators
     end
 
     def date_of_year(date, year)
-      Date.civil(year, date.month, date.day)
+      return date if date.year == year
+
+      years_offset = date.year - year
+      date - years_offset.years
     end
 
     def days_cap

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -11,4 +11,4 @@ lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_ho
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb: 214a138b7dbedc186662ea2df1389864
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb: 096f7b9741d693cdab7295300b8cfa0d
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb: 22ab0c04098de9e46ab3dc6207fb8756
-lib/smart_answer/calculators/holiday_entitlement.rb: 790123490288361297bfb64099e84816
+lib/smart_answer/calculators/holiday_entitlement.rb: 9249c8321a6d021916ea55a4fa6c216c

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -11,4 +11,4 @@ lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_ho
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb: 214a138b7dbedc186662ea2df1389864
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb: 096f7b9741d693cdab7295300b8cfa0d
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb: 22ab0c04098de9e46ab3dc6207fb8756
-lib/smart_answer/calculators/holiday_entitlement.rb: 034d62a8817643e86340cb1d6231a83c
+lib/smart_answer/calculators/holiday_entitlement.rb: 2e642f3d02f3f4a3defa2c618c5f8289

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -11,4 +11,4 @@ lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_ho
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb: 214a138b7dbedc186662ea2df1389864
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb: 096f7b9741d693cdab7295300b8cfa0d
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb: 22ab0c04098de9e46ab3dc6207fb8756
-lib/smart_answer/calculators/holiday_entitlement.rb: 9249c8321a6d021916ea55a4fa6c216c
+lib/smart_answer/calculators/holiday_entitlement.rb: 034d62a8817643e86340cb1d6231a83c

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -99,11 +99,6 @@ module SmartAnswer::Calculators
               calc = HolidayEntitlement.new(start_date: Date.parse('2013-01-21'), leave_year_start_date: Date.parse('2013-02-01'))
               assert_equal '0.0301', sprintf('%.4f', calc.fraction_of_year)
             end
-
-            should 'return the fraction of a year when the leave year start falls on the 29th of Feb and the start date is a non-leap year' do
-              calc = HolidayEntitlement.new(start_date: Date.parse('2015-10-22'), leave_year_start_date: Date.parse('2016-02-29'))
-              assert_equal '0.3534', sprintf('%.4f', calc.fraction_of_year)
-            end
           end # context - start date before leave_year_start
 
           context "start date after leave_year_start" do
@@ -361,6 +356,30 @@ module SmartAnswer::Calculators
 
         should "return the holiday entitlement in shifts" do
           assert_equal '14.673', sprintf('%.3f', @calc.shift_entitlement)
+        end
+      end
+    end
+
+    context 'date_of_year' do
+      setup do
+        @calc = HolidayEntitlement.new
+      end
+
+      context 'given a leap year date, and non-leap year' do
+        should 'return feb 28th for the non-leap year' do
+          date = Date.parse('2016-02-29')
+          year = Date.parse('2015-01-01').year
+
+          assert_equal @calc.date_of_year(date, year), Date.parse("#{year}-02-28")
+        end
+      end
+
+      context 'given a non-leap year date, and non-leap year' do
+        should 'return the same day and month for the non-leap year' do
+          date = Date.parse('2016-02-28')
+          year = Date.parse('2015-01-01').year
+
+          assert_equal @calc.date_of_year(date, year), Date.parse("#{year}-02-28")
         end
       end
     end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -99,6 +99,11 @@ module SmartAnswer::Calculators
               calc = HolidayEntitlement.new(start_date: Date.parse('2013-01-21'), leave_year_start_date: Date.parse('2013-02-01'))
               assert_equal '0.0301', sprintf('%.4f', calc.fraction_of_year)
             end
+
+            should 'return the fraction of a year when the leave year start falls on the 29th of Feb and the start date is a non-leap year' do
+              calc = HolidayEntitlement.new(start_date: Date.parse('2015-10-22'), leave_year_start_date: Date.parse('2016-02-29'))
+              assert_equal '0.3534', sprintf('%.4f', calc.fraction_of_year)
+            end
           end # context - start date before leave_year_start
 
           context "start date after leave_year_start" do


### PR DESCRIPTION
The date_of_year function allows you to return a date containing the day and month values of the first argument, with the year of the second, which fails when passing a 29th of Feb value for the date and non-leap value for the year.
    
This change simply subtracts the difference in years from the two arguments, so an earlier year will subtract a positive number of years and a later year subtracts a negative number of years.

In cases where both arguments have equal year values, it avoids the subtraction and simply returns the existing date.

Addresses issue #1828 where Feb 29th values in the first argument cause a failure when the second argument has a non-leap year value.

## Expected changes

[Example URL](https://www.gov.uk/calculate-your-holiday-entitlement/y/days-worked-per-week/leaving/2015-05-01/2016-02-29/1)
 * Should no longer result in an application error "Sorry, we are experiencing technical difficulties", and should calculate the holiday entitlement.

<img width="1025" alt="screen shot 2015-10-29 at 5 16 53 pm" src="https://cloud.githubusercontent.com/assets/351763/10826282/e61ceab0-7e60-11e5-8eea-f7c23bd3ffc9.png">
