### PR TITLE
Use next_node blocks in energy-grants-calculator

### DIFF
--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -116,9 +116,20 @@ module SmartAnswer
           end
         end
 
-        next_node_if(:which_benefits?) { circumstances.include?('benefits') }
-        next_node_if(:outcome_help_with_bills) { bills_help } # outcome 1
-        next_node(:when_property_built?) # Q6
+        permitted_next_nodes = [
+          :which_benefits?,
+          :outcome_help_with_bills,
+          :when_property_built?
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if circumstances.include?('benefits')
+            :which_benefits?
+          elsif bills_help
+            :outcome_help_with_bills # outcome 1
+          else
+            :when_property_built? # Q6
+          end
+        end
       end
 
       # Q4

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -216,8 +216,17 @@ module SmartAnswer
           response != 'none' && benefits_claimed.include?('universal_credit')
         end
 
-        next_node_if(:outcome_help_with_bills) { bills_help } # outcome 1
-        next_node(:when_property_built?) # Q6
+        permitted_next_nodes = [
+          :outcome_help_with_bills,
+          :when_property_built?
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if bills_help
+            :outcome_help_with_bills # outcome 1
+          else
+            :when_property_built? # Q6
+          end
+        end
       end
 
       # Q6

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -283,9 +283,20 @@ module SmartAnswer
         option :ground_floor
         save_input_as :flat_type
 
-        next_node_if(:home_features_modern?) { modern }
-        next_node_if(:home_features_older?) { older }
-        next_node(:home_features_historic?)
+        permitted_next_nodes = [
+          :home_features_modern?,
+          :home_features_older?,
+          :home_features_historic?
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if modern
+            :home_features_modern?
+          elsif older
+            :home_features_older?
+          else
+            :home_features_historic?
+          end
+        end
       end
 
       # Q8a modern

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -81,14 +81,25 @@ module SmartAnswer
 
         validate(:error_perm_prop) { |r| ! r.include?('permission,property') }
 
-        define_predicate(:measure?) {
+        next_node_calculation(:measure) {
           %w(help_energy_efficiency help_boiler_measure).include?(which_help)
         }
 
-        next_node_if(:date_of_birth?) { both_help }
-        on_condition(measure?) do
-          next_node_if(:which_benefits?, responded_with("benefits"))
-          next_node :when_property_built?
+        permitted_next_nodes = [
+          :date_of_birth?,
+          :which_benefits?,
+          :when_property_built?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if both_help
+            :date_of_birth?
+          elsif measure
+            if response == 'benefits'
+              :which_benefits?
+            else
+              :when_property_built?
+            end
+          end
         end
       end
 

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -310,27 +310,40 @@ module SmartAnswer
           response.split(",")
         end
 
-        define_predicate(:modern_and_gas_and_electric_heating?) do |response|
+        next_node_calculation(:modern_and_gas_and_electric_heating) do |response|
           modern && response.include?('mains_gas') && response.include?('electric_heating')
         end
 
-        define_predicate(:measure_help_and_property_permission_circumstance?) do
+        next_node_calculation(:measure_help_and_property_permission_circumstance) do
           measure_help && (circumstances & %w(property permission)).any?
         end
 
-        define_predicate(:no_benefits?) { circumstances.exclude?('benefits') }
+        next_node_calculation(:no_benefits) { circumstances.exclude?('benefits') }
 
-        define_predicate(:property_permission_circumstance_and_benefits?) do
+        next_node_calculation(:property_permission_circumstance_and_benefits) do
           (circumstances & %w(property permission)).any? and ((benefits_claimed & %w(child_tax_credit esa pension_credit)).any? or incomesupp_jobseekers_1 or incomesupp_jobseekers_2)
         end
 
-        next_node_if(:outcome_no_green_deal_no_energy_measures, modern_and_gas_and_electric_heating?)
-        on_condition(measure_help_and_property_permission_circumstance?) do
-          next_node(:outcome_measures_help_green_deal)
+        permitted_next_nodes = [
+          :outcome_no_green_deal_no_energy_measures,
+          :outcome_measures_help_green_deal,
+          :outcome_bills_and_measures_no_benefits,
+          :outcome_bills_and_measures_on_benefits_eco_eligible,
+          :outcome_bills_and_measures_on_benefits_not_eco_eligible
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if modern_and_gas_and_electric_heating
+            :outcome_no_green_deal_no_energy_measures
+          elsif measure_help_and_property_permission_circumstance
+            :outcome_measures_help_green_deal
+          elsif no_benefits
+            :outcome_bills_and_measures_no_benefits
+          elsif property_permission_circumstance_and_benefits
+            :outcome_bills_and_measures_on_benefits_eco_eligible
+          else
+            :outcome_bills_and_measures_on_benefits_not_eco_eligible
+          end
         end
-        next_node_if(:outcome_bills_and_measures_no_benefits, no_benefits?)
-        next_node_if(:outcome_bills_and_measures_on_benefits_eco_eligible, property_permission_circumstance_and_benefits?)
-        next_node(:outcome_bills_and_measures_on_benefits_not_eco_eligible)
       end
 
       # Q8b

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -28,8 +28,18 @@ module SmartAnswer
           ''
         end
 
-        next_node_if(:what_are_your_circumstances?, responded_with("help_with_fuel_bill")) # Q2
-        next_node :what_are_your_circumstances_without_bills_help? # Q2A
+        permitted_next_nodes = [
+          :what_are_your_circumstances?,
+          :what_are_your_circumstances_without_bills_help?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case response
+          when 'help_with_fuel_bill'
+            :what_are_your_circumstances? # Q2
+          else
+            :what_are_your_circumstances_without_bills_help? # Q2A
+          end
+        end
       end
 
       # Q2

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -406,22 +406,33 @@ module SmartAnswer
           response.split(",")
         end
 
-        define_predicate(:measure_help_and_property_permission_circumstance?) do
+        next_node_calculation(:measure_help_and_property_permission_circumstance) do
           measure_help && (circumstances & %w(property permission)).any?
         end
 
-        define_predicate(:no_benefits?) { circumstances.exclude?('benefits') }
+        next_node_calculation(:no_benefits) { circumstances.exclude?('benefits') }
 
-        define_predicate(:property_permission_circumstance_and_benefits?) do
+        next_node_calculation(:property_permission_circumstance_and_benefits) do
           (circumstances & %w(property permission)).any? and ((benefits_claimed & %w(child_tax_credit esa pension_credit)).any? or incomesupp_jobseekers_1 or incomesupp_jobseekers_2)
         end
 
-        on_condition(measure_help_and_property_permission_circumstance?) do
-          next_node(:outcome_measures_help_green_deal)
+        permitted_next_nodes = [
+          :outcome_measures_help_green_deal,
+          :outcome_bills_and_measures_no_benefits,
+          :outcome_bills_and_measures_on_benefits_eco_eligible,
+          :outcome_bills_and_measures_on_benefits_not_eco_eligible
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if measure_help_and_property_permission_circumstance
+            :outcome_measures_help_green_deal
+          elsif no_benefits
+            :outcome_bills_and_measures_no_benefits
+          elsif property_permission_circumstance_and_benefits
+            :outcome_bills_and_measures_on_benefits_eco_eligible
+          else
+            :outcome_bills_and_measures_on_benefits_not_eco_eligible
+          end
         end
-        next_node_if(:outcome_bills_and_measures_no_benefits, no_benefits?)
-        next_node_if(:outcome_bills_and_measures_on_benefits_eco_eligible, property_permission_circumstance_and_benefits?)
-        next_node(:outcome_bills_and_measures_on_benefits_not_eco_eligible)
       end
 
       outcome :outcome_help_with_bills do

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -255,12 +255,26 @@ module SmartAnswer
         option :flat
         save_input_as :property_type
 
-        on_condition(responded_with('house')) do
-          next_node_if(:home_features_modern?) { modern }
-          next_node_if(:home_features_older?) { older }
-          next_node(:home_features_historic?)
+        permitted_next_nodes = [
+          :home_features_modern?,
+          :home_features_older?,
+          :home_features_historic?,
+          :type_of_flat?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case response
+          when 'house'
+            if modern
+              :home_features_modern?
+            elsif older
+              :home_features_older?
+            else
+              :home_features_historic?
+            end
+          else
+            :type_of_flat?
+          end
         end
-        next_node(:type_of_flat?)
       end
 
       # Q7b

--- a/test/data/energy-grants-calculator-files.yml
+++ b/test/data/energy-grants-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/energy-grants-calculator.rb: 167b1c7372c43f754a91ce0dab85dede
+lib/smart_answer_flows/energy-grants-calculator.rb: 55d04a36d23b1777fd5ff0d1c7777fa4
 lib/smart_answer_flows/locales/en/energy-grants-calculator.yml: dd640cd1e93bbdac129b3863552cb554
 test/data/energy-grants-calculator-questions-and-responses.yml: e725aa49320518369f4fdc601cd217b2
 test/data/energy-grants-calculator-responses-and-expected-results.yml: 8b1d6c6350f162a2d4efbc65362b5ae8


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
