### PR TITLE
Inline #presenter_for method

### DIFF
--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -38,7 +38,7 @@ class FlowRegistrationPresenter
   def indexable_content
     HTMLEntities.new.decode(
       text = @flow.questions.inject([start_node.body]) { |acc, node|
-        pres = presenter_for(node)
+        pres = QuestionPresenter.new(@i18n_prefix, node)
         acc.concat(NODE_PRESENTER_METHODS.map { |method|
           begin
             pres.send(method)
@@ -56,15 +56,6 @@ class FlowRegistrationPresenter
   end
 
 private
-
-  def presenter_for(node)
-    case node
-    when SmartAnswer::Question::Base
-      QuestionPresenter.new(@i18n_prefix, node)
-    when SmartAnswer::Outcome
-      OutcomePresenter.new(@i18n_prefix, node)
-    end
-  end
 
   def start_node
     node = SmartAnswer::Node.new(@flow, @flow.name.underscore.to_sym)


### PR DESCRIPTION
Since becb787a1247c3192fed391184d93956b047bc7d we've only been dealing with
question nodes in #indexable_content so we can always instantiate a
QuestionPresenter.