### PR TITLE
Use next_node blocks in check-uk-visa

### DIFF
--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -123,7 +123,7 @@ module SmartAnswer
             :outcome_medical_y
           when 'transit'
             if country_group_datv.include?(passport_country) ||
-               country_group_visa_national.include?(passport_country) || %w(taiwan venezuela).include?(passport_country)
+                country_group_visa_national.include?(passport_country) || %w(taiwan venezuela).include?(passport_country)
               :planning_to_leave_airport?
             else
               :outcome_no_visa_needed

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -187,29 +187,46 @@ module SmartAnswer
         option :longer_than_six_months
         save_input_as :period_of_staying
 
-        on_condition(responded_with('longer_than_six_months')) do
-          next_node_if(:outcome_study_y) { purpose_of_visit_answer == 'study' } #outcome 2 study y
-          next_node_if(:outcome_work_y) { purpose_of_visit_answer == 'work' } #outcome 4 work y
-        end
-        on_condition(responded_with('six_months_or_less')) do
-          on_condition(->(_) { purpose_of_visit_answer == 'study' }) do
-            #outcome 12 visit outcome_visit_waiver
-            next_node_if(:outcome_visit_waiver) { %w(oman qatar united-arab-emirates).include?(passport_country) }
-            next_node_if(:outcome_taiwan_exception) { %w(taiwan).include?(passport_country) }
-            #outcome 3 study m visa needed short courses
-            next_node_if(:outcome_study_m) { (country_group_datv + country_group_visa_national).include?(passport_country) }
-            #outcome 1 no visa needed
-            next_node_if(:outcome_no_visa_needed) { (country_group_ukot + country_group_non_visa_national).include?(passport_country) }
-          end
-          on_condition(->(_) { purpose_of_visit_answer == 'work' }) do
-            #outcome 5.5 work N no visa needed
-            next_node_if(:outcome_work_n) {
-              ( (country_group_ukot +
+        permitted_next_nodes = [
+          :outcome_study_y,
+          :outcome_work_y,
+          :outcome_visit_waiver,
+          :outcome_taiwan_exception,
+          :outcome_study_m,
+          :outcome_no_visa_needed,
+          :outcome_work_n,
+          :outcome_work_m
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case response
+          when 'longer_than_six_months'
+            if purpose_of_visit_answer == 'study'
+              :outcome_study_y #outcome 2 study y
+            elsif purpose_of_visit_answer == 'work'
+              :outcome_work_y #outcome 4 work y
+            end
+          when 'six_months_or_less'
+            if purpose_of_visit_answer == 'study'
+              if %w(oman qatar united-arab-emirates).include?(passport_country)
+                :outcome_visit_waiver #outcome 12 visit outcome_visit_waiver
+              elsif %w(taiwan).include?(passport_country)
+                :outcome_taiwan_exception
+              elsif (country_group_datv + country_group_visa_national).include?(passport_country)
+                :outcome_study_m #outcome 3 study m visa needed short courses
+              elsif (country_group_ukot + country_group_non_visa_national).include?(passport_country)
+                :outcome_no_visa_needed #outcome 1 no visa needed
+              end
+            elsif purpose_of_visit_answer == 'work'
+              if ( (country_group_ukot +
                 country_group_non_visa_national) |
                 %w(taiwan) ).include?(passport_country)
-            }
-            # outcome 5 work m visa needed short courses
-            next_node_if(:outcome_work_m) { (country_group_datv + country_group_visa_national).include?(passport_country) }
+                #outcome 5.5 work N no visa needed
+                :outcome_work_n
+              elsif (country_group_datv + country_group_visa_national).include?(passport_country)
+                # outcome 5 work m visa needed short courses
+                :outcome_work_m
+              end
+            end
           end
         end
       end

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -215,9 +215,9 @@ module SmartAnswer
                 :outcome_no_visa_needed #outcome 1 no visa needed
               end
             elsif purpose_of_visit_answer == 'work'
-              if ( (country_group_ukot +
+              if ((country_group_ukot +
                 country_group_non_visa_national) |
-                %w(taiwan) ).include?(passport_country)
+                %w(taiwan)).include?(passport_country)
                 #outcome 5.5 work N no visa needed
                 :outcome_work_n
               elsif (country_group_datv + country_group_visa_national).include?(passport_country)

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -104,7 +104,7 @@ module SmartAnswer
             end
           end
 
-          if country_group_non_visa_national.include?(passport_country) or country_group_ukot.include?(passport_country)
+          if country_group_non_visa_national.include?(passport_country) || country_group_ukot.include?(passport_country)
             if %w{tourism school}.include?(response)
               next :outcome_school_n
             elsif response == 'medical'
@@ -122,8 +122,8 @@ module SmartAnswer
           when 'medical'
             :outcome_medical_y
           when 'transit'
-            if country_group_datv.include?(passport_country) or
-               country_group_visa_national.include?(passport_country) or %w(taiwan venezuela).include?(passport_country)
+            if country_group_datv.include?(passport_country) ||
+               country_group_visa_national.include?(passport_country) || %w(taiwan venezuela).include?(passport_country)
               :planning_to_leave_airport?
             else
               :outcome_no_visa_needed

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -156,9 +156,7 @@ module SmartAnswer
           :outcome_no_visa_needed
         ]
         next_node(permitted: permitted_next_nodes) do |response|
-          if %w(taiwan).include?(passport_country)
-            next :outcome_visit_waiver
-          end
+          next :outcome_visit_waiver if %w(taiwan).include?(passport_country)
 
           case response
           when 'yes'

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/check-uk-visa.rb: dc6d8a2256ebf289915b827bed41bde6
+lib/smart_answer_flows/check-uk-visa.rb: e57516742f6d8cc125fb83408b54d332
 lib/smart_answer_flows/locales/en/check-uk-visa.yml: a8c595b226b52e2c9b5d7b32723fbdb2
 test/data/check-uk-visa-questions-and-responses.yml: 9994bc5cd128249d65befb525a894b45
 test/data/check-uk-visa-responses-and-expected-results.yml: 603a0b14f2a49a20d01cc4b959fb90b7


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
