### PR TITLE
Correctly pluralise values in calculate-your-holiday-entitlement

### DIFF
--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/annualised_hours_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/annualised_hours_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!The statutory entitlement is <%= holiday_entitlement_hours %> hours and <%= holiday_entitlement_minutes %> minutes holiday for the year.$!
+  $!The statutory entitlement is <%= pluralize(holiday_entitlement_hours, 'hour') %> and <%= pluralize(holiday_entitlement_minutes, 'minute') %> holiday for the year.$!
 
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' -%>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/casual_or_irregular_hours_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/casual_or_irregular_hours_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!The statutory holiday entitlement is <%= holiday_entitlement_hours %> hours and <%= holiday_entitlement_minutes %> minutes for the time that’s been worked.$!
+  $!The statutory holiday entitlement is <%= pluralize(holiday_entitlement_hours, 'hour') %> and <%= pluralize(holiday_entitlement_minutes, 'minute') %> for the time that’s been worked.$!
 
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' -%>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!The statutory holiday entitlement is <%= holiday_entitlement_hours %> hours and <%= holiday_entitlement_minutes %> minutes holiday for the year. Rather than taking a day’s holiday it’s <%= hours_daily %> hours and <%= minutes_daily %> minutes holiday for each day otherwise worked.$!
+  $!The statutory holiday entitlement is <%= pluralize(holiday_entitlement_hours, 'hour') %> and <%= pluralize(holiday_entitlement_minutes, 'minute') %> holiday for the year. Rather than taking a day’s holiday it’s <%= pluralize(hours_daily, 'hour') %> and <%= pluralize(minutes_daily, 'minute') %> holiday for each day otherwise worked.$!
 
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' -%>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!The statutory holiday entitlement is <%= holiday_entitlement_days %> days holiday.$!
+  $!The statutory holiday entitlement is <%= pluralize(holiday_entitlement_days, 'day') %> holiday.$!
 
   <% if days_per_week > 5 and calculator.full_time_part_time_days >= 28 %>
     Even though more than 5 days a week are worked the maximum statutory holiday entitlement is 28 days.

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!The statutory entitlement is <%= holiday_entitlement_hours %> hours and <%= holiday_entitlement_minutes %> minutes holiday.$!
+  $!The statutory entitlement is <%= pluralize(holiday_entitlement_hours, 'hour') %> and <%= pluralize(holiday_entitlement_minutes, 'minute') %> holiday.$!
 
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' -%>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!The statutory holiday entitlement is <%= holiday_entitlement_shifts %> shifts for the year. Each shift being <%= hours_per_shift %> hours.$!
+  $!The statutory holiday entitlement is <%= pluralize(holiday_entitlement_shifts, 'shift') %> for the year. Each shift being <%= pluralize(hours_per_shift, 'hour') %>.$!
 
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' -%>
 <% end %>

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -5,10 +5,10 @@ test/data/calculate-your-holiday-entitlement-questions-and-responses.yml: a5d687
 test/data/calculate-your-holiday-entitlement-responses-and-expected-results.yml: 5ff2290223d8188d45a84cde9883acf6
 lib/smart_answer_flows/calculate-your-holiday-entitlement/calculate_your_holiday_entitlement.govspeak.erb: 76f569916a2429d42e52afc658285f6a
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_your_employer_with_rounding.govspeak.erb: 968b6d15a99334328227528f3feea6ba
-lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/annualised_hours_done.govspeak.erb: efe17cf18e3f9218d7c2ee569ada84cc
-lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/casual_or_irregular_hours_done.govspeak.erb: 160b87c3f0128752e6827d7404602515
-lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.govspeak.erb: c69ba051d4b41d8a729d656dd86afc47
-lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb: 214a138b7dbedc186662ea2df1389864
-lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb: 096f7b9741d693cdab7295300b8cfa0d
-lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb: 22ab0c04098de9e46ab3dc6207fb8756
+lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/annualised_hours_done.govspeak.erb: 581b3c28d63a883ca932ad0a309e4f3e
+lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/casual_or_irregular_hours_done.govspeak.erb: daee267a4fe443aea13fd56b51d08c92
+lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.govspeak.erb: 2c3efdf31e9e9fc09f8577be1d58b1a1
+lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb: 30bd1611f5d7f82ac201081d85bbf2fc
+lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb: 49beabeab25baddb8b42b02eebaca12a
+lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb: 58a7a83fc28b048485a3fce1cdda59d2
 lib/smart_answer/calculators/holiday_entitlement.rb: 2e642f3d02f3f4a3defa2c618c5f8289


### PR DESCRIPTION
## Expected changes

* [Example URL](https://www.gov.uk/calculate-your-holiday-entitlement/y/days-worked-per-week/full-year/0.17)
  * Outcome displays correct pluralization of "1 day" in outcome

<img width="1091" alt="screen shot 2015-11-09 at 8 39 20 am" src="https://cloud.githubusercontent.com/assets/351763/11029222/6bc0d0e6-86bd-11e5-8cd0-03304319d2e2.png">
