### PR TITLE
Use next_node blocks in calculate-your-child-maintenance

### DIFF
--- a/lib/smart_answer_flows/calculate-your-child-maintenance.rb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance.rb
@@ -52,8 +52,18 @@ module SmartAnswer
           Calculators::ChildMaintenanceCalculator.new(number_of_children, benefits, paying_or_receiving)
         end
 
-        next_node_if(:how_many_nights_children_stay_with_payee?, responded_with('yes'))
-        next_node :gross_income_of_payee?
+        permitted_next_nodes = [
+          :how_many_nights_children_stay_with_payee?,
+          :gross_income_of_payee?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case response
+          when 'yes'
+            :how_many_nights_children_stay_with_payee?
+          when 'no'
+            :gross_income_of_payee?
+          end
+        end
       end
 
       ## Q3

--- a/lib/smart_answer_flows/calculate-your-child-maintenance.rb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance.rb
@@ -78,9 +78,21 @@ module SmartAnswer
           calculator.rate_type
         end
 
-        next_node_if(:nil_rate_result) { rate_type == :nil }
-        next_node_if(:flat_rate_result) { rate_type == :flat }
-        next_node :how_many_other_children_in_payees_household?
+        permitted_next_nodes = [
+          :nil_rate_result,
+          :flat_rate_result,
+          :how_many_other_children_in_payees_household?
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          case rate_type
+          when :nil
+            :nil_rate_result
+          when :flat
+            :flat_rate_result
+          else
+            :how_many_other_children_in_payees_household?
+          end
+        end
       end
 
       ## Q4

--- a/lib/smart_answer_flows/calculate-your-child-maintenance.rb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance.rb
@@ -131,9 +131,21 @@ module SmartAnswer
           calculator.rate_type
         end
 
-        next_node_if(:nil_rate_result) { rate_type == :nil }
-        next_node_if(:flat_rate_result) { rate_type == :flat }
-        next_node :reduced_and_basic_rates_result
+        permitted_next_nodes = [
+          :nil_rate_result,
+          :flat_rate_result,
+          :reduced_and_basic_rates_result
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          case rate_type
+          when :nil
+            :nil_rate_result
+          when :flat
+            :flat_rate_result
+          else
+            :reduced_and_basic_rates_result
+          end
+        end
       end
 
       outcome :nil_rate_result

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-your-child-maintenance.rb: 2dcb25a6f88c10ba535eb2279d4d9af6
+lib/smart_answer_flows/calculate-your-child-maintenance.rb: 8ec5dae1e6ee86b857e0a2f77d943792
 lib/smart_answer_flows/locales/en/calculate-your-child-maintenance.yml: dec73c1424c87441761d30d342a6a962
 test/data/calculate-your-child-maintenance-questions-and-responses.yml: 4534340cf82c2d7f24a865a8b70855fd
 test/data/calculate-your-child-maintenance-responses-and-expected-results.yml: e5f2d15987daf89c77c28fc4b4b82042


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).