### PR TITLE
Remove space between number and weight in towing rules

### DIFF
--- a/lib/smart_answer_flows/towing-rules/towing_rules.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/towing_rules.govspeak.erb
@@ -12,5 +12,5 @@
 
   This tool assumes that you already have the minimum of a full car driving licence (category B). You need a full car licence before being able to tow with any larger vehicle.
 
-  ^A full car licence already lets you tow trailers weighing no more than 750 kg. You can also tow heavier trailers with a car as long as the total weight of vehicle and trailer isn’t more than 3,500 kg.^
+  ^A full car licence already lets you tow trailers weighing no more than 750kg. You can also tow heavier trailers with a car as long as the total weight of vehicle and trailer isn’t more than 3,500kg.^
 <% end %>

--- a/test/artefacts/towing-rules/towing-rules.txt
+++ b/test/artefacts/towing-rules/towing-rules.txt
@@ -4,5 +4,5 @@ Use this tool to find out if you’re old enough or have the right kind of licen
 
 This tool assumes that you already have the minimum of a full car driving licence (category B). You need a full car licence before being able to tow with any larger vehicle.
 
-^A full car licence already lets you tow trailers weighing no more than 750 kg. You can also tow heavier trailers with a car as long as the total weight of vehicle and trailer isn’t more than 3,500 kg.^
+^A full car licence already lets you tow trailers weighing no more than 750kg. You can also tow heavier trailers with a car as long as the total weight of vehicle and trailer isn’t more than 3,500kg.^
 

--- a/test/data/towing-rules-files.yml
+++ b/test/data/towing-rules-files.yml
@@ -25,4 +25,4 @@ lib/smart_answer_flows/towing-rules/outcomes/not_old_enough_bus.govspeak.erb: f7
 lib/smart_answer_flows/towing-rules/outcomes/not_old_enough_lv.govspeak.erb: 5a94374e913caa7597ebc530c32ad421
 lib/smart_answer_flows/towing-rules/outcomes/not_old_enough_minibus.govspeak.erb: d85ab81444e874f4549adeba688f73e6
 lib/smart_answer_flows/towing-rules/outcomes/too_young_msv.govspeak.erb: cea2cd5ded9e75435518dcd67cda65b0
-lib/smart_answer_flows/towing-rules/towing_rules.govspeak.erb: 53a2f897e49f589999a7684b5c6f24f0
+lib/smart_answer_flows/towing-rules/towing_rules.govspeak.erb: d48bec315e82adf8e068fa2b20d748c2


### PR DESCRIPTION
This change applies removes the spaces between number and 'kg' - for style in the towing rules smart answer start page.

## Expected changes
 * 750 kg becomes 750kg
 * 3,500 kg becomes 3,500kg
 
<img width="1050" alt="screen shot 2015-11-02 at 4 58 03 pm" src="https://cloud.githubusercontent.com/assets/351763/10888291/41d25212-8183-11e5-89d5-d89454925b45.png">

Closes #2044 

@keithiopia 