### PR TITLE
Add ADR for removal of Smartdown

### DIFF
--- a/doc/arch/adr-001-removing-smartdown.md
+++ b/doc/arch/adr-001-removing-smartdown.md
@@ -35,7 +35,7 @@ Accepted.
 
 ## Consequences
 
-The Smart Answers project is simpler now that there is one less way of authoring Smart Answers.
+The Smart Answers application is simpler now that there is one less way of authoring Smart Answers.
 
 Developers new to the Smart Answers project have one less thing to learn to get up to speed.
 

--- a/doc/arch/adr-001-removing-smartdown.md
+++ b/doc/arch/adr-001-removing-smartdown.md
@@ -19,6 +19,10 @@ As at April 2015 there were:
 
 ## Decision
 
+We will make Ruby Smart Answers as simple and accessible as possible, on the assumption that we'll have a high turnover of people working on it.
+
+We will standardise on Ruby Smart Answers to optimise for maintenance and Business As Usual throughput.
+
 We will take some of the learnings from Smartdown and use them to improve the Ruby Smart Answers.
 
 We will use ERB templates instead of [PhraseLists][phraselist-commit] to bring Ruby Smart Answer outcomes closer to Smartdown outcomes.

--- a/doc/arch/adr-001-removing-smartdown.md
+++ b/doc/arch/adr-001-removing-smartdown.md
@@ -1,0 +1,44 @@
+# ADR 1: Removing Smartdown
+
+## Context
+
+[Smart Answers][smart-answers-github] have been historically painful to develop and maintain. In particular, relatively simple content changes can incur quite a high development cost.
+
+[Smartdown][smartdown-github] was developed in an attempt to reduce the overhead of Smart Answers development. [Smartdown was added to the Smart Answers project on 6 Aug 2014][smartdown-in-smart-answers].
+
+Smartdown made it easier for content designers to edit questions and outcome content, but was quite restrictive when it came to defining the rules of the Smart Answer (see the rules in [pay-leave-for-parents/partner_earned_more_than_lower_earnings_limit][spl-complicated-next-node-rules], for example).
+
+Smartdown didn't match Ruby Smart Answers in terms of features.
+
+As at April 2015 there were:
+
+* 35 published (and 15 draft) Ruby Smart Answers
+* 2 published (and 2 draft) Smartdown Smart Answers
+
+## Decision
+
+Take some of the learnings from Smartdown and use them to improve the Ruby Smart Answers.
+
+Use ERB templates instead of [PhraseLists][phraselist-commit] to bring Ruby Smart Answer outcomes closer to Smartdown outcomes.
+
+Convert existing Smartdown Smart Answers to Ruby.
+
+Remove Smartdown.
+
+## Status
+
+Accepted.
+
+## Consequences
+
+It's easier for content designers to edit Smart Answer outcomes.
+
+The Smart Answers project is simpler now that there is one less way of authoring Smart Answers.
+
+Developers new to the Smart Answers project have one less thing to learn to get up to speed.
+
+[phraselist-commit]: https://github.com/alphagov/smart-answers/commit/9a5e7ee0927f9da2bec0658946e14691e7e2a5c0
+[smartdown-github]: https://github.com/alphagov/smartdown
+[smart-answers-github]: https://github.com/alphagov/smart-answers
+[smartdown-in-smart-answers]: https://github.com/alphagov/smart-answers/commit/a042c1b748819266a1e59365b07738737872e392
+[spl-complicated-next-node-rules]: https://github.com/alphagov/smart-answers/blob/cbc065f78abde540165df4e376025f56261b4723/lib/smartdown_flows/pay-leave-for-parents-old/questions/partner_earned_more_than_lower_earnings_limit.txt

--- a/doc/arch/adr-001-removing-smartdown.md
+++ b/doc/arch/adr-001-removing-smartdown.md
@@ -35,8 +35,6 @@ Accepted.
 
 ## Consequences
 
-It's easier for content designers to edit Smart Answer outcomes.
-
 The Smart Answers project is simpler now that there is one less way of authoring Smart Answers.
 
 Developers new to the Smart Answers project have one less thing to learn to get up to speed.

--- a/doc/arch/adr-001-removing-smartdown.md
+++ b/doc/arch/adr-001-removing-smartdown.md
@@ -12,8 +12,6 @@ Smartdown didn't match Ruby Smart Answers in terms of features. Adding support f
 
 The state of many of the Ruby Smart Answers would've made it hard to convert them to Smartdown without extensive refactoring.
 
-
-
 As at April 2015 there were:
 
 * 35 published (and 15 draft) Ruby Smart Answers

--- a/doc/arch/adr-001-removing-smartdown.md
+++ b/doc/arch/adr-001-removing-smartdown.md
@@ -19,13 +19,13 @@ As at April 2015 there were:
 
 ## Decision
 
-Take some of the learnings from Smartdown and use them to improve the Ruby Smart Answers.
+We will take some of the learnings from Smartdown and use them to improve the Ruby Smart Answers.
 
-Use ERB templates instead of [PhraseLists][phraselist-commit] to bring Ruby Smart Answer outcomes closer to Smartdown outcomes.
+We will use ERB templates instead of [PhraseLists][phraselist-commit] to bring Ruby Smart Answer outcomes closer to Smartdown outcomes.
 
-Convert existing Smartdown Smart Answers to Ruby.
+We will convert existing Smartdown Smart Answers to Ruby.
 
-Remove Smartdown.
+We will remove Smartdown.
 
 ## Status
 

--- a/doc/arch/adr-001-removing-smartdown.md
+++ b/doc/arch/adr-001-removing-smartdown.md
@@ -8,7 +8,11 @@
 
 Smartdown made it easier for content designers to edit questions and outcome content, but was quite restrictive when it came to defining the rules of the Smart Answer (see the rules in [pay-leave-for-parents/partner_earned_more_than_lower_earnings_limit][spl-complicated-next-node-rules], for example).
 
-Smartdown didn't match Ruby Smart Answers in terms of features.
+Smartdown didn't match Ruby Smart Answers in terms of features. Adding support for these features to Smartdown would have required extensions to the grammar and hence the parser. The cost of this would've been relatively high, especially considering that Ruby Smart Answers already had all the functionality we needed (apart from multiple questions-per-page).
+
+The state of many of the Ruby Smart Answers would've made it hard to convert them to Smartdown without extensive refactoring.
+
+
 
 As at April 2015 there were:
 


### PR DESCRIPTION
This documents our decision to remove Smartdown from the Smart Answers project.

See Documenting Architecture Decisions[1] for some background of ADRs.

See presentation/adr-001[2] and backdrop/adr-001[3] for examples of ADR use
within GDS.

[1]: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
[2]: https://github.com/openregister/presentation/blob/master/doc/arch/adr-001-remove-kafka.md
[3]: https://github.com/alphagov/backdrop/blob/master/doc/arch/adr-001-implementation-language.md