### PR TITLE
Replaced 'vehicle weight' with 'vehicle MAM'

### DIFF
--- a/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement.govspeak.erb
@@ -5,7 +5,7 @@
 
   You can tow trailers up to 750kg MAM (maximum authorised mass).
 
-  You can also tow larger trailers if the combined trailer and vehicle weight isn't more than 3,500kg.
+  You can also tow larger trailers if the combined trailer and vehicle MAM isn't more than 3,500kg.
 
   ##Category B+E
 


### PR DESCRIPTION
__This has been superseded by PR #2074.__

Comes from: https://govuk.zendesk.com/agent/tickets/1127165