### PR TITLE
Add missing calculated value in paternity calculator

### DIFF
--- a/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
@@ -102,6 +102,10 @@ multiple_choice :employee_responsible_for_upbringing? do
     due_date
   end
 
+  calculate :qualifying_week_start do
+    calculator.qualifying_week.first
+  end
+
   calculate :p_notice_leave do
     calculator.notice_of_leave_deadline
   end

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -19,7 +19,7 @@ lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_leave_a
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_not_entitled_to_leave_or_pay.govspeak.erb: 6909d514cd992d94400407ded6f4a024
 lib/smart_answer_flows/shared_logic/adoption-calculator.rb: c166e63f0d4694acc664c789953659ba
 lib/smart_answer_flows/shared_logic/maternity-calculator.rb: 5b566b38ef501d2a7c69a5e94ca18c2e
-lib/smart_answer_flows/shared_logic/paternity-calculator.rb: 5aa842a23e800ee5575553f17dafbc39
+lib/smart_answer_flows/shared_logic/paternity-calculator.rb: b09bdfd9c704ddbe78252173c4ccd0bd
 lib/smart_answer/calculators/maternity_paternity_calculator.rb: 24de99189c23e9a7cc048871a817bb3c
 lib/data/rates/maternity_paternity_birth.yml: 3eef956f1020576a9343647fec34dd01
 lib/data/rates/maternity_paternity_adoption.yml: 453c4d90b6fd9ffe1556782665f313fc

--- a/test/integration/smart_answer_flows/adoption_calculator_test.rb
+++ b/test/integration/smart_answer_flows/adoption_calculator_test.rb
@@ -53,6 +53,10 @@ class AdoptionCalculatorTest < ActiveSupport::TestCase
                 assert_state_variable "employee_has_contract_adoption", 'yes'
                 assert_current_node :adoption_is_the_employee_on_your_payroll?
               end
+              should 'render the question title with an interpolated date' do
+                nodes = Capybara.string(current_question.to_s)
+                assert nodes.has_content?('Was the employee (or will they be) on your payroll on')
+              end
               context "answer yes" do
                 setup { add_response :yes }
                 ## QA6

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -22,6 +22,13 @@ module FlowTestHelper
     end
   end
 
+  def current_question
+    @current_question ||= begin
+      presenter = QuestionPresenter.new("flow.#{@flow.name}", @flow.node(current_state.current_node), current_state)
+      presenter.title
+    end
+  end
+
   def outcome_body
     @outcome_body ||= begin
       presenter = OutcomePresenter.new("flow.#{@flow.name}", @flow.node(current_state.current_node), current_state)

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -350,6 +350,10 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
               should "ask if the employee is on your payroll" do
                 assert_current_node :is_the_employee_on_your_payroll?
               end
+              should 'render the question title with an interpolated date' do
+                nodes = Capybara.string(current_question.to_s)
+                assert nodes.has_content?('Was the employee (or will they be) on your payroll on')
+              end
               context "answer yes" do
                 setup do
                   add_response :yes

--- a/test/integration/smart_answer_flows/paternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/paternity_calculator_test.rb
@@ -84,6 +84,10 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
                     assert_current_node :employee_on_payroll_paternity?
                   end
 
+                  should 'render the question title with an interpolated date' do
+                    nodes = Capybara.string(current_question.to_s)
+                    assert nodes.has_content?('Was the employee (or will they be) on your payroll on')
+                  end
                   context "answer yes" do
                     setup { add_response :yes }
 
@@ -332,6 +336,10 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
                     assert_current_node :employee_on_payroll_paternity?
                   end
 
+                  should 'render the question title with an interpolated date' do
+                    nodes = Capybara.string(current_question.to_s)
+                    assert nodes.has_content?('Was the employee (or will they be) on your payroll on')
+                  end
                   context "answer no" do
                     setup { add_response :no }
 


### PR DESCRIPTION
Adds tests to the adoption, maternity and paternity smart answers to ensure that questions with interpolated values are rendered correctly.

Adds a test helper method #question_title reads the value of a question as a String, forcing the interpolation to occur, so it can be asserted with a has_content? matcher in integration tests.

Updates the paternity calculator, adding the missing calculated value that is interpolated into the question title.

## Verify step

[Example URL](http://localhost:3000/maternity-paternity-calculator/y/paternity/no/2015-10-29/2015-10-29/yes/yes/yes/yes/yes/2015-10-29/two_weeks/2015-07-16)
 * Shows a question "Was the employee (or will they be) on your payroll on 12 July 2015?" within the previous answers without breaking the page.

<img width="1155" alt="screen shot 2015-11-05 at 4 16 09 pm" src="https://cloud.githubusercontent.com/assets/351763/10974661/14e9f8d6-83db-11e5-9c2b-8708b5030ec7.png">

