### PR TITLE
Use Publishing API v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 24.4.0'
+  gem 'gds-api-adapters', '~> 25.1'
 end
 
 if ENV['GOVSPEAK_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,12 +66,12 @@ GEM
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     docile (1.1.5)
-    domain_name (0.5.24)
+    domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.4.0)
     extlib (0.9.16)
-    gds-api-adapters (24.4.0)
+    gds-api-adapters (25.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -121,7 +121,7 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
@@ -139,7 +139,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.6.4)
-    rack-cache (1.2)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -265,7 +265,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   ci_reporter
   extlib (= 0.9.16)
-  gds-api-adapters (~> 24.4.0)
+  gds-api-adapters (~> 25.1)
   govspeak (~> 3.3.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint

--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -7,12 +7,13 @@ class FlowContentItem
 
   def payload
     {
+      base_path: base_path,
       title: flow_presenter.title,
       content_id: flow_presenter.content_id,
       format: 'placeholder_smart_answer',
       publishing_app: 'smartanswers',
       rendering_app: 'smartanswers',
-      update_type: 'minor',
+      update_type: 'minor', # This is not used, but required by the schema.
       locale: 'en',
       public_updated_at: Time.now.iso8601,
       routes: [
@@ -20,6 +21,12 @@ class FlowContentItem
       ]
     }
   end
+
+  def content_id
+    flow_presenter.content_id
+  end
+
+private
 
   def base_path
     '/' + flow_presenter.slug

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -2,7 +2,8 @@ class ContentItemPublisher
   def publish(flow_presenters)
     flow_presenters.each do |smart_answer|
       content_item = FlowContentItem.new(smart_answer)
-      Services.publishing_api.put_content_item(content_item.base_path, content_item.payload)
+      Services.publishing_api.put_content(content_item.content_id, content_item.payload)
+      Services.publishing_api.publish(content_item.content_id, 'minor')
     end
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,10 +1,10 @@
-require 'gds_api/publishing_api'
+require 'gds_api/publishing_api_v2'
 require 'gds_api/imminence'
 require 'gds_api/worldwide'
 
 module Services
   def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
+    @publishing_api ||= GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
   end
 
   def self.imminence_api

--- a/lib/smart_answer_flows/pay-leave-for-parents.rb
+++ b/lib/smart_answer_flows/pay-leave-for-parents.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   class PayLeaveForParentsFlow < Flow
     def define
+      content_id "1f6b4ecc-ce2c-488a-b9c7-b78b3bba5598"
       name "pay-leave-for-parents"
       status :published
       satisfies_need "101018"

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/pay-leave-for-parents.rb: 2e88417e998adfcf81610f01d9434e1b
+lib/smart_answer_flows/pay-leave-for-parents.rb: 1c29ac285bf104fbda7c7592a590aae1
 lib/smart_answer_flows/locales/en/pay-leave-for-parents.yml: 4fbf50de17ab9c2082b335519cce6b69
 test/data/pay-leave-for-parents-questions-and-responses.yml: 6aae67d1b585e8445878fb2994bac8d1
 test/data/pay-leave-for-parents-responses-and-expected-results.yml: 2cdd65aad00267bdf9a534e22858f03d

--- a/test/unit/flow_content_item_test.rb
+++ b/test/unit/flow_content_item_test.rb
@@ -19,10 +19,10 @@ module SmartAnswer
     end
 
     test '#base_path is the name of the flow' do
-      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death'))
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '25b98dfb-fabe-4b16-b587-072c8233f6bc'))
       content_item = FlowContentItem.new(presenter)
 
-      base_path = content_item.base_path
+      base_path = content_item.payload[:base_path]
 
       assert_equal "/bridge-of-death", base_path
     end

--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -7,11 +7,14 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
   end
 
   test 'sending item to content store' do
-    request = stub_request(:put, "http://publishing-api.dev.gov.uk/content/bridge-of-death")
+    draft_request = stub_request(:put, "http://publishing-api.dev.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685")
+    publishing_request = stub_request(:post, "http://publishing-api.dev.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685/publish")
+
     presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685'))
 
     ContentItemPublisher.new.publish([presenter])
 
-    assert_requested request
+    assert_requested draft_request
+    assert_requested publishing_request
   end
 end


### PR DESCRIPTION
The new V2 endpoint:

- works by content_id, which means we can more easily change slugs in the future
- allows us to only send the content, not the links. The links will contain the taggings for this content item, and tagging them separately will enable us to tag from more than one tool. Without this "content-only", this app would overwrite taggings done by other apps.

cc @rboulton