### PR TITLE
Refactor calculate-statutory-sick-pay

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -150,6 +150,10 @@ module SmartAnswer
         self.class.lower_earning_limit_on(sick_start_date)
       end
 
+      def pattern_days_total
+        pattern_days * 28
+      end
+
       # define as static so we don't have to instantiate the calculator too early in the flow
       def self.lower_earning_limit_on(date)
         SmartAnswer::Calculators::RatesQuery.new('statutory_sick_pay').rates(date).lower_earning_limit_rate

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -29,8 +29,8 @@ module SmartAnswer::Calculators
       (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
     end
 
-    def not_getting_maternity_pay?
-      (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}).any?
+    def already_getting_maternity_pay?
+      (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}).none?
     end
 
     # define as static so we don't have to instantiate the calculator too early in the flow

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -1,6 +1,8 @@
 module SmartAnswer
   module Calculators
     class StatutorySickPayCalculator
+      MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK = 4
+
       include ActiveModel::Model
 
       attr_accessor :prev_sick_days, :sick_start_date, :sick_end_date, :days_of_the_week_worked
@@ -47,6 +49,20 @@ module SmartAnswer
 
       def valid_linked_sickness_start_date?(value)
         sick_start_date > value
+      end
+
+      def within_eight_weeks_of_current_sickness_period?(value)
+        furthest_allowed_date = sick_start_date - 8.weeks
+        value > furthest_allowed_date
+      end
+
+      def at_least_1_day_before_first_sick_day?(value)
+        value < sick_start_date - 1
+      end
+
+      def valid_period_of_incapacity_for_work?(value)
+        period = DateRange.new(begins_on: linked_sickness_start_date, ends_on: value)
+        period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
       end
 
       def sick_start_date_for_awe

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -2,7 +2,7 @@ module SmartAnswer::Calculators
   class StatutorySickPayCalculator
     include ActiveModel::Model
 
-    attr_writer :prev_sick_days, :sick_start_date, :sick_end_date, :days_of_the_week_worked
+    attr_accessor :prev_sick_days, :sick_start_date, :sick_end_date, :days_of_the_week_worked
 
     def waiting_days
       @prev_sick_days >= 3 ? 0 : 3 - @prev_sick_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -73,6 +73,10 @@ module SmartAnswer
         value < sick_start_date - 1
       end
 
+      def valid_period_of_incapacity_for_work?
+        days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
+      end
+
       def valid_linked_period_of_incapacity_for_work?(value)
         period = DateRange.new(begins_on: linked_sickness_start_date, ends_on: value)
         period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -7,6 +7,7 @@ module SmartAnswer
 
       attr_accessor :prev_sick_days, :sick_start_date, :sick_end_date, :days_of_the_week_worked
       attr_accessor :other_pay_types_received, :enough_notice_of_absence
+      attr_accessor :has_linked_sickness
       attr_accessor :linked_sickness_start_date, :linked_sickness_end_date
 
       def waiting_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -5,6 +5,7 @@ module SmartAnswer
 
       attr_accessor :prev_sick_days, :sick_start_date, :sick_end_date, :days_of_the_week_worked
       attr_accessor :other_pay_types_received, :enough_notice_of_absence
+      attr_accessor :linked_sickness_start_date, :linked_sickness_end_date
 
       def waiting_days
         @prev_sick_days >= 3 ? 0 : 3 - @prev_sick_days
@@ -42,6 +43,14 @@ module SmartAnswer
       def valid_last_sick_day?(value)
         period = DateRange.new(begins_on: sick_start_date, ends_on: value)
         period.number_of_days >= 1
+      end
+
+      def sick_start_date_for_awe
+        linked_sickness_start_date || sick_start_date
+      end
+
+      def sick_end_date_for_awe
+        linked_sickness_end_date || sick_end_date
       end
 
       # define as static so we don't have to instantiate the calculator too early in the flow

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -45,6 +45,10 @@ module SmartAnswer
         period.number_of_days >= 1
       end
 
+      def valid_linked_sickness_start_date?(value)
+        sick_start_date > value
+      end
+
       def sick_start_date_for_awe
         linked_sickness_start_date || sick_start_date
       end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -249,7 +249,7 @@ module SmartAnswer
 
       def weekly_payments
         payments = sick_pay_weekly_dates.map { |date| [date, weekly_payment(date)] }
-        payments.pop while payments.any? and payments.last.last == 0
+        payments.pop while payments.any? && (payments.last.last == 0)
         payments
       end
 

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -11,6 +11,7 @@ module SmartAnswer
       attr_accessor :linked_sickness_start_date, :linked_sickness_end_date
       attr_accessor :relevant_period_to, :relevant_period_from
       attr_accessor :eight_weeks_earnings
+      attr_accessor :pay_pattern
 
       def prev_sick_days
         prior_sick_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -211,6 +211,10 @@ module SmartAnswer
         employee_average_weekly_earnings < self.class.lower_earning_limit_on(sick_start_date)
       end
 
+      def maximum_entitlement_reached?
+        prior_sick_days >= (days_of_the_week_worked.size * 28 + 3)
+      end
+
       def self.contractual_earnings_awe(pay, days_worked)
         (pay / BigDecimal.new(days_worked.to_s) * 7).round(2)
       end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -215,6 +215,10 @@ module SmartAnswer
         prior_sick_days >= (days_of_the_week_worked.size * 28 + 3)
       end
 
+      def maximum_entitlement_reached_v2?
+        days_that_can_be_paid_for_this_period == 0
+      end
+
       def entitled_to_sick_pay?
         ssp_payment > 0
       end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -9,6 +9,7 @@ module SmartAnswer
       attr_accessor :other_pay_types_received, :enough_notice_of_absence
       attr_accessor :has_linked_sickness
       attr_accessor :linked_sickness_start_date, :linked_sickness_end_date
+      attr_accessor :relevant_period_to
 
       def prev_sick_days
         prior_sick_days
@@ -86,6 +87,10 @@ module SmartAnswer
           pattern: days_of_the_week_worked
         )
         prev_sick_days.length
+      end
+
+      def pay_day_offset
+        relevant_period_to - 8.weeks
       end
 
       # define as static so we don't have to instantiate the calculator too early in the flow

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -146,6 +146,10 @@ module SmartAnswer
         end
       end
 
+      def lower_earning_limit
+        self.class.lower_earning_limit_on(sick_start_date)
+      end
+
       # define as static so we don't have to instantiate the calculator too early in the flow
       def self.lower_earning_limit_on(date)
         SmartAnswer::Calculators::RatesQuery.new('statutory_sick_pay').rates(date).lower_earning_limit_rate

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -1,186 +1,188 @@
-module SmartAnswer::Calculators
-  class StatutorySickPayCalculator
-    include ActiveModel::Model
+module SmartAnswer
+  module Calculators
+    class StatutorySickPayCalculator
+      include ActiveModel::Model
 
-    attr_accessor :prev_sick_days, :sick_start_date, :sick_end_date, :days_of_the_week_worked
-    attr_accessor :other_pay_types_received, :enough_notice_of_absence
+      attr_accessor :prev_sick_days, :sick_start_date, :sick_end_date, :days_of_the_week_worked
+      attr_accessor :other_pay_types_received, :enough_notice_of_absence
 
-    def waiting_days
-      @prev_sick_days >= 3 ? 0 : 3 - @prev_sick_days
-    end
-
-    def pattern_days
-      @days_of_the_week_worked.length
-    end
-
-    def normal_workdays_missed
-      @normal_workdays_missed ||= init_normal_workdays_missed(@days_of_the_week_worked)
-    end
-
-    def normal_workdays
-      normal_workdays_missed.length
-    end
-
-    def payable_days
-      @payable_days ||= init_payable_days
-    end
-
-    def paternity_maternity_warning?
-      (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
-    end
-
-    def already_getting_maternity_pay?
-      (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}).none?
-    end
-
-    def days_sick
-      period = SmartAnswer::DateRange.new(begins_on: sick_start_date, ends_on: sick_end_date)
-      period.number_of_days
-    end
-
-    def valid_last_sick_day?(value)
-      period = SmartAnswer::DateRange.new(begins_on: sick_start_date, ends_on: value)
-      period.number_of_days >= 1
-    end
-
-    # define as static so we don't have to instantiate the calculator too early in the flow
-    def self.lower_earning_limit_on(date)
-      SmartAnswer::Calculators::RatesQuery.new('statutory_sick_pay').rates(date).lower_earning_limit_rate
-    end
-
-    def self.months_between(start_date, end_date)
-      end_month = end_date.month
-      current_month = start_date.next_month
-      count = 0
-      count += 1 if start_date.day < 17
-      count += 1 if end_date.day > 15
-      while current_month.month != end_month
-        count += 1
-        current_month = current_month.next_month
+      def waiting_days
+        @prev_sick_days >= 3 ? 0 : 3 - @prev_sick_days
       end
-      count
-    end
 
-    def self.average_weekly_earnings(args)
-      pay, pay_pattern, monthly_pattern_payments = args.values_at(:pay, :pay_pattern, :monthly_pattern_payments)
-      case pay_pattern
-      when "weekly", "fortnightly", "every_4_weeks"
-        pay / 8.0
-      when "monthly"
-        pay / monthly_pattern_payments * 12.0 / 52
-      when "irregularly"
-        relevant_period_to, relevant_period_from = args.values_at(:relevant_period_to, :relevant_period_from)
-        pay / (relevant_period_to - relevant_period_from).to_i * 7
+      def pattern_days
+        @days_of_the_week_worked.length
       end
-    end
 
-    def daily_rate_from_weekly(weekly_rate, pattern_days)
-      # we need to calculate the daily rate by truncating to four decimal places to match unrounded daily rates used by HMRC
-      # doing .round(6) after multiplication to avoid float precision issues
-      # Simply using .round(4) on ssp_weekly_rate/@pattern_days will be off by 0.0001 for 3 and 7 pattern days and lead to 1p difference in some statutory amount calculations
-      pattern_days > 0 ? ((((weekly_rate / pattern_days) * 10000).round(6).floor) / 10000.0) : 0.0000
-    end
+      def normal_workdays_missed
+        @normal_workdays_missed ||= init_normal_workdays_missed(@days_of_the_week_worked)
+      end
 
-    def days_paid
-      [days_to_pay, days_that_can_be_paid_for_this_period].min
-    end
+      def normal_workdays
+        normal_workdays_missed.length
+      end
 
-    def days_that_can_be_paid_for_this_period
-      [max_days_that_can_be_paid - days_paid_in_linked_period, 0].max
-    end
+      def payable_days
+        @payable_days ||= init_payable_days
+      end
 
-    def formatted_sick_pay_weekly_amounts
-      weekly_payments.map { |week|
-        [week.first.strftime("%e %B %Y"), sprintf("£%.2f", week.second)].join("|")
-      }.join("\n")
-    end
+      def paternity_maternity_warning?
+        (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
+      end
 
-    def ssp_payment
-      BigDecimal.new(weekly_payments.map(&:last).sum.round(10).to_s).round(2, BigDecimal::ROUND_UP).to_f
-    end
+      def already_getting_maternity_pay?
+        (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}).none?
+      end
 
-    def self.contractual_earnings_awe(pay, days_worked)
-      (pay / BigDecimal.new(days_worked.to_s) * 7).round(2)
-    end
+      def days_sick
+        period = DateRange.new(begins_on: sick_start_date, ends_on: sick_end_date)
+        period.number_of_days
+      end
 
-    def self.total_earnings_awe(pay, days_worked)
-      if days_worked % 7 == 0
-        (pay / (days_worked / 7)).round(2)
-      else
+      def valid_last_sick_day?(value)
+        period = DateRange.new(begins_on: sick_start_date, ends_on: value)
+        period.number_of_days >= 1
+      end
+
+      # define as static so we don't have to instantiate the calculator too early in the flow
+      def self.lower_earning_limit_on(date)
+        SmartAnswer::Calculators::RatesQuery.new('statutory_sick_pay').rates(date).lower_earning_limit_rate
+      end
+
+      def self.months_between(start_date, end_date)
+        end_month = end_date.month
+        current_month = start_date.next_month
+        count = 0
+        count += 1 if start_date.day < 17
+        count += 1 if end_date.day > 15
+        while current_month.month != end_month
+          count += 1
+          current_month = current_month.next_month
+        end
+        count
+      end
+
+      def self.average_weekly_earnings(args)
+        pay, pay_pattern, monthly_pattern_payments = args.values_at(:pay, :pay_pattern, :monthly_pattern_payments)
+        case pay_pattern
+        when "weekly", "fortnightly", "every_4_weeks"
+          pay / 8.0
+        when "monthly"
+          pay / monthly_pattern_payments * 12.0 / 52
+        when "irregularly"
+          relevant_period_to, relevant_period_from = args.values_at(:relevant_period_to, :relevant_period_from)
+          pay / (relevant_period_to - relevant_period_from).to_i * 7
+        end
+      end
+
+      def daily_rate_from_weekly(weekly_rate, pattern_days)
+        # we need to calculate the daily rate by truncating to four decimal places to match unrounded daily rates used by HMRC
+        # doing .round(6) after multiplication to avoid float precision issues
+        # Simply using .round(4) on ssp_weekly_rate/@pattern_days will be off by 0.0001 for 3 and 7 pattern days and lead to 1p difference in some statutory amount calculations
+        pattern_days > 0 ? ((((weekly_rate / pattern_days) * 10000).round(6).floor) / 10000.0) : 0.0000
+      end
+
+      def days_paid
+        [days_to_pay, days_that_can_be_paid_for_this_period].min
+      end
+
+      def days_that_can_be_paid_for_this_period
+        [max_days_that_can_be_paid - days_paid_in_linked_period, 0].max
+      end
+
+      def formatted_sick_pay_weekly_amounts
+        weekly_payments.map { |week|
+          [week.first.strftime("%e %B %Y"), sprintf("£%.2f", week.second)].join("|")
+        }.join("\n")
+      end
+
+      def ssp_payment
+        BigDecimal.new(weekly_payments.map(&:last).sum.round(10).to_s).round(2, BigDecimal::ROUND_UP).to_f
+      end
+
+      def self.contractual_earnings_awe(pay, days_worked)
         (pay / BigDecimal.new(days_worked.to_s) * 7).round(2)
       end
-    end
 
-    def self.dates_matching_pattern(from:, to:, pattern:)
-      dates = from..to
-      # create an array of all dates that would have been normal workdays
-      matching_dates = []
-      dates.each do |d|
-        matching_dates << d if pattern.include?(d.wday.to_s)
+      def self.total_earnings_awe(pay, days_worked)
+        if days_worked % 7 == 0
+          (pay / (days_worked / 7)).round(2)
+        else
+          (pay / BigDecimal.new(days_worked.to_s) * 7).round(2)
+        end
       end
-      matching_dates
-    end
 
-  private
-
-    def weekly_rate_on(date)
-      SmartAnswer::Calculators::RatesQuery.new('statutory_sick_pay').rates(date).ssp_weekly_rate
-    end
-
-    def max_days_that_can_be_paid
-      (28 * pattern_days).round(10)
-    end
-
-    def days_to_pay
-      payable_days.length
-    end
-
-    def sick_pay_weekly_dates
-      if @sick_end_date.sunday?
-        ssp_week_end = @sick_end_date + 6
-      else
-        ssp_week_end = @sick_end_date.end_of_week - 1
+      def self.dates_matching_pattern(from:, to:, pattern:)
+        dates = from..to
+        # create an array of all dates that would have been normal workdays
+        matching_dates = []
+        dates.each do |d|
+          matching_dates << d if pattern.include?(d.wday.to_s)
+        end
+        matching_dates
       end
-      (@sick_start_date..ssp_week_end).select { |day| day.wday == 6 }
-    end
 
-    def weekly_payments
-      payments = sick_pay_weekly_dates.map { |date| [date, weekly_payment(date)] }
-      payments.pop while payments.any? and payments.last.last == 0
-      payments
-    end
+    private
 
-    def weekly_payment(week_start_date)
-      pay = 0.0
-      ((week_start_date - 6)..week_start_date).each do |date|
-        pay += daily_rate_from_weekly(weekly_rate_on(date), pattern_days) if payable_days.include?(date)
+      def weekly_rate_on(date)
+        SmartAnswer::Calculators::RatesQuery.new('statutory_sick_pay').rates(date).ssp_weekly_rate
       end
-      BigDecimal.new(pay.round(10).to_s).round(2, BigDecimal::ROUND_UP).to_f
-    end
 
-    def days_paid_in_linked_period
-      if @prev_sick_days > 3
-        @prev_sick_days - 3
-      else
-        0
+      def max_days_that_can_be_paid
+        (28 * pattern_days).round(10)
       end
-    end
 
-    def init_normal_workdays_missed(days_of_the_week_worked)
-      self.class.dates_matching_pattern(
-        from: @sick_start_date,
-        to: @sick_end_date,
-        pattern: days_of_the_week_worked
-      )
-    end
+      def days_to_pay
+        payable_days.length
+      end
 
-    def init_payable_days
-      # copy not to modify the instance variable we need to keep
-      payable_days_temp = normal_workdays_missed.dup
-      ## 1. remove up to 3 first dates from the array if there are waiting days in this period
-      payable_days_temp.shift(waiting_days)
-      ## 2. return only the first days_that_can_be_paid_for_this_period
-      payable_days_temp.shift(days_that_can_be_paid_for_this_period)
+      def sick_pay_weekly_dates
+        if @sick_end_date.sunday?
+          ssp_week_end = @sick_end_date + 6
+        else
+          ssp_week_end = @sick_end_date.end_of_week - 1
+        end
+        (@sick_start_date..ssp_week_end).select { |day| day.wday == 6 }
+      end
+
+      def weekly_payments
+        payments = sick_pay_weekly_dates.map { |date| [date, weekly_payment(date)] }
+        payments.pop while payments.any? and payments.last.last == 0
+        payments
+      end
+
+      def weekly_payment(week_start_date)
+        pay = 0.0
+        ((week_start_date - 6)..week_start_date).each do |date|
+          pay += daily_rate_from_weekly(weekly_rate_on(date), pattern_days) if payable_days.include?(date)
+        end
+        BigDecimal.new(pay.round(10).to_s).round(2, BigDecimal::ROUND_UP).to_f
+      end
+
+      def days_paid_in_linked_period
+        if @prev_sick_days > 3
+          @prev_sick_days - 3
+        else
+          0
+        end
+      end
+
+      def init_normal_workdays_missed(days_of_the_week_worked)
+        self.class.dates_matching_pattern(
+          from: @sick_start_date,
+          to: @sick_end_date,
+          pattern: days_of_the_week_worked
+        )
+      end
+
+      def init_payable_days
+        # copy not to modify the instance variable we need to keep
+        payable_days_temp = normal_workdays_missed.dup
+        ## 1. remove up to 3 first dates from the array if there are waiting days in this period
+        payable_days_temp.shift(waiting_days)
+        ## 2. return only the first days_that_can_be_paid_for_this_period
+        payable_days_temp.shift(days_that_can_be_paid_for_this_period)
+      end
     end
   end
 end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -10,6 +10,7 @@ module SmartAnswer
       attr_accessor :has_linked_sickness
       attr_accessor :linked_sickness_start_date, :linked_sickness_end_date
       attr_accessor :relevant_period_to, :relevant_period_from
+      attr_accessor :eight_weeks_earnings
 
       def prev_sick_days
         prior_sick_days
@@ -103,6 +104,18 @@ module SmartAnswer
 
       def monthly_pattern_payments
         self.class.months_between(relevant_period_from, relevant_period_to)
+      end
+
+      def paid_at_least_8_weeks_of_earnings?
+        eight_weeks_earnings == 'eight_weeks_more'
+      end
+
+      def paid_less_than_8_weeks_of_earnings?
+        eight_weeks_earnings == 'eight_weeks_less'
+      end
+
+      def fell_sick_before_payday?
+        eight_weeks_earnings == 'before_payday'
       end
 
       # define as static so we don't have to instantiate the calculator too early in the flow

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -3,6 +3,7 @@ module SmartAnswer::Calculators
     include ActiveModel::Model
 
     attr_accessor :prev_sick_days, :sick_start_date, :sick_end_date, :days_of_the_week_worked
+    attr_accessor :other_pay_types_received
 
     def waiting_days
       @prev_sick_days >= 3 ? 0 : 3 - @prev_sick_days
@@ -22,6 +23,14 @@ module SmartAnswer::Calculators
 
     def payable_days
       @payable_days ||= init_payable_days
+    end
+
+    def paternity_maternity_warning?
+      (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
+    end
+
+    def not_getting_maternity_pay?
+      (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}).any?
     end
 
     # define as static so we don't have to instantiate the calculator too early in the flow

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -14,6 +14,7 @@ module SmartAnswer
       attr_accessor :pay_pattern
       attr_accessor :relevant_contractual_pay
       attr_accessor :total_earnings_before_sick_period
+      attr_accessor :employee_average_weekly_earnings
 
       def prev_sick_days
         prior_sick_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -3,7 +3,7 @@ module SmartAnswer::Calculators
     include ActiveModel::Model
 
     attr_accessor :prev_sick_days, :sick_start_date, :sick_end_date, :days_of_the_week_worked
-    attr_accessor :other_pay_types_received
+    attr_accessor :other_pay_types_received, :enough_notice_of_absence
 
     def waiting_days
       @prev_sick_days >= 3 ? 0 : 3 - @prev_sick_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -13,6 +13,7 @@ module SmartAnswer
       attr_accessor :eight_weeks_earnings
       attr_accessor :pay_pattern
       attr_accessor :relevant_contractual_pay
+      attr_accessor :total_earnings_before_sick_period
 
       def prev_sick_days
         prior_sick_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -73,7 +73,7 @@ module SmartAnswer
         value < sick_start_date - 1
       end
 
-      def valid_period_of_incapacity_for_work?(value)
+      def valid_linked_period_of_incapacity_for_work?(value)
         period = DateRange.new(begins_on: linked_sickness_start_date, ends_on: value)
         period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
       end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -207,6 +207,10 @@ module SmartAnswer
         Money.new(amount)
       end
 
+      def not_earned_enough?
+        employee_average_weekly_earnings < self.class.lower_earning_limit_on(sick_start_date)
+      end
+
       def self.contractual_earnings_awe(pay, days_worked)
         (pay / BigDecimal.new(days_worked.to_s) * 7).round(2)
       end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -12,6 +12,7 @@ module SmartAnswer
       attr_accessor :relevant_period_to, :relevant_period_from
       attr_accessor :eight_weeks_earnings
       attr_accessor :pay_pattern
+      attr_accessor :relevant_contractual_pay
 
       def prev_sick_days
         prior_sick_days

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -14,7 +14,9 @@ module SmartAnswer
       attr_accessor :pay_pattern
       attr_accessor :relevant_contractual_pay
       attr_accessor :total_earnings_before_sick_period
-      attr_accessor :employee_average_weekly_earnings
+      attr_accessor :total_employee_earnings
+      attr_accessor :contractual_days_covered_by_earnings
+      attr_accessor :days_covered_by_earnings
 
       def prev_sick_days
         prior_sick_days
@@ -120,6 +122,28 @@ module SmartAnswer
 
       def fell_sick_before_payday?
         eight_weeks_earnings == 'before_payday'
+      end
+
+      def employee_average_weekly_earnings
+        if paid_at_least_8_weeks_of_earnings?
+          self.class.average_weekly_earnings(
+            pay: total_employee_earnings,
+            pay_pattern: pay_pattern,
+            monthly_pattern_payments: monthly_pattern_payments,
+            relevant_period_to: relevant_period_to,
+            relevant_period_from: relevant_period_from
+          )
+        elsif paid_less_than_8_weeks_of_earnings?
+          self.class.total_earnings_awe(
+            total_earnings_before_sick_period,
+            days_covered_by_earnings
+          )
+        elsif fell_sick_before_payday?
+          self.class.contractual_earnings_awe(
+            relevant_contractual_pay,
+            contractual_days_covered_by_earnings
+          )
+        end
       end
 
       # define as static so we don't have to instantiate the calculator too early in the flow

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -71,6 +71,10 @@ module SmartAnswer
         period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
       end
 
+      def valid_last_payday_before_sickness?(value)
+        value < sick_start_date
+      end
+
       def sick_start_date_for_awe
         linked_sickness_start_date || sick_start_date
       end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -33,6 +33,16 @@ module SmartAnswer::Calculators
       (other_pay_types_received & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}).none?
     end
 
+    def days_sick
+      period = SmartAnswer::DateRange.new(begins_on: sick_start_date, ends_on: sick_end_date)
+      period.number_of_days
+    end
+
+    def valid_last_sick_day?(value)
+      period = SmartAnswer::DateRange.new(begins_on: sick_start_date, ends_on: value)
+      period.number_of_days >= 1
+    end
+
     # define as static so we don't have to instantiate the calculator too early in the flow
     def self.lower_earning_limit_on(date)
       SmartAnswer::Calculators::RatesQuery.new('statutory_sick_pay').rates(date).lower_earning_limit_rate

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -200,12 +200,6 @@ module SmartAnswer
         [max_days_that_can_be_paid - days_paid_in_linked_period, 0].max
       end
 
-      def formatted_sick_pay_weekly_amounts
-        weekly_payments.map { |week|
-          [week.first.strftime("%e %B %Y"), sprintf("£%.2f", week.second)].join("|")
-        }.join("\n")
-      end
-
       def ssp_payment
         amount = BigDecimal.new(weekly_payments.map(&:last).sum.round(10).to_s).round(2, BigDecimal::ROUND_UP).to_f
         Money.new(amount)
@@ -249,6 +243,12 @@ module SmartAnswer
         matching_dates
       end
 
+      def weekly_payments
+        payments = sick_pay_weekly_dates.map { |date| [date, weekly_payment(date)] }
+        payments.pop while payments.any? and payments.last.last == 0
+        payments
+      end
+
     private
 
       def weekly_rate_on(date)
@@ -270,12 +270,6 @@ module SmartAnswer
           ssp_week_end = @sick_end_date.end_of_week - 1
         end
         (@sick_start_date..ssp_week_end).select { |day| day.wday == 6 }
-      end
-
-      def weekly_payments
-        payments = sick_pay_weekly_dates.map { |date| [date, weekly_payment(date)] }
-        payments.pop while payments.any? and payments.last.last == 0
-        payments
       end
 
       def weekly_payment(week_start_date)

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -163,13 +163,5 @@ module SmartAnswer::Calculators
       ## 2. return only the first days_that_can_be_paid_for_this_period
       payable_days_temp.shift(days_that_can_be_paid_for_this_period)
     end
-
-    def find_6th_april_after(date)
-      year = date.year
-      if (date.month > 4) or (date.month == 4 and date.day > 6)
-        year += 1
-      end
-      Date.new(year, 4, 6)
-    end
   end
 end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -9,7 +9,7 @@ module SmartAnswer
       attr_accessor :other_pay_types_received, :enough_notice_of_absence
       attr_accessor :has_linked_sickness
       attr_accessor :linked_sickness_start_date, :linked_sickness_end_date
-      attr_accessor :relevant_period_to
+      attr_accessor :relevant_period_to, :relevant_period_from
 
       def prev_sick_days
         prior_sick_days
@@ -99,6 +99,10 @@ module SmartAnswer
 
       def pay_day_offset
         relevant_period_to - 8.weeks
+      end
+
+      def monthly_pattern_payments
+        self.class.months_between(relevant_period_from, relevant_period_to)
       end
 
       # define as static so we don't have to instantiate the calculator too early in the flow

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -203,7 +203,8 @@ module SmartAnswer
       end
 
       def ssp_payment
-        BigDecimal.new(weekly_payments.map(&:last).sum.round(10).to_s).round(2, BigDecimal::ROUND_UP).to_f
+        amount = BigDecimal.new(weekly_payments.map(&:last).sum.round(10).to_s).round(2, BigDecimal::ROUND_UP).to_f
+        Money.new(amount)
       end
 
       def self.contractual_earnings_awe(pay, days_worked)

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -215,6 +215,10 @@ module SmartAnswer
         prior_sick_days >= (days_of_the_week_worked.size * 28 + 3)
       end
 
+      def entitled_to_sick_pay?
+        ssp_payment > 0
+      end
+
       def self.contractual_earnings_awe(pay, days_worked)
         (pay / BigDecimal.new(days_worked.to_s) * 7).round(2)
       end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -75,6 +75,10 @@ module SmartAnswer
         value < sick_start_date
       end
 
+      def valid_last_payday_before_offset?(value)
+        value <= pay_day_offset
+      end
+
       def sick_start_date_for_awe
         linked_sickness_start_date || sick_start_date
       end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -269,13 +269,12 @@ module SmartAnswer
 
       # Question 9
       money_question :pay_amount_if_not_sick? do
-        save_input_as :relevant_contractual_pay
-
         precalculate :sick_start_date_for_awe do
           calculator.sick_start_date_for_awe
         end
 
-        next_node(permitted: [:contractual_days_covered_by_earnings?]) do
+        next_node(permitted: [:contractual_days_covered_by_earnings?]) do |response|
+          calculator.relevant_contractual_pay = response
           :contractual_days_covered_by_earnings?
         end
       end
@@ -283,7 +282,7 @@ module SmartAnswer
       # Question 9.1
       value_question :contractual_days_covered_by_earnings? do
         next_node_calculation :employee_average_weekly_earnings do |response|
-          pay = relevant_contractual_pay
+          pay = calculator.relevant_contractual_pay
           days_worked = response
           Calculators::StatutorySickPayCalculator.contractual_earnings_awe(pay, days_worked)
         end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -291,9 +291,8 @@ module SmartAnswer
 
       # Question 10
       money_question :total_earnings_before_sick_period? do
-        save_input_as :earnings
-
-        next_node(permitted: [:days_covered_by_earnings?]) do
+        next_node(permitted: [:days_covered_by_earnings?]) do |response|
+          calculator.total_earnings_before_sick_period = response
           :days_covered_by_earnings?
         end
       end
@@ -302,7 +301,7 @@ module SmartAnswer
       value_question :days_covered_by_earnings? do
 
         next_node_calculation :employee_average_weekly_earnings do |response|
-          pay = earnings
+          pay = calculator.total_earnings_before_sick_period
           days_worked = response.to_i
           Calculators::StatutorySickPayCalculator.total_earnings_awe(pay, days_worked)
         end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -357,14 +357,6 @@ module SmartAnswer
         precalculate :normal_workdays_out do calculator.normal_workdays end
         precalculate :pattern_days do calculator.pattern_days end
         precalculate :pattern_days_total do calculator.pattern_days_total end
-
-        precalculate :formatted_sick_pay_weekly_amounts do
-          if calculator.ssp_payment > 0
-            calculator.formatted_sick_pay_weekly_amounts
-          else
-            ""
-          end
-        end
       end
 
       # Answer 7

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -109,11 +109,14 @@ module SmartAnswer
 
         validate { days_sick >= 1 }
 
-        next_node_if(:has_linked_sickness?) do
-          days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
+        permitted_next_nodes = [:has_linked_sickness?, :must_be_sick_for_4_days]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
+            :has_linked_sickness?
+          else
+            :must_be_sick_for_4_days
+          end
         end
-
-        next_node(:must_be_sick_for_4_days)
       end
 
       # Question 6

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -24,10 +24,10 @@ module SmartAnswer
         permitted_next_nodes = [:employee_tell_within_limit?, :already_getting_maternity]
         next_node(permitted: permitted_next_nodes) do |response|
           calculator.other_pay_types_received = response.split(",")
-          if calculator.not_getting_maternity_pay?
-            :employee_tell_within_limit?
-          else
+          if calculator.already_getting_maternity_pay?
             :already_getting_maternity
+          else
+            :employee_tell_within_limit?
           end
         end
       end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -299,7 +299,9 @@ module SmartAnswer
       money_question :pay_amount_if_not_sick? do
         save_input_as :relevant_contractual_pay
 
-        next_node :contractual_days_covered_by_earnings?
+        next_node(permitted: [:contractual_days_covered_by_earnings?]) do
+          :contractual_days_covered_by_earnings?
+        end
       end
 
       # Question 9.1

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -166,8 +166,6 @@ module SmartAnswer
         option :eight_weeks_less
         option :before_payday
 
-        save_input_as :eight_weeks_earnings
-
         precalculate :sick_start_date_for_awe do
           calculator.sick_start_date_for_awe
         end
@@ -177,11 +175,13 @@ module SmartAnswer
           :total_earnings_before_sick_period?
         ]
         next_node(permitted: permitted_next_nodes) do |response|
-          case response
-          when 'eight_weeks_more', 'before_payday'
+          calculator.eight_weeks_earnings = response
+          if calculator.paid_at_least_8_weeks_of_earnings?
             :how_often_pay_employee_pay_patterns? # Question 7.2
-          when 'eight_weeks_less'
+          elsif calculator.paid_less_than_8_weeks_of_earnings?
             :total_earnings_before_sick_period? # Question 10
+          elsif calculator.fell_sick_before_payday?
+            :how_often_pay_employee_pay_patterns? # Question 7.2
           end
         end
       end
@@ -201,7 +201,7 @@ module SmartAnswer
           :pay_amount_if_not_sick?
         ]
         next_node(permitted: permitted_next_nodes) do |response|
-          if eight_weeks_earnings == 'eight_weeks_more'
+          if calculator.paid_at_least_8_weeks_of_earnings?
             :last_payday_before_sickness? # Question 8
           else
             :pay_amount_if_not_sick? # Question 9

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -356,7 +356,7 @@ module SmartAnswer
         precalculate :days_paid do calculator.days_paid end
         precalculate :normal_workdays_out do calculator.normal_workdays end
         precalculate :pattern_days do calculator.pattern_days end
-        precalculate :pattern_days_total do calculator.pattern_days * 28 end
+        precalculate :pattern_days_total do calculator.pattern_days_total end
 
         precalculate :formatted_sick_pay_weekly_amounts do
           if calculator.ssp_payment > 0

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -194,13 +194,12 @@ module SmartAnswer
         option :monthly
         option :irregularly
 
-        save_input_as :pay_pattern
-
         permitted_next_nodes = [
           :last_payday_before_sickness?,
           :pay_amount_if_not_sick?
         ]
         next_node(permitted: permitted_next_nodes) do |response|
+          calculator.pay_pattern = response
           if calculator.paid_at_least_8_weeks_of_earnings?
             :last_payday_before_sickness? # Question 8
           else
@@ -253,7 +252,7 @@ module SmartAnswer
       money_question :total_employee_earnings? do
         next_node_calculation :employee_average_weekly_earnings do |response|
           Calculators::StatutorySickPayCalculator.average_weekly_earnings(
-            pay: response, pay_pattern: pay_pattern, monthly_pattern_payments: calculator.monthly_pattern_payments,
+            pay: response, pay_pattern: calculator.pay_pattern, monthly_pattern_payments: calculator.monthly_pattern_payments,
             relevant_period_to: calculator.relevant_period_to, relevant_period_from: calculator.relevant_period_from)
         end
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -45,7 +45,9 @@ module SmartAnswer
           response == 'yes'
         end
 
-        next_node(:employee_work_different_days?)
+        next_node(permitted: [:employee_work_different_days?]) do
+          :employee_work_different_days?
+        end
       end
 
       # Question 3

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -154,7 +154,9 @@ module SmartAnswer
           sick_start_date > sick_start_date_for_awe
         end
 
-        next_node(:linked_sickness_end_date?)
+        next_node(permitted: [:linked_sickness_end_date?]) do
+          :linked_sickness_end_date?
+        end
       end
 
       # Question 6.2

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -307,18 +307,6 @@ module SmartAnswer
           employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(sick_start_date)
         end
 
-        calculate :ssp_payment do
-          Money.new(calculator.ssp_payment)
-        end
-
-        calculate :formatted_sick_pay_weekly_amounts do |response|
-          if calculator.ssp_payment > 0
-            calculator.formatted_sick_pay_weekly_amounts
-          else
-            ""
-          end
-        end
-
         next_node_calculation(:prior_sick_days) do |response|
           if has_linked_sickness == 'yes'
             prev_sick_days = Calculators::StatutorySickPayCalculator.dates_matching_pattern(
@@ -375,10 +363,22 @@ module SmartAnswer
 
       # Answer 6
       outcome :entitled_to_sick_pay do
+        precalculate :ssp_payment do
+          Money.new(calculator.ssp_payment)
+        end
+
         precalculate :days_paid do calculator.days_paid end
         precalculate :normal_workdays_out do calculator.normal_workdays end
         precalculate :pattern_days do calculator.pattern_days end
         precalculate :pattern_days_total do calculator.pattern_days * 28 end
+
+        precalculate :formatted_sick_pay_weekly_amounts do
+          if calculator.ssp_payment > 0
+            calculator.formatted_sick_pay_weekly_amounts
+          else
+            ""
+          end
+        end
       end
 
       # Answer 7

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -21,9 +21,11 @@ module SmartAnswer
           # this avoids lots of content duplication in the YML
           PhraseList.new(:ssp_link)
         end
+
         calculate :paternity_maternity_warning do |response|
           (response.split(",") & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
         end
+
         next_node_if(:employee_tell_within_limit?,
           response_is_one_of(%w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}))
         next_node(:already_getting_maternity)
@@ -75,7 +77,6 @@ module SmartAnswer
         end
 
         next_node :last_sick_day?
-
       end
 
       # Question 5
@@ -98,9 +99,11 @@ module SmartAnswer
         end
 
         validate { days_sick >= 1 }
+
         next_node_if(:has_linked_sickness?) do
           days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
         end
+
         next_node(:must_be_sick_for_4_days)
       end
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -258,7 +258,7 @@ module SmartAnswer
           calculator.relevant_period_to
         end
 
-        next_node(permitted: [:usual_work_days?])  do |response|
+        next_node(permitted: [:usual_work_days?]) do |response|
           calculator.total_employee_earnings = response
           :usual_work_days?
         end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -127,7 +127,7 @@ module SmartAnswer
         validate_in_range
 
         validate :linked_sickness_must_be_before do |response|
-          calculator.sick_start_date > response
+          calculator.valid_linked_sickness_start_date?(response)
         end
 
         next_node(permitted: [:linked_sickness_end_date?]) do |response|

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -151,7 +151,7 @@ module SmartAnswer
         end
 
         validate :must_be_valid_period_of_incapacity_for_work do |response|
-          calculator.valid_period_of_incapacity_for_work?(response)
+          calculator.valid_linked_period_of_incapacity_for_work?(response)
         end
 
         next_node(permitted: [:paid_at_least_8_weeks?]) do |response|

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -350,7 +350,7 @@ module SmartAnswer
       # Answer 6
       outcome :entitled_to_sick_pay do
         precalculate :ssp_payment do
-          Money.new(calculator.ssp_payment)
+          calculator.ssp_payment
         end
 
         precalculate :days_paid do calculator.days_paid end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -220,10 +220,7 @@ module SmartAnswer
         end
 
         validate do |response|
-          payday = response
-          start = calculator.sick_start_date
-
-          payday < start
+          calculator.valid_last_payday_before_sickness?(response)
         end
 
         next_node(permitted: [:last_payday_before_offset?]) do |response|

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -183,7 +183,9 @@ module SmartAnswer
           period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
         end
 
-        next_node(:paid_at_least_8_weeks?)
+        next_node(permitted: [:paid_at_least_8_weeks?]) do
+          :paid_at_least_8_weeks?
+        end
       end
 
       # Question 7.1

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -239,8 +239,9 @@ module SmartAnswer
           calculator.pay_day_offset
         end
 
-        # You must enter a date on or before [pay_day_offset]
-        validate { |payday| payday <= calculator.pay_day_offset }
+        validate do |response|
+          calculator.valid_last_payday_before_offset?(response)
+        end
 
         # input plus 1 day = relevant_period_from
         calculate :relevant_period_from do |response|

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -317,7 +317,7 @@ module SmartAnswer
             :not_earned_enough
           elsif calculator.maximum_entitlement_reached?
             :maximum_entitlement_reached # Answer 8
-          elsif calculator.ssp_payment > 0
+          elsif calculator.entitled_to_sick_pay?
             :entitled_to_sick_pay # Answer 6
           elsif calculator.days_that_can_be_paid_for_this_period == 0
             :maximum_entitlement_reached # Answer 8

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -17,11 +17,6 @@ module SmartAnswer
         option :statutory_adoption_pay
         option :additional_statutory_paternity_pay
 
-        calculate :employee_not_entitled_pdf do
-          # this avoids lots of content duplication in the YML
-          PhraseList.new(:ssp_link)
-        end
-
         calculate :paternity_maternity_warning do |response|
           (response.split(",") & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
         end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -87,10 +87,6 @@ module SmartAnswer
         to { Date.today.end_of_year }
         validate_in_range
 
-        calculate :sick_end_date do |response|
-          response
-        end
-
         calculate :sick_end_date_for_awe do |response|
           response
         end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -89,7 +89,7 @@ module SmartAnswer
         permitted_next_nodes = [:has_linked_sickness?, :must_be_sick_for_4_days]
         next_node(permitted: permitted_next_nodes) do |response|
           calculator.sick_end_date = response
-          if calculator.days_sick >= Calculators::StatutorySickPayCalculator::MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
+          if calculator.valid_period_of_incapacity_for_work?
             :has_linked_sickness?
           else
             :must_be_sick_for_4_days

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -318,7 +318,9 @@ module SmartAnswer
       money_question :total_earnings_before_sick_period? do
         save_input_as :earnings
 
-        next_node :days_covered_by_earnings?
+        next_node(permitted: [:days_covered_by_earnings?]) do
+          :days_covered_by_earnings?
+        end
       end
 
       # Question 10.1

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -102,8 +102,6 @@ module SmartAnswer
         option :yes
         option :no
 
-        save_input_as :has_linked_sickness
-
         permitted_next_nodes = [
           :linked_sickness_start_date?,
           :paid_at_least_8_weeks?

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -220,8 +220,17 @@ module SmartAnswer
 
         save_input_as :pay_pattern
 
-        next_node_if(:last_payday_before_sickness?, variable_matches(:eight_weeks_earnings, 'eight_weeks_more')) # Question 8
-        next_node(:pay_amount_if_not_sick?) # Question 9
+        permitted_next_nodes = [
+          :last_payday_before_sickness?,
+          :pay_amount_if_not_sick?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if eight_weeks_earnings == 'eight_weeks_more'
+            :last_payday_before_sickness? # Question 8
+          else
+            :pay_amount_if_not_sick? # Question 9
+          end
+        end
       end
 
       # Question 8

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -92,17 +92,14 @@ module SmartAnswer
           response
         end
 
-        next_node_calculation(:days_sick) do |response|
-          period = DateRange.new(begins_on: calculator.sick_start_date, ends_on: response)
-          period.number_of_days
+        validate do |response|
+          calculator.valid_last_sick_day?(response)
         end
-
-        validate { days_sick >= 1 }
 
         permitted_next_nodes = [:has_linked_sickness?, :must_be_sick_for_4_days]
         next_node(permitted: permitted_next_nodes) do |response|
           calculator.sick_end_date = response
-          if days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
+          if calculator.days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
             :has_linked_sickness?
           else
             :must_be_sick_for_4_days

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -26,9 +26,14 @@ module SmartAnswer
           (response.split(",") & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
         end
 
-        next_node_if(:employee_tell_within_limit?,
-          response_is_one_of(%w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}))
-        next_node(:already_getting_maternity)
+        permitted_next_nodes = [:employee_tell_within_limit?, :already_getting_maternity]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if (response.split(",") & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}).any?
+            :employee_tell_within_limit?
+          else
+            :already_getting_maternity
+          end
+        end
       end
 
       # Question 2

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -315,7 +315,7 @@ module SmartAnswer
           calculator.days_of_the_week_worked = response.split(",")
           if calculator.not_earned_enough?
             :not_earned_enough
-          elsif calculator.prior_sick_days >= (calculator.days_of_the_week_worked.size * 28 + 3)
+          elsif calculator.maximum_entitlement_reached?
             :maximum_entitlement_reached # Answer 8
           elsif calculator.ssp_payment > 0
             :entitled_to_sick_pay # Answer 6

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -111,8 +111,10 @@ module SmartAnswer
         next_node(permitted: permitted_next_nodes) do |response|
           case response
           when 'yes'
+            calculator.has_linked_sickness = true
             :linked_sickness_start_date?
           when 'no'
+            calculator.has_linked_sickness = false
             :paid_at_least_8_weeks?
           end
         end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -313,7 +313,7 @@ module SmartAnswer
         ]
         next_node(permitted: permitted_next_nodes) do |response|
           calculator.days_of_the_week_worked = response.split(",")
-          if calculator.employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(calculator.sick_start_date)
+          if calculator.not_earned_enough?
             :not_earned_enough
           elsif calculator.prior_sick_days >= (calculator.days_of_the_week_worked.size * 28 + 3)
             :maximum_entitlement_reached # Answer 8

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -256,9 +256,9 @@ module SmartAnswer
       money_question :total_employee_earnings? do
         save_input_as :relevant_period_pay
 
-        calculate :employee_average_weekly_earnings do
+        next_node_calculation :employee_average_weekly_earnings do |response|
           Calculators::StatutorySickPayCalculator.average_weekly_earnings(
-            pay: relevant_period_pay, pay_pattern: pay_pattern, monthly_pattern_payments: monthly_pattern_payments,
+            pay: response, pay_pattern: pay_pattern, monthly_pattern_payments: monthly_pattern_payments,
             relevant_period_to: relevant_period_to, relevant_period_from: relevant_period_from)
         end
 
@@ -276,7 +276,7 @@ module SmartAnswer
       value_question :contractual_days_covered_by_earnings? do
         save_input_as :contractual_earnings_days
 
-        calculate :employee_average_weekly_earnings do |response|
+        next_node_calculation :employee_average_weekly_earnings do |response|
           pay = relevant_contractual_pay
           days_worked = response
           Calculators::StatutorySickPayCalculator.contractual_earnings_awe(pay, days_worked)
@@ -294,7 +294,7 @@ module SmartAnswer
       # Question 10.1
       value_question :days_covered_by_earnings? do
 
-        calculate :employee_average_weekly_earnings do |response|
+        next_node_calculation :employee_average_weekly_earnings do |response|
           pay = earnings
           days_worked = response.to_i
           Calculators::StatutorySickPayCalculator.total_earnings_awe(pay, days_worked)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -254,7 +254,9 @@ module SmartAnswer
           payday < start
         end
 
-        next_node(:last_payday_before_offset?)
+        next_node(permitted: [:last_payday_before_offset?]) do
+          :last_payday_before_offset?
+        end
       end
 
       # Question 8.1

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -259,11 +259,7 @@ module SmartAnswer
         end
 
         next_node(permitted: [:usual_work_days?])  do |response|
-          calculator.employee_average_weekly_earnings =
-            Calculators::StatutorySickPayCalculator.average_weekly_earnings(
-              pay: response, pay_pattern: calculator.pay_pattern, monthly_pattern_payments: calculator.monthly_pattern_payments,
-              relevant_period_to: calculator.relevant_period_to, relevant_period_from: calculator.relevant_period_from
-            )
+          calculator.total_employee_earnings = response
           :usual_work_days?
         end
       end
@@ -283,11 +279,7 @@ module SmartAnswer
       # Question 9.1
       value_question :contractual_days_covered_by_earnings? do
         next_node(permitted: [:usual_work_days?]) do |response|
-          calculator.employee_average_weekly_earnings =
-            Calculators::StatutorySickPayCalculator.contractual_earnings_awe(
-              calculator.relevant_contractual_pay,
-              response
-            )
+          calculator.contractual_days_covered_by_earnings = response
           :usual_work_days?
         end
       end
@@ -303,11 +295,7 @@ module SmartAnswer
       # Question 10.1
       value_question :days_covered_by_earnings? do
         next_node(permitted: [:usual_work_days?]) do |response|
-          calculator.employee_average_weekly_earnings =
-            Calculators::StatutorySickPayCalculator.total_earnings_awe(
-              calculator.total_earnings_before_sick_period,
-              response.to_i
-            )
+          calculator.days_covered_by_earnings = response.to_i
           :usual_work_days?
         end
       end
@@ -352,6 +340,10 @@ module SmartAnswer
       outcome :not_earned_enough do
         precalculate :lower_earning_limit do
           Calculators::StatutorySickPayCalculator.lower_earning_limit_on(calculator.sick_start_date)
+        end
+
+        precalculate :employee_average_weekly_earnings do
+          calculator.employee_average_weekly_earnings
         end
       end
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -254,8 +254,6 @@ module SmartAnswer
 
       # Question 8.2
       money_question :total_employee_earnings? do
-        save_input_as :relevant_period_pay
-
         next_node_calculation :employee_average_weekly_earnings do |response|
           Calculators::StatutorySickPayCalculator.average_weekly_earnings(
             pay: response, pay_pattern: pay_pattern, monthly_pattern_payments: monthly_pattern_payments,
@@ -274,8 +272,6 @@ module SmartAnswer
 
       # Question 9.1
       value_question :contractual_days_covered_by_earnings? do
-        save_input_as :contractual_earnings_days
-
         next_node_calculation :employee_average_weekly_earnings do |response|
           pay = relevant_contractual_pay
           days_worked = response

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -83,7 +83,9 @@ module SmartAnswer
           response
         end
 
-        next_node :last_sick_day?
+        next_node(permitted: [:last_sick_day?]) do
+          :last_sick_day?
+        end
       end
 
       # Question 5

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -279,7 +279,9 @@ module SmartAnswer
           Calculators::StatutorySickPayCalculator.months_between(start_date, end_date)
         end
 
-        next_node(:total_employee_earnings?)
+        next_node(permitted: [:total_employee_earnings?]) do
+          :total_employee_earnings?
+        end
       end
 
       # Question 8.2

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -319,7 +319,7 @@ module SmartAnswer
             :maximum_entitlement_reached # Answer 8
           elsif calculator.entitled_to_sick_pay?
             :entitled_to_sick_pay # Answer 6
-          elsif calculator.days_that_can_be_paid_for_this_period == 0
+          elsif calculator.maximum_entitlement_reached_v2?
             :maximum_entitlement_reached # Answer 8
           else
             :not_entitled_3_days_not_paid # Answer 7

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -17,17 +17,14 @@ module SmartAnswer
         option :statutory_adoption_pay
         option :additional_statutory_paternity_pay
 
-        calculate :paternity_maternity_warning do |response|
-          (response.split(",") & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
-        end
-
         next_node_calculation :calculator do
           Calculators::StatutorySickPayCalculator.new
         end
 
         permitted_next_nodes = [:employee_tell_within_limit?, :already_getting_maternity]
         next_node(permitted: permitted_next_nodes) do |response|
-          if (response.split(",") & %w{statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}).any?
+          calculator.other_pay_types_received = response.split(",")
+          if calculator.not_getting_maternity_pay?
             :employee_tell_within_limit?
           else
             :already_getting_maternity

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -37,11 +37,12 @@ module SmartAnswer
         option :yes
         option :no
 
-        calculate :enough_notice_of_absence do |response|
-          response == 'yes'
-        end
-
-        next_node(permitted: [:employee_work_different_days?]) do
+        next_node(permitted: [:employee_work_different_days?]) do |response|
+          if response == 'yes'
+            calculator.enough_notice_of_absence = true
+          else
+            calculator.enough_notice_of_absence = false
+          end
           :employee_work_different_days?
         end
       end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -339,7 +339,7 @@ module SmartAnswer
       # Answer 5
       outcome :not_earned_enough do
         precalculate :lower_earning_limit do
-          Calculators::StatutorySickPayCalculator.lower_earning_limit_on(calculator.sick_start_date)
+          calculator.lower_earning_limit
         end
 
         precalculate :employee_average_weekly_earnings do

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -353,10 +353,9 @@ module SmartAnswer
         next_node(permitted: permitted_next_nodes) do |response|
           calculator.prev_sick_days = prior_sick_days
           calculator.days_of_the_week_worked = response.split(",")
-          days_worked = response.split(',').size
           if employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(calculator.sick_start_date)
             :not_earned_enough
-          elsif prior_sick_days >= (days_worked * 28 + 3)
+          elsif prior_sick_days >= (calculator.days_of_the_week_worked.size * 28 + 3)
             :maximum_entitlement_reached # Answer 8
           elsif calculator.ssp_payment > 0
             :entitled_to_sick_pay # Answer 6

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
@@ -3,7 +3,7 @@
 
   Your employee is entitled to SSP for <%= days_paid %> days out of <%= normal_workdays_out %> working days taken off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(calculator.sick_end_date) %>
 
-  <% unless enough_notice_of_absence %>
+  <% unless calculator.enough_notice_of_absence %>
     You don’t have to pay until your employee tells you that they’re ill. You’ll have to pay any withheld amounts by the end of your employee's entitlement to sick pay if your employee is sick for more than 28 weeks.
   <% end %>
 
@@ -20,7 +20,7 @@
 
   <% end %>
 
-  SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of <%= pattern_days_total %> days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. <%= render partial: 'esa.govspeak.erb', locals: {enough_notice_of_absence: enough_notice_of_absence} -%>
+  SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of <%= pattern_days_total %> days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. <%= render partial: 'esa.govspeak.erb', locals: {enough_notice_of_absence: calculator.enough_notice_of_absence} -%>
 
 
   There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
@@ -10,7 +10,9 @@
 
   Week ending | SSP amount
   -|-
-  <%= formatted_sick_pay_weekly_amounts %>
+  <% calculator.weekly_payments.each do |week_ending, ssp_amount| %>
+    <%= format_date(week_ending) %>|<%= sprintf("£%.2f", ssp_amount) %>
+  <% end %>
    | **Total SSP: <%= format_money(ssp_payment) %>**
 
   ##What you need to know

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   ##Statutory Sick Pay (SSP)
 
-  Your employee is entitled to SSP for <%= days_paid %> days out of <%= normal_workdays_out %> working days taken off sick between <%= format_date(sick_start_date) %> and <%= format_date(sick_end_date) %>
+  Your employee is entitled to SSP for <%= days_paid %> days out of <%= normal_workdays_out %> working days taken off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(sick_end_date) %>
 
   <% unless enough_notice_of_absence %>
     You don’t have to pay until your employee tells you that they’re ill. You’ll have to pay any withheld amounts by the end of your employee's entitlement to sick pay if your employee is sick for more than 28 weeks.

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
@@ -15,7 +15,7 @@
 
   ##What you need to know
 
-  <% if paternity_maternity_warning %>
+  <% if calculator.paternity_maternity_warning? %>
     ^ Your employee will not be able to collect Statutory Paternity Pay or Statutory Adoption Pay while collecting Statutory Sick Pay. ^
 
   <% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   ##Statutory Sick Pay (SSP)
 
-  Your employee is entitled to SSP for <%= days_paid %> days out of <%= normal_workdays_out %> working days taken off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(sick_end_date) %>
+  Your employee is entitled to SSP for <%= days_paid %> days out of <%= normal_workdays_out %> working days taken off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(calculator.sick_end_date) %>
 
   <% unless enough_notice_of_absence %>
     You don’t have to pay until your employee tells you that they’re ill. You’ll have to pay any withheld amounts by the end of your employee's entitlement to sick pay if your employee is sick for more than 28 weeks.

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_3_days_not_paid.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_3_days_not_paid.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
   Your employee isn’t entitled to Statutory Sick Pay because the first 3 days of illness aren’t paid.
 
-  This employee has taken <%= normal_workdays_out %> working days off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(sick_end_date) %>.
+  This employee has taken <%= normal_workdays_out %> working days off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(calculator.sick_end_date) %>.
 <% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_3_days_not_paid.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_3_days_not_paid.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
   Your employee isn’t entitled to Statutory Sick Pay because the first 3 days of illness aren’t paid.
 
-  This employee has taken <%= normal_workdays_out %> working days off sick between <%= format_date(sick_start_date) %> and <%= format_date(sick_end_date) %>.
+  This employee has taken <%= normal_workdays_out %> working days off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(sick_end_date) %>.
 <% end %>

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -1,7 +1,7 @@
 en-GB:
   flow:
     calculate-statutory-sick-pay:
-      # Q1
+      # Question 1
       is_your_employee_getting?:
         title: Is your employee getting any of the following?
         hint: If none apply just click ‘Next step’
@@ -60,7 +60,7 @@ en-GB:
         must_be_within_eight_weeks: You need to enter a date within 8 weeks of the current period of sickness or it isn't a linked period of sickness.
         must_be_at_least_1_day_before_first_sick_day: You need to enter a date at least 1 day before the start of the current period of sickness or it isn't a separate linked period of sickness.
 
-      # Q7.1
+      # Question 7.1
       paid_at_least_8_weeks?:
         title: On %{sick_start_date_for_awe} had you paid your employee at least 8 weeks of earnings?
         options:
@@ -68,7 +68,7 @@ en-GB:
           eight_weeks_less: "No, paid less than 8 weeks earnings"
           before_payday: "No, employee is new and fell sick before their first payday"
 
-      # Q7.2
+      # Question 7.2
       how_often_pay_employee_pay_patterns?:
         title: How often do you pay the employee?
         options:

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -1,14 +1,6 @@
 en-GB:
   flow:
     calculate-statutory-sick-pay:
-      phrases:
-        ssp_link: |
-
-
-          $D
-            [Download ‘Form SSP1, employee not entitled to SSP’ (PDF, 130KB)](http://www.dwp.gov.uk/advisers/claimforms/ssp1.pdf)
-          $D
-
       # Q1
       is_your_employee_getting?:
         title: Is your employee getting any of the following?

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,17 +1,17 @@
 ---
-lib/smart_answer_flows/calculate-statutory-sick-pay.rb: e641dfc583d79d0897dd5960a845ea87
-lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml: 4eea84d779e65da86463fa66fb3fd45c
+lib/smart_answer_flows/calculate-statutory-sick-pay.rb: 0f9e3f075417480564caa5d34b3a4eda
+lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml: bb112c0795e3d4b13995b55846102451
 test/data/calculate-statutory-sick-pay-questions-and-responses.yml: dfd8baf65a8c26430cf17958e8908202
 test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: b42519fbb030e7eaf0912d1de0b8ff47
 lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: f91dc1d321c164a06271889100875600
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/_esa.govspeak.erb: 660031398fda690ed7b3e2186ba64060
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/already_getting_maternity.govspeak.erb: 258fd4422c4ae665c83d5ee1e061bbff
-lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb: 5aaeb3dfcda9285d28e2eb98e4c4cca1
+lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb: ed74ac72ff6fc4fb4f814bcb16d1d44d
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/maximum_entitlement_reached.govspeak.erb: eb12d5290c873df20fd23ff9eb06c273
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/must_be_sick_for_4_days.govspeak.erb: 17b34a7463bcbbf7e2a5c417ec5452f9
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_earned_enough.govspeak.erb: 1e5cd1c6d99b6bd3145578416d62e7c5
-lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_3_days_not_paid.govspeak.erb: 98dc338280df70b2b6032a7a9dcba428
+lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_3_days_not_paid.govspeak.erb: 2bb339147988e5beeeda2e0da1bb956a
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_regular_schedule.govspeak.erb: 98b6f0d902fabae8fda39c1859cd2a46
-lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 829caa333843af877c30cefff97edc35
+lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 0fa9f00b11c092206ef230fbeb5c2f2e
 lib/smart_answer/calculators/rates_query.rb: c9568eac2742cad26f93458ed2276876
 lib/data/rates/statutory_sick_pay.yml: de2d34118e3016d1137c394745d33280

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -124,7 +124,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert current_state.calculator.paid_at_least_8_weeks_of_earnings?
           add_response 'weekly'
           assert_current_node :last_payday_before_sickness?
-          assert_state_variable :pay_pattern, 'weekly'
+          assert_equal current_state.calculator.pay_pattern, 'weekly'
           add_response '2013-03-31'
           assert_current_node :last_payday_before_offset?
           add_response '2013-01-31'
@@ -152,7 +152,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert current_state.calculator.paid_at_least_8_weeks_of_earnings?
           add_response 'weekly'
           assert_current_node :last_payday_before_sickness?
-          assert_state_variable :pay_pattern, 'weekly'
+          assert_equal current_state.calculator.pay_pattern, 'weekly'
           add_response '2013-03-31'
           assert_current_node :last_payday_before_offset?
           add_response '2013-01-31'

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -277,7 +277,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response '1,2,3,4,5' # Q13
     end
     should "take you to result A5 as awe < LEL (as of 2013-06-10)" do
-      assert_state_variable :employee_average_weekly_earnings, 100
+      assert_equal current_state.calculator.employee_average_weekly_earnings, 100
       assert_current_node :not_earned_enough
     end
   end

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -121,7 +121,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert_current_node :paid_at_least_8_weeks?
           add_response 'eight_weeks_more'
           assert_current_node :how_often_pay_employee_pay_patterns?
-          assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
+          assert current_state.calculator.paid_at_least_8_weeks_of_earnings?
           add_response 'weekly'
           assert_current_node :last_payday_before_sickness?
           assert_state_variable :pay_pattern, 'weekly'
@@ -149,7 +149,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert_current_node :paid_at_least_8_weeks?
           add_response 'eight_weeks_more'
           assert_current_node :how_often_pay_employee_pay_patterns?
-          assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
+          assert current_state.calculator.paid_at_least_8_weeks_of_earnings?
           add_response 'weekly'
           assert_current_node :last_payday_before_sickness?
           assert_state_variable :pay_pattern, 'weekly'

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -375,24 +375,24 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response "3,6"
 
       assert_current_node :entitled_to_sick_pay
-      assert_state_variable :formatted_sick_pay_weekly_amounts,
-                            ["12 January 2013|£42.93",
-                             "19 January 2013|£85.85",
-                             "26 January 2013|£85.85",
-                             " 2 February 2013|£85.85",
-                             " 9 February 2013|£85.85",
-                             "16 February 2013|£85.85",
-                             "23 February 2013|£85.85",
-                             " 2 March 2013|£85.85",
-                             " 9 March 2013|£85.85",
-                             "16 March 2013|£85.85",
-                             "23 March 2013|£85.85",
-                             "30 March 2013|£85.85",
-                             " 6 April 2013|£86.28",
-                             "13 April 2013|£86.70",
-                             "20 April 2013|£86.70",
-                             "27 April 2013|£86.70",
-                             " 4 May 2013|£43.35"].join("\n")
+      assert_equal current_state.calculator.weekly_payments,
+                            [[Date.parse("12 January 2013"), 42.93],
+                             [Date.parse("19 January 2013"), 85.85],
+                             [Date.parse("26 January 2013"), 85.85],
+                             [Date.parse(" 2 February 2013"), 85.85],
+                             [Date.parse(" 9 February 2013"), 85.85],
+                             [Date.parse("16 February 2013"), 85.85],
+                             [Date.parse("23 February 2013"), 85.85],
+                             [Date.parse(" 2 March 2013"), 85.85],
+                             [Date.parse(" 9 March 2013"), 85.85],
+                             [Date.parse("16 March 2013"), 85.85],
+                             [Date.parse("23 March 2013"), 85.85],
+                             [Date.parse("30 March 2013"), 85.85],
+                             [Date.parse(" 6 April 2013"), 86.28],
+                             [Date.parse("13 April 2013"), 86.70],
+                             [Date.parse("20 April 2013"), 86.70],
+                             [Date.parse("27 April 2013"), 86.70],
+                             [Date.parse(" 4 May 2013"), 43.35]]
     end
 
     should "have consistent rates for all weekly rates that are produced" do
@@ -412,24 +412,24 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response "2,3,4"
 
       assert_current_node :entitled_to_sick_pay
-      assert_state_variable :formatted_sick_pay_weekly_amounts,
-                            ["12 January 2013|£85.85",
-                             "19 January 2013|£85.85",
-                             "26 January 2013|£85.85",
-                             " 2 February 2013|£85.85",
-                             " 9 February 2013|£85.85",
-                             "16 February 2013|£85.85",
-                             "23 February 2013|£85.85",
-                             " 2 March 2013|£85.85",
-                             " 9 March 2013|£85.85",
-                             "16 March 2013|£85.85",
-                             "23 March 2013|£85.85",
-                             "30 March 2013|£85.85",
-                             " 6 April 2013|£85.85",
-                             "13 April 2013|£86.70",
-                             "20 April 2013|£86.70",
-                             "27 April 2013|£86.70",
-                             " 4 May 2013|£86.70"].join("\n")
+      assert_equal current_state.calculator.weekly_payments,
+                            [[Date.parse("12 January 2013"), 85.85],
+                             [Date.parse("19 January 2013"), 85.85],
+                             [Date.parse("26 January 2013"), 85.85],
+                             [Date.parse(" 2 February 2013"), 85.85],
+                             [Date.parse(" 9 February 2013"), 85.85],
+                             [Date.parse("16 February 2013"), 85.85],
+                             [Date.parse("23 February 2013"), 85.85],
+                             [Date.parse(" 2 March 2013"), 85.85],
+                             [Date.parse(" 9 March 2013"), 85.85],
+                             [Date.parse("16 March 2013"), 85.85],
+                             [Date.parse("23 March 2013"), 85.85],
+                             [Date.parse("30 March 2013"), 85.85],
+                             [Date.parse(" 6 April 2013"), 85.85],
+                             [Date.parse("13 April 2013"), 86.70],
+                             [Date.parse("20 April 2013"), 86.70],
+                             [Date.parse("27 April 2013"), 86.70],
+                             [Date.parse(" 4 May 2013"), 86.70]]
     end
 
     should "show formatted weekly payment amounts with adjusted 3 days start amount for ordinary SPP" do
@@ -447,24 +447,24 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response "1,2,3,4"
 
       assert_current_node :entitled_to_sick_pay
-      assert_state_variable :formatted_sick_pay_weekly_amounts,
-                            ["12 January 2013|£21.47",
-                             "19 January 2013|£85.85",
-                             "26 January 2013|£85.85",
-                             " 2 February 2013|£85.85",
-                             " 9 February 2013|£85.85",
-                             "16 February 2013|£85.85",
-                             "23 February 2013|£85.85",
-                             " 2 March 2013|£85.85",
-                             " 9 March 2013|£85.85",
-                             "16 March 2013|£85.85",
-                             "23 March 2013|£85.85",
-                             "30 March 2013|£85.85",
-                             " 6 April 2013|£85.85",
-                             "13 April 2013|£86.70",
-                             "20 April 2013|£86.70",
-                             "27 April 2013|£86.70",
-                             " 4 May 2013|£86.70"].join("\n")
+      assert_equal current_state.calculator.weekly_payments,
+                            [[Date.parse("12 January 2013"), 21.47],
+                             [Date.parse("19 January 2013"), 85.85],
+                             [Date.parse("26 January 2013"), 85.85],
+                             [Date.parse(" 2 February 2013"), 85.85],
+                             [Date.parse(" 9 February 2013"), 85.85],
+                             [Date.parse("16 February 2013"), 85.85],
+                             [Date.parse("23 February 2013"), 85.85],
+                             [Date.parse(" 2 March 2013"), 85.85],
+                             [Date.parse(" 9 March 2013"), 85.85],
+                             [Date.parse("16 March 2013"), 85.85],
+                             [Date.parse("23 March 2013"), 85.85],
+                             [Date.parse("30 March 2013"), 85.85],
+                             [Date.parse(" 6 April 2013"), 85.85],
+                             [Date.parse("13 April 2013"), 86.70],
+                             [Date.parse("20 April 2013"), 86.70],
+                             [Date.parse("27 April 2013"), 86.70],
+                             [Date.parse(" 4 May 2013"), 86.70]]
 
     end
 
@@ -483,24 +483,24 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response "1,2,3,4"
 
       assert_current_node :entitled_to_sick_pay
-      assert_state_variable :formatted_sick_pay_weekly_amounts,
-                            ["12 January 2013|£21.47",
-                             "19 January 2013|£85.85",
-                             "26 January 2013|£85.85",
-                             " 2 February 2013|£85.85",
-                             " 9 February 2013|£85.85",
-                             "16 February 2013|£85.85",
-                             "23 February 2013|£85.85",
-                             " 2 March 2013|£85.85",
-                             " 9 March 2013|£85.85",
-                             "16 March 2013|£85.85",
-                             "23 March 2013|£85.85",
-                             "30 March 2013|£85.85",
-                             " 6 April 2013|£85.85",
-                             "13 April 2013|£86.70",
-                             "20 April 2013|£86.70",
-                             "27 April 2013|£86.70",
-                             " 4 May 2013|£86.70"].join("\n")
+      assert_equal current_state.calculator.weekly_payments,
+                            [[Date.parse("12 January 2013"), 21.47],
+                             [Date.parse("19 January 2013"), 85.85],
+                             [Date.parse("26 January 2013"), 85.85],
+                             [Date.parse(" 2 February 2013"), 85.85],
+                             [Date.parse(" 9 February 2013"), 85.85],
+                             [Date.parse("16 February 2013"), 85.85],
+                             [Date.parse("23 February 2013"), 85.85],
+                             [Date.parse(" 2 March 2013"), 85.85],
+                             [Date.parse(" 9 March 2013"), 85.85],
+                             [Date.parse("16 March 2013"), 85.85],
+                             [Date.parse("23 March 2013"), 85.85],
+                             [Date.parse("30 March 2013"), 85.85],
+                             [Date.parse(" 6 April 2013"), 85.85],
+                             [Date.parse("13 April 2013"), 86.70],
+                             [Date.parse("20 April 2013"), 86.70],
+                             [Date.parse("27 April 2013"), 86.70],
+                             [Date.parse(" 4 May 2013"), 86.70]]
 
     end
   end

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -101,7 +101,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response :no
           assert_current_node :first_sick_day? # Q4
           add_response '2013-04-02'
-          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
 
           add_response '2013-04-04'
@@ -112,7 +112,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response :no
           assert_current_node :first_sick_day? # Q4
           add_response '2013-04-02'
-          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
@@ -139,7 +139,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response :no
           assert_current_node :first_sick_day? # Q4
           add_response '2013-04-02'
-          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
 
           add_response '2013-04-10'
@@ -167,7 +167,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response :no
           assert_current_node :first_sick_day? # Q4
           add_response '2013-04-02'
-          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
@@ -194,7 +194,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response :no
           assert_current_node :first_sick_day? # Q4
           add_response '2013-04-02'
-          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
@@ -217,7 +217,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response :no
           assert_current_node :first_sick_day? # Q4
           add_response '2013-04-02'
-          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
@@ -242,7 +242,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response :no
           assert_current_node :first_sick_day? # Q4
           add_response '2013-04-02'
-          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -30,7 +30,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "set adoption warning state variable" do
-      assert_state_variable :paternity_maternity_warning, true
+      assert current_state.calculator.paternity_maternity_warning?
     end
     should "take you to Q2" do
       assert_current_node :employee_tell_within_limit? # Q2
@@ -43,7 +43,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "set adoption warning state variable" do
-      assert_state_variable :paternity_maternity_warning, true
+      assert current_state.calculator.paternity_maternity_warning?
     end
 
     should "take you to Q2" do

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -115,7 +115,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
-          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_equal current_state.calculator.sick_end_date, Date.parse('10 April 2013')
           assert_current_node :has_linked_sickness?
           add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
@@ -143,7 +143,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert_current_node :last_sick_day? # Q5
 
           add_response '2013-04-10'
-          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_equal current_state.calculator.sick_end_date, Date.parse('10 April 2013')
           assert_current_node :has_linked_sickness?
           add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
@@ -170,7 +170,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
-          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_equal current_state.calculator.sick_end_date, Date.parse('10 April 2013')
           assert_current_node :has_linked_sickness?
           add_response 'yes'
           assert_current_node :linked_sickness_start_date?
@@ -197,7 +197,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
-          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_equal current_state.calculator.sick_end_date, Date.parse('10 April 2013')
           assert_current_node :has_linked_sickness?
           add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
@@ -220,7 +220,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
-          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_equal current_state.calculator.sick_end_date, Date.parse('10 April 2013')
           assert_current_node :has_linked_sickness?
           add_response 'yes'
           assert_current_node :linked_sickness_start_date?
@@ -245,7 +245,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert_equal current_state.calculator.sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
           add_response '2013-04-10'
-          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_equal current_state.calculator.sick_end_date, Date.parse('10 April 2013')
           assert_current_node :has_linked_sickness?
           add_response 'no'
           assert_current_node :paid_at_least_8_weeks?

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -215,7 +215,6 @@ module SmartAnswer
           assert_equal @calculator.waiting_days, 2
           assert_equal @calculator.normal_workdays, 5
           assert_equal @calculator.send(:days_to_pay), 3
-
         end
       end
 
@@ -307,7 +306,7 @@ module SmartAnswer
           assert_equal @calculator.prev_sick_days, 0
         end
 
-        should "give correct ssp calculation" do  # 15 days with 3 waiting days, so 6 days at lower weekly rate, 6 days at higher rate
+        should "give correct ssp calculation" do # 15 days with 3 waiting days, so 6 days at lower weekly rate, 6 days at higher rate
           assert_equal @calculator.waiting_days, 3
           assert_equal @calculator.send(:days_to_pay), 12
           assert_equal @calculator.normal_workdays, 15

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -1,813 +1,815 @@
 require_relative "../../test_helper"
 
-module SmartAnswer::Calculators
-  class StatutorySickPayCalculatorTest < ActiveSupport::TestCase
-
-    context ".dates_matching_pattern" do
-      should "return dates maching working days pattern" do
-        working_days = %w(Sunday Tuesday Thursday).map { |d| Date::DAYNAMES.index(d).to_s }
-        dates = StatutorySickPayCalculator.dates_matching_pattern(
-          from: Date.parse("Sun, 04 Jan 2015"),
-          to:   Date.parse("Wed, 14 Jan 2015"),
-          pattern: working_days
-        )
-        assert_equal [
-          Date.parse("Sun, 04 Jan 2015"), Date.parse("Tue, 06 Jan 2015"), Date.parse("Thu, 08 Jan 2015"),
-          Date.parse("Sun, 11 Jan 2015"), Date.parse("Tue, 13 Jan 2015")
-        ], dates
-      end
-    end
-
-    context ".months_between" do
-      should "calculate number of months between dates" do
-        months = StatutorySickPayCalculator.months_between(Date.parse("04/02/2012"), Date.parse("17/05/2012"))
-        assert_equal 4, months
-      end
-
-      should "not count the first month if it's later than the 17th" do
-        months = StatutorySickPayCalculator.months_between(Date.parse("18/02/2012"), Date.parse("17/05/2012"))
-        assert_equal 3, months
-      end
-
-      should "not count the last month if it's before the 15th" do
-        months = StatutorySickPayCalculator.months_between(Date.parse("13/02/2012"), Date.parse("14/05/2012"))
-        assert_equal 3, months
-      end
-    end # end .months_between
-
-    context ".average_weekly_earnings" do
-      should "calculate AWE for weekly pay patterns" do
-        assert_equal 100, StatutorySickPayCalculator.average_weekly_earnings(pay: 800, pay_pattern: 'weekly')
-        assert_equal 100, StatutorySickPayCalculator.average_weekly_earnings(pay: 800, pay_pattern: 'fortnightly')
-        assert_equal 100, StatutorySickPayCalculator.average_weekly_earnings(pay: 800, pay_pattern: 'every_4_weeks')
-      end
-      should "calculate AWE for monthly pay patterns" do
-        assert_equal 92.31, StatutorySickPayCalculator.average_weekly_earnings(
-          pay: 1200, pay_pattern: 'monthly', monthly_pattern_payments: 3).round(2)
-      end
-      should "calculate AWE for irregular pay patterns" do
-        assert_equal 700, StatutorySickPayCalculator.average_weekly_earnings(
-          pay: 1000, pay_pattern: 'irregularly', relevant_period_to: Date.parse("31 December 2013"), relevant_period_from: Date.parse("21 December 2013"))
-      end
-    end # end .average_weekly_earnings
-
-    context "0 days per week worked" do
-      setup do
-        @days_worked = []
-        @start_date = Date.parse("1 October 2012")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: @days_worked,
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "return daily rate of 0.0" do
-        @weekly_rate = @calculator.send(:weekly_rate_on, @start_date)
-        assert_equal @calculator.daily_rate_from_weekly(@weekly_rate, @days_worked.length), 0.0
-      end
-    end
-
-    context "prev_sick_days is 5, M-F, 7 days out" do
-      setup do
-        @start_date = Date.parse("1 October 2012")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Fri, 7 Sep 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 5
-      end
-
-      should "return waiting_days of 0" do
-        assert_equal @calculator.waiting_days, 0
-      end
-
-      should "return daily rate of 17.1700" do
-        @weekly_rate = @calculator.send(:weekly_rate_on, @start_date)
-        assert_equal @weekly_rate, 85.8500
-        assert_equal @calculator.daily_rate_from_weekly(@weekly_rate, 5), 17.1700
-      end
-
-      should "normal working days missed is 5" do
-        assert_equal @calculator.normal_workdays, 5
-      end
-
-      should "return correct ssp_payment" do
-        assert_equal 85.85, @calculator.ssp_payment
-      end
-    end
-
-    context "daily rate test for 3 days per week worked (M-W-F)" do
-      setup do
-        @start_date = Date.parse("1 October 2012")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(1 3 5),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Wed, 12 Sep 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 5
-      end
-
-      should "return daily rate of 28.6166" do
-        assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 3), 28.6166 # should be 28.6166 according to HMRC table
-      end
-    end
-
-    context "daily rate test for 7 days per week worked" do
-      setup do
-        @start_date = Date.parse("1 October 2012")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(0 1 2 3 4 5 6),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Wed, 5 Sep 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 5
-      end
-
-      should "return daily rate of 12.2642" do
-        assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 7), 12.2642 # unrounded, matches the HMRC SSP daily rate table
-      end
-    end
-
-    context "daily rate test for 6 days per week worked" do
-      setup do
-        @start_date = Date.parse("1 October 2012")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5 6),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Thu, 6 Sep 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 5
-      end
-
-      should "return daily rate of 14.3083" do
-        assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 6), 14.3083
-      end
-    end
-
-    context "daily rate test for 2 days per week worked (Thu-Fri)" do
-      setup do
-        @start_date = Date.parse("1 October 2012")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(4 5),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Thu, 6 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Thu, 20 Sep 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 5
-      end
-
-      should "return daily rate of 42.9250" do
-        assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 2), 42.9250
-      end
-    end
-
-    context "waiting days if prev_sick_days is 2" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("6 April 2012"),
-          sick_end_date: Date.parse("6 May 2012"),
-          days_of_the_week_worked: %w(1 2 3),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Tue, 4 Sep 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 2
-      end
-
-      should "return waiting_days of 1" do
-        assert_equal @calculator.waiting_days, 1
-      end
-    end
-
-    context "waiting days if prev_sick_days is 1" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("6 April 2012"),
-          sick_end_date: Date.parse("17 April 2012"),
-          days_of_the_week_worked: %w(1 2 3),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Mon, 3 Sep 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 1
-      end
-
-      should "return waiting_days of 2" do
-        assert_equal @calculator.waiting_days, 2
-        assert_equal @calculator.normal_workdays, 5
-        assert_equal @calculator.send(:days_to_pay), 3
-
-      end
-    end
-
-    context "waiting days if prev_sick_days is 0" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("6 April 2012"),
-          sick_end_date: Date.parse("12 April 2012"),
-          days_of_the_week_worked: %w(1 2 3),
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "return waiting_days of 3, ssp payment of 0" do
-        assert_equal @calculator.waiting_days, 3
-        assert_equal @calculator.send(:days_to_pay), 0
-        assert_equal @calculator.normal_workdays, 3
-        assert_equal @calculator.ssp_payment, 0.00
-      end
-    end
-
-    context "maximum days payable for 5 days a week" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("6 April 2012"),
-          sick_end_date: Date.parse("6 December 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5),
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "have a max of 140 days payable" do
-        assert_equal @calculator.send(:days_to_pay), 140
-        assert_equal @calculator.normal_workdays, 175
-        assert_equal @calculator.ssp_payment, 2403.80 #140 * 17.1700 or 28 * 85.85
-      end
-    end
-
-    context "maximum days payable for 3 days a week" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("6 April 2012"),
-          sick_end_date: Date.parse("6 December 2012"),
-          days_of_the_week_worked: %w(2 3 4),
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "have a max of 84 days payable" do
-        assert_equal @calculator.send(:days_to_pay), 84
-        assert_equal @calculator.normal_workdays, 105
-        assert_equal @calculator.ssp_payment, 2403.80 #28 weeks at 85.85 a week
-      end
-    end
-
-    context "historic rate test 1" do
-      setup do
-        @start_date = Date.parse("5 April 2012")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: Date.parse("10 April 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Wed, 5 Sep 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 3
-      end
-
-      should "use ssp rate and lel for 2011-12" do
-        assert_equal StatutorySickPayCalculator.lower_earning_limit_on(@start_date), 102
-        assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 5), 16.3200
-      end
-    end
-
-    # Monday - Friday
-    context "test scenario 1 - M-F, no waiting days, cross tax years" do
-      setup do
-        @start_date = Date.parse("26 March 2012")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: Date.parse("13 April 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5),
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "give correct ssp calculation" do  # 15 days with 3 waiting days, so 6 days at lower weekly rate, 6 days at higher rate
-        assert_equal @calculator.waiting_days, 3
-        assert_equal @calculator.send(:days_to_pay), 12
-        assert_equal @calculator.normal_workdays, 15
-        assert_equal @calculator.ssp_payment, 200.94
-      end
-    end
-
-    context "test date 4 May 2014" do
-      setup do
-        @start_date = Date.parse("4 May 2014")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: Date.parse("3 August 2014"),
-          days_of_the_week_worked: %w(1 2 3 4 5),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Wed, 5 Sep 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 3
-      end
-
-      should "use ssp rate and lel for 2014-15" do
-        assert_equal StatutorySickPayCalculator.lower_earning_limit_on(@start_date), 111
-        assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 5), 17.51
-      end
-    end
-
-    context "weekly rate fallback. When date is not covered by any known ranges" do
-      setup do
-        @start_date = Date.parse("4 May 2054")
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: @start_date,
-          sick_end_date: @start_date + 1.month,
-          days_of_the_week_worked: %w(1 2 3 4 5),
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "not break and use ssp rate for the latest know fiscal year" do
-        assert @calculator.send(:weekly_rate_on, @start_date).is_a?(Numeric)
-      end
-    end
-
-    # Tuesday to Friday
-    context "test scenario 2 - T-F, 7 waiting days, cross tax years" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("28 February 2012"),
-          sick_end_date: Date.parse("7 April 2012"),
-          days_of_the_week_worked: %w(2 3 4 5),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Tue, 3 Jan 2012"),
-          linked_sickness_end_date: Date.parse("Thu, 12 Jan 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 7
-      end
-
-      should "give correct ssp calculation" do # 24 days with no waiting days, so 22 days at lower weekly rate, 2 days at higher rate
-        assert_equal @calculator.normal_workdays, 24
-        assert_equal @calculator.send(:days_to_pay), 24
-        assert_equal @calculator.ssp_payment, 490.67
-      end
-    end
-
-    # Monday, Wednesday, Friday
-    context "test scenario 3" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("25 July 2012"),
-          sick_end_date: Date.parse("4 September 2012"),
-          days_of_the_week_worked: %w(1 3 5),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Mon, 7 May 2012"),
-          linked_sickness_end_date: Date.parse("Sun, 1 Jul 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 24
-      end
-
-      should "give correct ssp calculation" do
-        assert_equal @calculator.prev_sick_days, 24
-        assert_equal @calculator.send(:days_to_pay), 18
-        assert_equal @calculator.ssp_payment, 515.11
-      end
-    end
-
-    #  Saturday and Sunday
-    context "test scenario 4" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("23 November 2012"),
-          sick_end_date: Date.parse("31 December 2012"),
-          days_of_the_week_worked: %w(0 6),
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "give correct ssp calculation" do # 12 days with 3 waiting days, all at 2012-13 daily rate
-        assert_equal @calculator.waiting_days, 3
-        assert_equal @calculator.send(:days_to_pay), 9
-        assert_equal @calculator.normal_workdays, 12
-        assert_equal @calculator.ssp_payment, 386.33
-      end
-    end
-
-    # Monday - Thursday
-    context "test scenario 5" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("29 March 2012"),
-          sick_end_date: Date.parse("6 May 2012"),
-          days_of_the_week_worked: %w(1 2 3 4),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Wed, 28 Sep 2011"),
-          linked_sickness_end_date: Date.parse("Mon, 19 Mar 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 99
-      end
-
-      should "give correct ssp calculation" do # max of 16 days that can still be paid with no waiting days, first four days at 2011-12,  2012-13 daily rate
-        assert_equal @calculator.send(:days_to_pay), 16
-        assert_equal @calculator.ssp_payment, 338.09
-      end
-    end
-
-    # Monday - Thursday
-    context "test scenario 6" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("29 March 2012"),
-          sick_end_date: Date.parse("6 May 2012"),
-          days_of_the_week_worked: %w(1 2 3 4),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Mon, 5 Sep 2011"),
-          linked_sickness_end_date: Date.parse("Wed, 21 Mar 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 115
-      end
-
-      should "give correct ssp calculation" do # there should be no more days for which employee can receive pay
-        assert_equal @calculator.ssp_payment, 0
-      end
-    end
-
-    # Wednesday
-    context "test scenario 7" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("28 August 2012"),
-          sick_end_date: Date.parse("6 October 2012"),
-          days_of_the_week_worked: ['3'],
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "give correct ssp calculation" do # there should be 3 normal workdays to pay
-        assert_equal @calculator.send(:days_to_pay), 3
-        assert_equal @calculator.waiting_days, 3
-        assert_equal @calculator.ssp_payment, 257.55
-      end
-    end
-
-    #  additional test scenario - rates for previous tax year
-    context "test scenario 6a - 1 day max to pay" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("29 March 2012"),
-          sick_end_date: Date.parse("10 April 2012"),
-          days_of_the_week_worked: %w(1 2 3 4),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Mon, 5 Sep 2011"),
-          linked_sickness_end_date: Date.parse("Tue, 20 Mar 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 114
-      end
-
-      should "give correct ssp calculation" do # there should be max 1 day for which employee can receive pay
-        assert_equal @calculator.send(:days_to_pay), 1
-        assert_equal @calculator.ssp_payment, 20.40
-      end
-    end
-
-    # new test scenario 2 - SSP spanning 2013/14 tax year, Tue - Thu, rate above LEL, no previous sickness
-    context "2013/14 test scenario 1" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("26 March 2013"),
-          sick_end_date: Date.parse("12 April 2013"),
-          days_of_the_week_worked: %w(2 3 4),
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "give correct SSP calculation" do
-        assert_equal @calculator.send(:days_to_pay), 6 # first 3 days are waiting days, so no pay
-        assert_equal @calculator.ssp_payment, 172.55 # one week at 85.85 plus one week at 86.70
-      end
-    end
-
-    # new test scenario 2 - SSP spanning 2013/14 tax year, Mon - Thu, no previous sickness
-    context "2013/14 test scenario 2" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("7 January 2013"),
-          sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(1 2 3 4),
-          has_linked_sickness: false
-        )
-        assert_equal @calculator.prev_sick_days, 0
-      end
-
-      should "give correct SSP calculation" do
-        assert_equal @calculator.send(:days_to_pay), 65 # 1 day + 16 weeks (4 days/week)
-        assert_equal @calculator.ssp_payment, 1398.47 # see spreadsheet
-      end
-    end
-
-    # new test scenario 3 - SSP spanning 2013/14 tax year, Wed and Sat, previous sickness of 8 days
-    context "2013/14 test scenario 3" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("7 January 2013"),
-          sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(3 6),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Sat, 1 Dec 2012"),
-          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 8
-      end
-
-      should "give correct SSP calculation" do
-        assert_equal @calculator.send(:days_to_pay), 33 # 1 day + 16 weeks (2 days/week)
-        assert_equal @calculator.ssp_payment, 1419.93 # see spreadsheet
-      end
-    end
-
-    # new test scenario 4 - SSP spanning 2013/14 tax year, Tue, Wed, Thu previous sickness of 42 days
-    context "2013/14 test scenario 4" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("7 January 2013"),
-          sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
-        )
-        assert_equal @calculator.prev_sick_days, 42
-      end
-
-      should "give correct SSP calculation" do
-        assert_equal @calculator.send(:days_to_pay), 45 # 15 weeks (3 days/week)
-        assert_equal @calculator.ssp_payment, 1289.45 # see spreadsheet
-      end
-    end
-
-    # new test 5 - SSP spanning 2014/2015 tax year, Mon to Fri
-    context "2014/2015 scenario 5" do
-      setup do
-        @calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("10 July 2014"),
-          sick_end_date: Date.parse("20 July 2014"),
-          days_of_the_week_worked: %w(1 2 3 4 5),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Sun, 1 Jun 2014"),
-          linked_sickness_end_date: Date.parse("Sat, 14 Jun 2014")
-        )
-        assert_equal @calculator.prev_sick_days, 10
-      end
-
-      should "give correct SSP calculation" do
-        assert_equal @calculator.send(:days_to_pay), 7
-        assert_equal @calculator.ssp_payment, 122.57
-      end
-    end
-
-    context "lower earnings limit (LEL)" do
-      context "in 2011/2012" do
+module SmartAnswer
+  module Calculators
+    class StatutorySickPayCalculatorTest < ActiveSupport::TestCase
+
+      context ".dates_matching_pattern" do
+        should "return dates maching working days pattern" do
+          working_days = %w(Sunday Tuesday Thursday).map { |d| Date::DAYNAMES.index(d).to_s }
+          dates = StatutorySickPayCalculator.dates_matching_pattern(
+            from: Date.parse("Sun, 04 Jan 2015"),
+            to:   Date.parse("Wed, 14 Jan 2015"),
+            pattern: working_days
+          )
+          assert_equal [
+            Date.parse("Sun, 04 Jan 2015"), Date.parse("Tue, 06 Jan 2015"), Date.parse("Thu, 08 Jan 2015"),
+            Date.parse("Sun, 11 Jan 2015"), Date.parse("Tue, 13 Jan 2015")
+          ], dates
+        end
+      end
+
+      context ".months_between" do
+        should "calculate number of months between dates" do
+          months = StatutorySickPayCalculator.months_between(Date.parse("04/02/2012"), Date.parse("17/05/2012"))
+          assert_equal 4, months
+        end
+
+        should "not count the first month if it's later than the 17th" do
+          months = StatutorySickPayCalculator.months_between(Date.parse("18/02/2012"), Date.parse("17/05/2012"))
+          assert_equal 3, months
+        end
+
+        should "not count the last month if it's before the 15th" do
+          months = StatutorySickPayCalculator.months_between(Date.parse("13/02/2012"), Date.parse("14/05/2012"))
+          assert_equal 3, months
+        end
+      end # end .months_between
+
+      context ".average_weekly_earnings" do
+        should "calculate AWE for weekly pay patterns" do
+          assert_equal 100, StatutorySickPayCalculator.average_weekly_earnings(pay: 800, pay_pattern: 'weekly')
+          assert_equal 100, StatutorySickPayCalculator.average_weekly_earnings(pay: 800, pay_pattern: 'fortnightly')
+          assert_equal 100, StatutorySickPayCalculator.average_weekly_earnings(pay: 800, pay_pattern: 'every_4_weeks')
+        end
+        should "calculate AWE for monthly pay patterns" do
+          assert_equal 92.31, StatutorySickPayCalculator.average_weekly_earnings(
+            pay: 1200, pay_pattern: 'monthly', monthly_pattern_payments: 3).round(2)
+        end
+        should "calculate AWE for irregular pay patterns" do
+          assert_equal 700, StatutorySickPayCalculator.average_weekly_earnings(
+            pay: 1000, pay_pattern: 'irregularly', relevant_period_to: Date.parse("31 December 2013"), relevant_period_from: Date.parse("21 December 2013"))
+        end
+      end # end .average_weekly_earnings
+
+      context "0 days per week worked" do
         setup do
-          @date = Date.parse("1 April 2012")
-          @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          @days_worked = []
+          @start_date = Date.parse("1 October 2012")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: Date.parse("7 October 2012"),
+            days_of_the_week_worked: @days_worked,
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
         end
 
-        should "be 102" do
-          assert_equal 102.00, @lel
+        should "return daily rate of 0.0" do
+          @weekly_rate = @calculator.send(:weekly_rate_on, @start_date)
+          assert_equal @calculator.daily_rate_from_weekly(@weekly_rate, @days_worked.length), 0.0
         end
       end
 
-      context "in the beginning of 2012/2013" do
+      context "prev_sick_days is 5, M-F, 7 days out" do
         setup do
-          @date = Date.parse("6 April 2012")
-          @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          @start_date = Date.parse("1 October 2012")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: Date.parse("7 October 2012"),
+            days_of_the_week_worked: %w(1 2 3 4 5),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Fri, 7 Sep 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 5
         end
 
-        should "be 107" do
-          assert_equal 107.00, @lel
+        should "return waiting_days of 0" do
+          assert_equal @calculator.waiting_days, 0
+        end
+
+        should "return daily rate of 17.1700" do
+          @weekly_rate = @calculator.send(:weekly_rate_on, @start_date)
+          assert_equal @weekly_rate, 85.8500
+          assert_equal @calculator.daily_rate_from_weekly(@weekly_rate, 5), 17.1700
+        end
+
+        should "normal working days missed is 5" do
+          assert_equal @calculator.normal_workdays, 5
+        end
+
+        should "return correct ssp_payment" do
+          assert_equal 85.85, @calculator.ssp_payment
         end
       end
 
-      context "in the beginning of 2013/2014" do
+      context "daily rate test for 3 days per week worked (M-W-F)" do
         setup do
-          @date = Date.parse("6 April 2013")
-          @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          @start_date = Date.parse("1 October 2012")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: Date.parse("7 October 2012"),
+            days_of_the_week_worked: %w(1 3 5),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Wed, 12 Sep 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 5
         end
 
-        should "be 109" do
-          assert_equal 109.00, @lel
+        should "return daily rate of 28.6166" do
+          assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 3), 28.6166 # should be 28.6166 according to HMRC table
         end
       end
 
-      context "in the beginning of 2014/2015" do
+      context "daily rate test for 7 days per week worked" do
         setup do
-          @date = Date.parse("6 April 2014")
-          @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          @start_date = Date.parse("1 October 2012")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: Date.parse("7 October 2012"),
+            days_of_the_week_worked: %w(0 1 2 3 4 5 6),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Wed, 5 Sep 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 5
         end
 
-        should "be 111" do
-          assert_equal 111.00, @lel
+        should "return daily rate of 12.2642" do
+          assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 7), 12.2642 # unrounded, matches the HMRC SSP daily rate table
         end
       end
 
-      context "in the beginning of 2015/2016" do
+      context "daily rate test for 6 days per week worked" do
         setup do
-          @date = Date.parse("6 April 2015")
-          @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          @start_date = Date.parse("1 October 2012")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: Date.parse("7 October 2012"),
+            days_of_the_week_worked: %w(1 2 3 4 5 6),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Thu, 6 Sep 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 5
         end
 
-        should "be 112" do
-          assert_equal 112.00, @lel
+        should "return daily rate of 14.3083" do
+          assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 6), 14.3083
         end
       end
 
-      context "fallback when no dates are matching" do
-        should "not break and use the rate of the latest available fiscal year" do
-          date = Date.parse("6 April 2056")
-          assert StatutorySickPayCalculator.lower_earning_limit_on(date).is_a?(Numeric)
+      context "daily rate test for 2 days per week worked (Thu-Fri)" do
+        setup do
+          @start_date = Date.parse("1 October 2012")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: Date.parse("7 October 2012"),
+            days_of_the_week_worked: %w(4 5),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Thu, 6 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Thu, 20 Sep 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 5
+        end
+
+        should "return daily rate of 42.9250" do
+          assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 2), 42.9250
         end
       end
-    end
 
-    context "sick_pay_weekly_dates" do
-      should "produce a list of Saturdays for the provided sick period" do
-        calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("7 January 2013"),
-          sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
-        )
-        assert_equal 42, calculator.prev_sick_days
-        assert_equal [Date.parse("12 Jan 2013"),
-                      Date.parse("19 Jan 2013"),
-                      Date.parse("26 Jan 2013"),
-                      Date.parse("02 Feb 2013"),
-                      Date.parse("09 Feb 2013"),
-                      Date.parse("16 Feb 2013"),
-                      Date.parse("23 Feb 2013"),
-                      Date.parse("02 Mar 2013"),
-                      Date.parse("09 Mar 2013"),
-                      Date.parse("16 Mar 2013"),
-                      Date.parse("23 Mar 2013"),
-                      Date.parse("30 Mar 2013"),
-                      Date.parse("06 Apr 2013"),
-                      Date.parse("13 Apr 2013"),
-                      Date.parse("20 Apr 2013"),
-                      Date.parse("27 Apr 2013"),
-                      Date.parse("04 May 2013")],
-                     calculator.send(:sick_pay_weekly_dates)
-      end
-    end
+      context "waiting days if prev_sick_days is 2" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("6 April 2012"),
+            sick_end_date: Date.parse("6 May 2012"),
+            days_of_the_week_worked: %w(1 2 3),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Tue, 4 Sep 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 2
+        end
 
-    context "sick_pay_weekly_amounts" do
-      should "return the payable weeks by taking into account the final SSP payment" do
-        calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("7 January 2013"),
-          sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
-        )
-
-        assert_equal 42, calculator.prev_sick_days
-        assert_equal [[Date.parse("12 Jan 2013"), 85.85],
-                      [Date.parse("19 Jan 2013"), 85.85],
-                      [Date.parse("26 Jan 2013"), 85.85],
-                      [Date.parse("02 Feb 2013"), 85.85],
-                      [Date.parse("09 Feb 2013"), 85.85],
-                      [Date.parse("16 Feb 2013"), 85.85],
-                      [Date.parse("23 Feb 2013"), 85.85],
-                      [Date.parse("02 Mar 2013"), 85.85],
-                      [Date.parse("09 Mar 2013"), 85.85],
-                      [Date.parse("16 Mar 2013"), 85.85],
-                      [Date.parse("23 Mar 2013"), 85.85],
-                      [Date.parse("30 Mar 2013"), 85.85],
-                      [Date.parse("06 Apr 2013"), 85.85],
-                      [Date.parse("13 Apr 2013"), 86.7],
-                      [Date.parse("20 Apr 2013"), 86.7]],
-                    calculator.send(:weekly_payments)
+        should "return waiting_days of 1" do
+          assert_equal @calculator.waiting_days, 1
+        end
       end
 
-      should "have the same reduced value as the ssp_payment value" do
-        calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("7 January 2013"),
-          sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
-        )
+      context "waiting days if prev_sick_days is 1" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("6 April 2012"),
+            sick_end_date: Date.parse("17 April 2012"),
+            days_of_the_week_worked: %w(1 2 3),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Mon, 3 Sep 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 1
+        end
 
-        assert_equal 42, calculator.prev_sick_days
-        assert_equal calculator.ssp_payment,
-                     calculator.send(:weekly_payments).map(&:second).sum
+        should "return waiting_days of 2" do
+          assert_equal @calculator.waiting_days, 2
+          assert_equal @calculator.normal_workdays, 5
+          assert_equal @calculator.send(:days_to_pay), 3
+
+        end
       end
-    end
 
-    context "formatted_sick_pay_weekly_amounts" do
-      should "produce a markdown (value) formatted string of weekly SSP dates and pay rates" do
-        calculator = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("7 January 2013"),
-          sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4),
-          has_linked_sickness: true,
-          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
-          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
-        )
+      context "waiting days if prev_sick_days is 0" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("6 April 2012"),
+            sick_end_date: Date.parse("12 April 2012"),
+            days_of_the_week_worked: %w(1 2 3),
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
+        end
 
-        assert_equal 42, calculator.prev_sick_days
-        assert_equal ["12 January 2013|£85.85",
-                      "19 January 2013|£85.85",
-                      "26 January 2013|£85.85",
-                      " 2 February 2013|£85.85",
-                      " 9 February 2013|£85.85",
-                      "16 February 2013|£85.85",
-                      "23 February 2013|£85.85",
-                      " 2 March 2013|£85.85",
-                      " 9 March 2013|£85.85",
-                      "16 March 2013|£85.85",
-                      "23 March 2013|£85.85",
-                      "30 March 2013|£85.85",
-                      " 6 April 2013|£85.85",
-                      "13 April 2013|£86.70",
-                      "20 April 2013|£86.70"].join("\n"),
-                     calculator.formatted_sick_pay_weekly_amounts
+        should "return waiting_days of 3, ssp payment of 0" do
+          assert_equal @calculator.waiting_days, 3
+          assert_equal @calculator.send(:days_to_pay), 0
+          assert_equal @calculator.normal_workdays, 3
+          assert_equal @calculator.ssp_payment, 0.00
+        end
       end
-    end
 
-    context "average weekly earnings for new employees who fell sick before first payday" do
-      should "give the average weekly earnings" do
-        pay = SmartAnswer::Money.new(100)
-        days_worked = 7
-        awe = StatutorySickPayCalculator.contractual_earnings_awe(pay, days_worked)
-        assert_equal 100, awe
+      context "maximum days payable for 5 days a week" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("6 April 2012"),
+            sick_end_date: Date.parse("6 December 2012"),
+            days_of_the_week_worked: %w(1 2 3 4 5),
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
+        end
+
+        should "have a max of 140 days payable" do
+          assert_equal @calculator.send(:days_to_pay), 140
+          assert_equal @calculator.normal_workdays, 175
+          assert_equal @calculator.ssp_payment, 2403.80 #140 * 17.1700 or 28 * 85.85
+        end
       end
-    end
 
-    context "average weekly earnings for new employees who fell sick before first payday - using decimal place" do
-      should "give the average weekly earnings" do
-        pay = SmartAnswer::Money.new(100)
-        days_worked = 10.5
-        awe = StatutorySickPayCalculator.contractual_earnings_awe(pay, days_worked)
-        assert_equal 66.67, awe
+      context "maximum days payable for 3 days a week" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("6 April 2012"),
+            sick_end_date: Date.parse("6 December 2012"),
+            days_of_the_week_worked: %w(2 3 4),
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
+        end
+
+        should "have a max of 84 days payable" do
+          assert_equal @calculator.send(:days_to_pay), 84
+          assert_equal @calculator.normal_workdays, 105
+          assert_equal @calculator.ssp_payment, 2403.80 #28 weeks at 85.85 a week
+        end
       end
-    end
 
-    context "xx average weekly earnings for employees who've been paid less than 8 weeks with exact weeks pay" do
-      should "give the average weekly earnings" do
-        pay = SmartAnswer::Money.new(532)
-        days_worked = 42
-        awe = StatutorySickPayCalculator.total_earnings_awe(pay, days_worked)
-        assert_equal 88.67, awe.to_f
+      context "historic rate test 1" do
+        setup do
+          @start_date = Date.parse("5 April 2012")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: Date.parse("10 April 2012"),
+            days_of_the_week_worked: %w(1 2 3 4 5),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Wed, 5 Sep 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 3
+        end
+
+        should "use ssp rate and lel for 2011-12" do
+          assert_equal StatutorySickPayCalculator.lower_earning_limit_on(@start_date), 102
+          assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 5), 16.3200
+        end
       end
-    end
 
-    context "average weekly earnings for employees who've been paid less than 8 weeks with in-exact weeks pay" do
-      should "give the average weekly earnings" do
-        pay = SmartAnswer::Money.new(600)
-        days_worked = 43
-        awe = StatutorySickPayCalculator.total_earnings_awe(pay, days_worked)
-        assert_equal 97.67, awe
+      # Monday - Friday
+      context "test scenario 1 - M-F, no waiting days, cross tax years" do
+        setup do
+          @start_date = Date.parse("26 March 2012")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: Date.parse("13 April 2012"),
+            days_of_the_week_worked: %w(1 2 3 4 5),
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
+        end
+
+        should "give correct ssp calculation" do  # 15 days with 3 waiting days, so 6 days at lower weekly rate, 6 days at higher rate
+          assert_equal @calculator.waiting_days, 3
+          assert_equal @calculator.send(:days_to_pay), 12
+          assert_equal @calculator.normal_workdays, 15
+          assert_equal @calculator.ssp_payment, 200.94
+        end
       end
-    end
 
-    context "when the last working day of the sick period is a Sunday" do
-      should "calculate the sick period including the Sunday" do
-        calc = StatutorySickPayCalculator.new(
-          sick_start_date: Date.parse("24 October 2013"),
-          sick_end_date: Date.parse("27 October 2013"),
-          days_of_the_week_worked: %w(0 1 3 4 5 6),
-          has_linked_sickness: false
-        )
+      context "test date 4 May 2014" do
+        setup do
+          @start_date = Date.parse("4 May 2014")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: Date.parse("3 August 2014"),
+            days_of_the_week_worked: %w(1 2 3 4 5),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Wed, 5 Sep 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 3
+        end
 
-        assert_equal 0, calc.prev_sick_days
-        assert_equal 14.45, calc.ssp_payment
+        should "use ssp rate and lel for 2014-15" do
+          assert_equal StatutorySickPayCalculator.lower_earning_limit_on(@start_date), 111
+          assert_equal @calculator.daily_rate_from_weekly(@calculator.send(:weekly_rate_on, @start_date), 5), 17.51
+        end
       end
-    end
-  end # SSP calculator
+
+      context "weekly rate fallback. When date is not covered by any known ranges" do
+        setup do
+          @start_date = Date.parse("4 May 2054")
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: @start_date,
+            sick_end_date: @start_date + 1.month,
+            days_of_the_week_worked: %w(1 2 3 4 5),
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
+        end
+
+        should "not break and use ssp rate for the latest know fiscal year" do
+          assert @calculator.send(:weekly_rate_on, @start_date).is_a?(Numeric)
+        end
+      end
+
+      # Tuesday to Friday
+      context "test scenario 2 - T-F, 7 waiting days, cross tax years" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("28 February 2012"),
+            sick_end_date: Date.parse("7 April 2012"),
+            days_of_the_week_worked: %w(2 3 4 5),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Tue, 3 Jan 2012"),
+            linked_sickness_end_date: Date.parse("Thu, 12 Jan 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 7
+        end
+
+        should "give correct ssp calculation" do # 24 days with no waiting days, so 22 days at lower weekly rate, 2 days at higher rate
+          assert_equal @calculator.normal_workdays, 24
+          assert_equal @calculator.send(:days_to_pay), 24
+          assert_equal @calculator.ssp_payment, 490.67
+        end
+      end
+
+      # Monday, Wednesday, Friday
+      context "test scenario 3" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("25 July 2012"),
+            sick_end_date: Date.parse("4 September 2012"),
+            days_of_the_week_worked: %w(1 3 5),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Mon, 7 May 2012"),
+            linked_sickness_end_date: Date.parse("Sun, 1 Jul 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 24
+        end
+
+        should "give correct ssp calculation" do
+          assert_equal @calculator.prev_sick_days, 24
+          assert_equal @calculator.send(:days_to_pay), 18
+          assert_equal @calculator.ssp_payment, 515.11
+        end
+      end
+
+      #  Saturday and Sunday
+      context "test scenario 4" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("23 November 2012"),
+            sick_end_date: Date.parse("31 December 2012"),
+            days_of_the_week_worked: %w(0 6),
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
+        end
+
+        should "give correct ssp calculation" do # 12 days with 3 waiting days, all at 2012-13 daily rate
+          assert_equal @calculator.waiting_days, 3
+          assert_equal @calculator.send(:days_to_pay), 9
+          assert_equal @calculator.normal_workdays, 12
+          assert_equal @calculator.ssp_payment, 386.33
+        end
+      end
+
+      # Monday - Thursday
+      context "test scenario 5" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("29 March 2012"),
+            sick_end_date: Date.parse("6 May 2012"),
+            days_of_the_week_worked: %w(1 2 3 4),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Wed, 28 Sep 2011"),
+            linked_sickness_end_date: Date.parse("Mon, 19 Mar 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 99
+        end
+
+        should "give correct ssp calculation" do # max of 16 days that can still be paid with no waiting days, first four days at 2011-12,  2012-13 daily rate
+          assert_equal @calculator.send(:days_to_pay), 16
+          assert_equal @calculator.ssp_payment, 338.09
+        end
+      end
+
+      # Monday - Thursday
+      context "test scenario 6" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("29 March 2012"),
+            sick_end_date: Date.parse("6 May 2012"),
+            days_of_the_week_worked: %w(1 2 3 4),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Mon, 5 Sep 2011"),
+            linked_sickness_end_date: Date.parse("Wed, 21 Mar 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 115
+        end
+
+        should "give correct ssp calculation" do # there should be no more days for which employee can receive pay
+          assert_equal @calculator.ssp_payment, 0
+        end
+      end
+
+      # Wednesday
+      context "test scenario 7" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("28 August 2012"),
+            sick_end_date: Date.parse("6 October 2012"),
+            days_of_the_week_worked: ['3'],
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
+        end
+
+        should "give correct ssp calculation" do # there should be 3 normal workdays to pay
+          assert_equal @calculator.send(:days_to_pay), 3
+          assert_equal @calculator.waiting_days, 3
+          assert_equal @calculator.ssp_payment, 257.55
+        end
+      end
+
+      #  additional test scenario - rates for previous tax year
+      context "test scenario 6a - 1 day max to pay" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("29 March 2012"),
+            sick_end_date: Date.parse("10 April 2012"),
+            days_of_the_week_worked: %w(1 2 3 4),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Mon, 5 Sep 2011"),
+            linked_sickness_end_date: Date.parse("Tue, 20 Mar 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 114
+        end
+
+        should "give correct ssp calculation" do # there should be max 1 day for which employee can receive pay
+          assert_equal @calculator.send(:days_to_pay), 1
+          assert_equal @calculator.ssp_payment, 20.40
+        end
+      end
+
+      # new test scenario 2 - SSP spanning 2013/14 tax year, Tue - Thu, rate above LEL, no previous sickness
+      context "2013/14 test scenario 1" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("26 March 2013"),
+            sick_end_date: Date.parse("12 April 2013"),
+            days_of_the_week_worked: %w(2 3 4),
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
+        end
+
+        should "give correct SSP calculation" do
+          assert_equal @calculator.send(:days_to_pay), 6 # first 3 days are waiting days, so no pay
+          assert_equal @calculator.ssp_payment, 172.55 # one week at 85.85 plus one week at 86.70
+        end
+      end
+
+      # new test scenario 2 - SSP spanning 2013/14 tax year, Mon - Thu, no previous sickness
+      context "2013/14 test scenario 2" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("7 January 2013"),
+            sick_end_date: Date.parse("3 May 2013"),
+            days_of_the_week_worked: %w(1 2 3 4),
+            has_linked_sickness: false
+          )
+          assert_equal @calculator.prev_sick_days, 0
+        end
+
+        should "give correct SSP calculation" do
+          assert_equal @calculator.send(:days_to_pay), 65 # 1 day + 16 weeks (4 days/week)
+          assert_equal @calculator.ssp_payment, 1398.47 # see spreadsheet
+        end
+      end
+
+      # new test scenario 3 - SSP spanning 2013/14 tax year, Wed and Sat, previous sickness of 8 days
+      context "2013/14 test scenario 3" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("7 January 2013"),
+            sick_end_date: Date.parse("3 May 2013"),
+            days_of_the_week_worked: %w(3 6),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Sat, 1 Dec 2012"),
+            linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 8
+        end
+
+        should "give correct SSP calculation" do
+          assert_equal @calculator.send(:days_to_pay), 33 # 1 day + 16 weeks (2 days/week)
+          assert_equal @calculator.ssp_payment, 1419.93 # see spreadsheet
+        end
+      end
+
+      # new test scenario 4 - SSP spanning 2013/14 tax year, Tue, Wed, Thu previous sickness of 42 days
+      context "2013/14 test scenario 4" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("7 January 2013"),
+            sick_end_date: Date.parse("3 May 2013"),
+            days_of_the_week_worked: %w(2 3 4),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
+          )
+          assert_equal @calculator.prev_sick_days, 42
+        end
+
+        should "give correct SSP calculation" do
+          assert_equal @calculator.send(:days_to_pay), 45 # 15 weeks (3 days/week)
+          assert_equal @calculator.ssp_payment, 1289.45 # see spreadsheet
+        end
+      end
+
+      # new test 5 - SSP spanning 2014/2015 tax year, Mon to Fri
+      context "2014/2015 scenario 5" do
+        setup do
+          @calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("10 July 2014"),
+            sick_end_date: Date.parse("20 July 2014"),
+            days_of_the_week_worked: %w(1 2 3 4 5),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Sun, 1 Jun 2014"),
+            linked_sickness_end_date: Date.parse("Sat, 14 Jun 2014")
+          )
+          assert_equal @calculator.prev_sick_days, 10
+        end
+
+        should "give correct SSP calculation" do
+          assert_equal @calculator.send(:days_to_pay), 7
+          assert_equal @calculator.ssp_payment, 122.57
+        end
+      end
+
+      context "lower earnings limit (LEL)" do
+        context "in 2011/2012" do
+          setup do
+            @date = Date.parse("1 April 2012")
+            @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          end
+
+          should "be 102" do
+            assert_equal 102.00, @lel
+          end
+        end
+
+        context "in the beginning of 2012/2013" do
+          setup do
+            @date = Date.parse("6 April 2012")
+            @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          end
+
+          should "be 107" do
+            assert_equal 107.00, @lel
+          end
+        end
+
+        context "in the beginning of 2013/2014" do
+          setup do
+            @date = Date.parse("6 April 2013")
+            @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          end
+
+          should "be 109" do
+            assert_equal 109.00, @lel
+          end
+        end
+
+        context "in the beginning of 2014/2015" do
+          setup do
+            @date = Date.parse("6 April 2014")
+            @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          end
+
+          should "be 111" do
+            assert_equal 111.00, @lel
+          end
+        end
+
+        context "in the beginning of 2015/2016" do
+          setup do
+            @date = Date.parse("6 April 2015")
+            @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          end
+
+          should "be 112" do
+            assert_equal 112.00, @lel
+          end
+        end
+
+        context "fallback when no dates are matching" do
+          should "not break and use the rate of the latest available fiscal year" do
+            date = Date.parse("6 April 2056")
+            assert StatutorySickPayCalculator.lower_earning_limit_on(date).is_a?(Numeric)
+          end
+        end
+      end
+
+      context "sick_pay_weekly_dates" do
+        should "produce a list of Saturdays for the provided sick period" do
+          calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("7 January 2013"),
+            sick_end_date: Date.parse("3 May 2013"),
+            days_of_the_week_worked: %w(2 3 4),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
+          )
+          assert_equal 42, calculator.prev_sick_days
+          assert_equal [Date.parse("12 Jan 2013"),
+                        Date.parse("19 Jan 2013"),
+                        Date.parse("26 Jan 2013"),
+                        Date.parse("02 Feb 2013"),
+                        Date.parse("09 Feb 2013"),
+                        Date.parse("16 Feb 2013"),
+                        Date.parse("23 Feb 2013"),
+                        Date.parse("02 Mar 2013"),
+                        Date.parse("09 Mar 2013"),
+                        Date.parse("16 Mar 2013"),
+                        Date.parse("23 Mar 2013"),
+                        Date.parse("30 Mar 2013"),
+                        Date.parse("06 Apr 2013"),
+                        Date.parse("13 Apr 2013"),
+                        Date.parse("20 Apr 2013"),
+                        Date.parse("27 Apr 2013"),
+                        Date.parse("04 May 2013")],
+                       calculator.send(:sick_pay_weekly_dates)
+        end
+      end
+
+      context "sick_pay_weekly_amounts" do
+        should "return the payable weeks by taking into account the final SSP payment" do
+          calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("7 January 2013"),
+            sick_end_date: Date.parse("3 May 2013"),
+            days_of_the_week_worked: %w(2 3 4),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
+          )
+
+          assert_equal 42, calculator.prev_sick_days
+          assert_equal [[Date.parse("12 Jan 2013"), 85.85],
+                        [Date.parse("19 Jan 2013"), 85.85],
+                        [Date.parse("26 Jan 2013"), 85.85],
+                        [Date.parse("02 Feb 2013"), 85.85],
+                        [Date.parse("09 Feb 2013"), 85.85],
+                        [Date.parse("16 Feb 2013"), 85.85],
+                        [Date.parse("23 Feb 2013"), 85.85],
+                        [Date.parse("02 Mar 2013"), 85.85],
+                        [Date.parse("09 Mar 2013"), 85.85],
+                        [Date.parse("16 Mar 2013"), 85.85],
+                        [Date.parse("23 Mar 2013"), 85.85],
+                        [Date.parse("30 Mar 2013"), 85.85],
+                        [Date.parse("06 Apr 2013"), 85.85],
+                        [Date.parse("13 Apr 2013"), 86.7],
+                        [Date.parse("20 Apr 2013"), 86.7]],
+                      calculator.send(:weekly_payments)
+        end
+
+        should "have the same reduced value as the ssp_payment value" do
+          calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("7 January 2013"),
+            sick_end_date: Date.parse("3 May 2013"),
+            days_of_the_week_worked: %w(2 3 4),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
+          )
+
+          assert_equal 42, calculator.prev_sick_days
+          assert_equal calculator.ssp_payment,
+                       calculator.send(:weekly_payments).map(&:second).sum
+        end
+      end
+
+      context "formatted_sick_pay_weekly_amounts" do
+        should "produce a markdown (value) formatted string of weekly SSP dates and pay rates" do
+          calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("7 January 2013"),
+            sick_end_date: Date.parse("3 May 2013"),
+            days_of_the_week_worked: %w(2 3 4),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+            linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
+          )
+
+          assert_equal 42, calculator.prev_sick_days
+          assert_equal ["12 January 2013|£85.85",
+                        "19 January 2013|£85.85",
+                        "26 January 2013|£85.85",
+                        " 2 February 2013|£85.85",
+                        " 9 February 2013|£85.85",
+                        "16 February 2013|£85.85",
+                        "23 February 2013|£85.85",
+                        " 2 March 2013|£85.85",
+                        " 9 March 2013|£85.85",
+                        "16 March 2013|£85.85",
+                        "23 March 2013|£85.85",
+                        "30 March 2013|£85.85",
+                        " 6 April 2013|£85.85",
+                        "13 April 2013|£86.70",
+                        "20 April 2013|£86.70"].join("\n"),
+                       calculator.formatted_sick_pay_weekly_amounts
+        end
+      end
+
+      context "average weekly earnings for new employees who fell sick before first payday" do
+        should "give the average weekly earnings" do
+          pay = SmartAnswer::Money.new(100)
+          days_worked = 7
+          awe = StatutorySickPayCalculator.contractual_earnings_awe(pay, days_worked)
+          assert_equal 100, awe
+        end
+      end
+
+      context "average weekly earnings for new employees who fell sick before first payday - using decimal place" do
+        should "give the average weekly earnings" do
+          pay = SmartAnswer::Money.new(100)
+          days_worked = 10.5
+          awe = StatutorySickPayCalculator.contractual_earnings_awe(pay, days_worked)
+          assert_equal 66.67, awe
+        end
+      end
+
+      context "xx average weekly earnings for employees who've been paid less than 8 weeks with exact weeks pay" do
+        should "give the average weekly earnings" do
+          pay = SmartAnswer::Money.new(532)
+          days_worked = 42
+          awe = StatutorySickPayCalculator.total_earnings_awe(pay, days_worked)
+          assert_equal 88.67, awe.to_f
+        end
+      end
+
+      context "average weekly earnings for employees who've been paid less than 8 weeks with in-exact weeks pay" do
+        should "give the average weekly earnings" do
+          pay = SmartAnswer::Money.new(600)
+          days_worked = 43
+          awe = StatutorySickPayCalculator.total_earnings_awe(pay, days_worked)
+          assert_equal 97.67, awe
+        end
+      end
+
+      context "when the last working day of the sick period is a Sunday" do
+        should "calculate the sick period including the Sunday" do
+          calc = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("24 October 2013"),
+            sick_end_date: Date.parse("27 October 2013"),
+            days_of_the_week_worked: %w(0 1 3 4 5 6),
+            has_linked_sickness: false
+          )
+
+          assert_equal 0, calc.prev_sick_days
+          assert_equal 14.45, calc.ssp_payment
+        end
+      end
+    end # SSP calculator
+  end
 end

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -56,11 +56,12 @@ module SmartAnswer::Calculators
         @days_worked = []
         @start_date = Date.parse("1 October 2012")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: @start_date,
           sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: @days_worked
+          days_of_the_week_worked: @days_worked,
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "return daily rate of 0.0" do
@@ -73,11 +74,14 @@ module SmartAnswer::Calculators
       setup do
         @start_date = Date.parse("1 October 2012")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 5,
           sick_start_date: @start_date,
           sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5)
+          days_of_the_week_worked: %w(1 2 3 4 5),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Fri, 7 Sep 2012")
         )
+        assert_equal @calculator.prev_sick_days, 5
       end
 
       should "return waiting_days of 0" do
@@ -103,11 +107,14 @@ module SmartAnswer::Calculators
       setup do
         @start_date = Date.parse("1 October 2012")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 5,
           sick_start_date: @start_date,
           sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(1 3 5)
+          days_of_the_week_worked: %w(1 3 5),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Wed, 12 Sep 2012")
         )
+        assert_equal @calculator.prev_sick_days, 5
       end
 
       should "return daily rate of 28.6166" do
@@ -119,11 +126,14 @@ module SmartAnswer::Calculators
       setup do
         @start_date = Date.parse("1 October 2012")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 5,
           sick_start_date: @start_date,
           sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(0 1 2 3 4 5 6)
+          days_of_the_week_worked: %w(0 1 2 3 4 5 6),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Wed, 5 Sep 2012")
         )
+        assert_equal @calculator.prev_sick_days, 5
       end
 
       should "return daily rate of 12.2642" do
@@ -135,11 +145,14 @@ module SmartAnswer::Calculators
       setup do
         @start_date = Date.parse("1 October 2012")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 5,
           sick_start_date: @start_date,
           sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5 6)
+          days_of_the_week_worked: %w(1 2 3 4 5 6),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Sat, 1 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Thu, 6 Sep 2012")
         )
+        assert_equal @calculator.prev_sick_days, 5
       end
 
       should "return daily rate of 14.3083" do
@@ -147,15 +160,18 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "daily rate test for 2 days per week worked" do
+    context "daily rate test for 2 days per week worked (Thu-Fri)" do
       setup do
         @start_date = Date.parse("1 October 2012")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 5,
           sick_start_date: @start_date,
           sick_end_date: Date.parse("7 October 2012"),
-          days_of_the_week_worked: %w(4 5)
+          days_of_the_week_worked: %w(4 5),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Thu, 6 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Thu, 20 Sep 2012")
         )
+        assert_equal @calculator.prev_sick_days, 5
       end
 
       should "return daily rate of 42.9250" do
@@ -166,11 +182,14 @@ module SmartAnswer::Calculators
     context "waiting days if prev_sick_days is 2" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 2,
           sick_start_date: Date.parse("6 April 2012"),
           sick_end_date: Date.parse("6 May 2012"),
-          days_of_the_week_worked: %w(1 2 3)
+          days_of_the_week_worked: %w(1 2 3),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Tue, 4 Sep 2012")
         )
+        assert_equal @calculator.prev_sick_days, 2
       end
 
       should "return waiting_days of 1" do
@@ -181,11 +200,14 @@ module SmartAnswer::Calculators
     context "waiting days if prev_sick_days is 1" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 1,
           sick_start_date: Date.parse("6 April 2012"),
           sick_end_date: Date.parse("17 April 2012"),
-          days_of_the_week_worked: %w(1 2 3)
+          days_of_the_week_worked: %w(1 2 3),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Mon, 3 Sep 2012")
         )
+        assert_equal @calculator.prev_sick_days, 1
       end
 
       should "return waiting_days of 2" do
@@ -199,11 +221,12 @@ module SmartAnswer::Calculators
     context "waiting days if prev_sick_days is 0" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: Date.parse("6 April 2012"),
           sick_end_date: Date.parse("12 April 2012"),
-          days_of_the_week_worked: %w(1 2 3)
+          days_of_the_week_worked: %w(1 2 3),
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "return waiting_days of 3, ssp payment of 0" do
@@ -217,11 +240,12 @@ module SmartAnswer::Calculators
     context "maximum days payable for 5 days a week" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: Date.parse("6 April 2012"),
           sick_end_date: Date.parse("6 December 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5)
+          days_of_the_week_worked: %w(1 2 3 4 5),
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "have a max of 140 days payable" do
@@ -234,11 +258,12 @@ module SmartAnswer::Calculators
     context "maximum days payable for 3 days a week" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: Date.parse("6 April 2012"),
           sick_end_date: Date.parse("6 December 2012"),
-          days_of_the_week_worked: %w(2 3 4)
+          days_of_the_week_worked: %w(2 3 4),
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "have a max of 84 days payable" do
@@ -252,11 +277,14 @@ module SmartAnswer::Calculators
       setup do
         @start_date = Date.parse("5 April 2012")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 3,
           sick_start_date: @start_date,
           sick_end_date: Date.parse("10 April 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5)
+          days_of_the_week_worked: %w(1 2 3 4 5),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Wed, 5 Sep 2012")
         )
+        assert_equal @calculator.prev_sick_days, 3
       end
 
       should "use ssp rate and lel for 2011-12" do
@@ -270,11 +298,12 @@ module SmartAnswer::Calculators
       setup do
         @start_date = Date.parse("26 March 2012")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: @start_date,
           sick_end_date: Date.parse("13 April 2012"),
-          days_of_the_week_worked: %w(1 2 3 4 5)
+          days_of_the_week_worked: %w(1 2 3 4 5),
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "give correct ssp calculation" do  # 15 days with 3 waiting days, so 6 days at lower weekly rate, 6 days at higher rate
@@ -289,11 +318,14 @@ module SmartAnswer::Calculators
       setup do
         @start_date = Date.parse("4 May 2014")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 3,
           sick_start_date: @start_date,
           sick_end_date: Date.parse("3 August 2014"),
-          days_of_the_week_worked: %w(1 2 3 4 5)
+          days_of_the_week_worked: %w(1 2 3 4 5),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Mon, 3 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Wed, 5 Sep 2012")
         )
+        assert_equal @calculator.prev_sick_days, 3
       end
 
       should "use ssp rate and lel for 2014-15" do
@@ -306,11 +338,12 @@ module SmartAnswer::Calculators
       setup do
         @start_date = Date.parse("4 May 2054")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: @start_date,
           sick_end_date: @start_date + 1.month,
-          days_of_the_week_worked: %w(1 2 3 4 5)
+          days_of_the_week_worked: %w(1 2 3 4 5),
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "not break and use ssp rate for the latest know fiscal year" do
@@ -322,11 +355,14 @@ module SmartAnswer::Calculators
     context "test scenario 2 - T-F, 7 waiting days, cross tax years" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 7,
           sick_start_date: Date.parse("28 February 2012"),
           sick_end_date: Date.parse("7 April 2012"),
-          days_of_the_week_worked: %w(2 3 4 5)
+          days_of_the_week_worked: %w(2 3 4 5),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Tue, 3 Jan 2012"),
+          linked_sickness_end_date: Date.parse("Thu, 12 Jan 2012")
         )
+        assert_equal @calculator.prev_sick_days, 7
       end
 
       should "give correct ssp calculation" do # 24 days with no waiting days, so 22 days at lower weekly rate, 2 days at higher rate
@@ -340,14 +376,18 @@ module SmartAnswer::Calculators
     context "test scenario 3" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 24,
           sick_start_date: Date.parse("25 July 2012"),
           sick_end_date: Date.parse("4 September 2012"),
-          days_of_the_week_worked: %w(1 3 5)
+          days_of_the_week_worked: %w(1 3 5),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Mon, 7 May 2012"),
+          linked_sickness_end_date: Date.parse("Sun, 1 Jul 2012")
         )
+        assert_equal @calculator.prev_sick_days, 24
       end
 
       should "give correct ssp calculation" do
+        assert_equal @calculator.prev_sick_days, 24
         assert_equal @calculator.send(:days_to_pay), 18
         assert_equal @calculator.ssp_payment, 515.11
       end
@@ -357,11 +397,12 @@ module SmartAnswer::Calculators
     context "test scenario 4" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: Date.parse("23 November 2012"),
           sick_end_date: Date.parse("31 December 2012"),
-          days_of_the_week_worked: %w(0 6)
+          days_of_the_week_worked: %w(0 6),
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "give correct ssp calculation" do # 12 days with 3 waiting days, all at 2012-13 daily rate
@@ -376,11 +417,14 @@ module SmartAnswer::Calculators
     context "test scenario 5" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 99,
           sick_start_date: Date.parse("29 March 2012"),
           sick_end_date: Date.parse("6 May 2012"),
-          days_of_the_week_worked: %w(1 2 3 4)
+          days_of_the_week_worked: %w(1 2 3 4),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Wed, 28 Sep 2011"),
+          linked_sickness_end_date: Date.parse("Mon, 19 Mar 2012")
         )
+        assert_equal @calculator.prev_sick_days, 99
       end
 
       should "give correct ssp calculation" do # max of 16 days that can still be paid with no waiting days, first four days at 2011-12,  2012-13 daily rate
@@ -393,11 +437,14 @@ module SmartAnswer::Calculators
     context "test scenario 6" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 115,
           sick_start_date: Date.parse("29 March 2012"),
           sick_end_date: Date.parse("6 May 2012"),
-          days_of_the_week_worked: %w(1 2 3 4)
+          days_of_the_week_worked: %w(1 2 3 4),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Mon, 5 Sep 2011"),
+          linked_sickness_end_date: Date.parse("Wed, 21 Mar 2012")
         )
+        assert_equal @calculator.prev_sick_days, 115
       end
 
       should "give correct ssp calculation" do # there should be no more days for which employee can receive pay
@@ -409,11 +456,12 @@ module SmartAnswer::Calculators
     context "test scenario 7" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: Date.parse("28 August 2012"),
           sick_end_date: Date.parse("6 October 2012"),
-          days_of_the_week_worked: ['3']
+          days_of_the_week_worked: ['3'],
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "give correct ssp calculation" do # there should be 3 normal workdays to pay
@@ -427,11 +475,14 @@ module SmartAnswer::Calculators
     context "test scenario 6a - 1 day max to pay" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 114,
           sick_start_date: Date.parse("29 March 2012"),
           sick_end_date: Date.parse("10 April 2012"),
-          days_of_the_week_worked: %w(1 2 3 4)
+          days_of_the_week_worked: %w(1 2 3 4),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Mon, 5 Sep 2011"),
+          linked_sickness_end_date: Date.parse("Tue, 20 Mar 2012")
         )
+        assert_equal @calculator.prev_sick_days, 114
       end
 
       should "give correct ssp calculation" do # there should be max 1 day for which employee can receive pay
@@ -444,11 +495,12 @@ module SmartAnswer::Calculators
     context "2013/14 test scenario 1" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: Date.parse("26 March 2013"),
           sick_end_date: Date.parse("12 April 2013"),
-          days_of_the_week_worked: %w(2 3 4)
+          days_of_the_week_worked: %w(2 3 4),
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "give correct SSP calculation" do
@@ -461,11 +513,12 @@ module SmartAnswer::Calculators
     context "2013/14 test scenario 2" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: Date.parse("7 January 2013"),
           sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(1 2 3 4)
+          days_of_the_week_worked: %w(1 2 3 4),
+          has_linked_sickness: false
         )
+        assert_equal @calculator.prev_sick_days, 0
       end
 
       should "give correct SSP calculation" do
@@ -478,11 +531,14 @@ module SmartAnswer::Calculators
     context "2013/14 test scenario 3" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 8,
           sick_start_date: Date.parse("7 January 2013"),
           sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(3 6)
+          days_of_the_week_worked: %w(3 6),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Sat, 1 Dec 2012"),
+          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
         )
+        assert_equal @calculator.prev_sick_days, 8
       end
 
       should "give correct SSP calculation" do
@@ -495,11 +551,14 @@ module SmartAnswer::Calculators
     context "2013/14 test scenario 4" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 42,
           sick_start_date: Date.parse("7 January 2013"),
           sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4)
+          days_of_the_week_worked: %w(2 3 4),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
         )
+        assert_equal @calculator.prev_sick_days, 42
       end
 
       should "give correct SSP calculation" do
@@ -512,11 +571,14 @@ module SmartAnswer::Calculators
     context "2014/2015 scenario 5" do
       setup do
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 10,
           sick_start_date: Date.parse("10 July 2014"),
           sick_end_date: Date.parse("20 July 2014"),
-          days_of_the_week_worked: %w(1 2 3 4 5)
+          days_of_the_week_worked: %w(1 2 3 4 5),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Sun, 1 Jun 2014"),
+          linked_sickness_end_date: Date.parse("Sat, 14 Jun 2014")
         )
+        assert_equal @calculator.prev_sick_days, 10
       end
 
       should "give correct SSP calculation" do
@@ -592,11 +654,14 @@ module SmartAnswer::Calculators
     context "sick_pay_weekly_dates" do
       should "produce a list of Saturdays for the provided sick period" do
         calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 42,
           sick_start_date: Date.parse("7 January 2013"),
           sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4)
+          days_of_the_week_worked: %w(2 3 4),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
         )
+        assert_equal 42, calculator.prev_sick_days
         assert_equal [Date.parse("12 Jan 2013"),
                       Date.parse("19 Jan 2013"),
                       Date.parse("26 Jan 2013"),
@@ -621,12 +686,15 @@ module SmartAnswer::Calculators
     context "sick_pay_weekly_amounts" do
       should "return the payable weeks by taking into account the final SSP payment" do
         calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 42,
           sick_start_date: Date.parse("7 January 2013"),
           sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4)
+          days_of_the_week_worked: %w(2 3 4),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
         )
 
+        assert_equal 42, calculator.prev_sick_days
         assert_equal [[Date.parse("12 Jan 2013"), 85.85],
                       [Date.parse("19 Jan 2013"), 85.85],
                       [Date.parse("26 Jan 2013"), 85.85],
@@ -647,12 +715,15 @@ module SmartAnswer::Calculators
 
       should "have the same reduced value as the ssp_payment value" do
         calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 42,
           sick_start_date: Date.parse("7 January 2013"),
           sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4)
+          days_of_the_week_worked: %w(2 3 4),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
         )
 
+        assert_equal 42, calculator.prev_sick_days
         assert_equal calculator.ssp_payment,
                      calculator.send(:weekly_payments).map(&:second).sum
       end
@@ -661,12 +732,15 @@ module SmartAnswer::Calculators
     context "formatted_sick_pay_weekly_amounts" do
       should "produce a markdown (value) formatted string of weekly SSP dates and pay rates" do
         calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 42,
           sick_start_date: Date.parse("7 January 2013"),
           sick_end_date: Date.parse("3 May 2013"),
-          days_of_the_week_worked: %w(2 3 4)
+          days_of_the_week_worked: %w(2 3 4),
+          has_linked_sickness: true,
+          linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
+          linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
         )
 
+        assert_equal 42, calculator.prev_sick_days
         assert_equal ["12 January 2013|£85.85",
                       "19 January 2013|£85.85",
                       "26 January 2013|£85.85",
@@ -725,12 +799,13 @@ module SmartAnswer::Calculators
     context "when the last working day of the sick period is a Sunday" do
       should "calculate the sick period including the Sunday" do
         calc = StatutorySickPayCalculator.new(
-          prev_sick_days: 0,
           sick_start_date: Date.parse("24 October 2013"),
           sick_end_date: Date.parse("27 October 2013"),
-          days_of_the_week_worked: %w(0 1 3 4 5 6)
+          days_of_the_week_worked: %w(0 1 3 4 5 6),
+          has_linked_sickness: false
         )
 
+        assert_equal 0, calc.prev_sick_days
         assert_equal 14.45, calc.ssp_payment
       end
     end

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -306,7 +306,7 @@ module SmartAnswer::Calculators
       setup do
         @start_date = Date.parse("4 May 2054")
         @calculator = StatutorySickPayCalculator.new(
-          prev_sick_days: 3,
+          prev_sick_days: 0,
           sick_start_date: @start_date,
           sick_end_date: @start_date + 1.month,
           days_of_the_week_worked: %w(1 2 3 4 5)

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -100,7 +100,7 @@ module SmartAnswer
         end
 
         should "return correct ssp_payment" do
-          assert_equal 85.85, @calculator.ssp_payment
+          assert_equal Money.new(85.85), @calculator.ssp_payment
         end
       end
 

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -730,37 +730,6 @@ module SmartAnswer
         end
       end
 
-      context "formatted_sick_pay_weekly_amounts" do
-        should "produce a markdown (value) formatted string of weekly SSP dates and pay rates" do
-          calculator = StatutorySickPayCalculator.new(
-            sick_start_date: Date.parse("7 January 2013"),
-            sick_end_date: Date.parse("3 May 2013"),
-            days_of_the_week_worked: %w(2 3 4),
-            has_linked_sickness: true,
-            linked_sickness_start_date: Date.parse("Fri, 21 Sep 2012"),
-            linked_sickness_end_date: Date.parse("Fri, 28 Dec 2012")
-          )
-
-          assert_equal 42, calculator.prev_sick_days
-          assert_equal ["12 January 2013|£85.85",
-                        "19 January 2013|£85.85",
-                        "26 January 2013|£85.85",
-                        " 2 February 2013|£85.85",
-                        " 9 February 2013|£85.85",
-                        "16 February 2013|£85.85",
-                        "23 February 2013|£85.85",
-                        " 2 March 2013|£85.85",
-                        " 9 March 2013|£85.85",
-                        "16 March 2013|£85.85",
-                        "23 March 2013|£85.85",
-                        "30 March 2013|£85.85",
-                        " 6 April 2013|£85.85",
-                        "13 April 2013|£86.70",
-                        "20 April 2013|£86.70"].join("\n"),
-                       calculator.formatted_sick_pay_weekly_amounts
-        end
-      end
-
       context "average weekly earnings for new employees who fell sick before first payday" do
         should "give the average weekly earnings" do
           pay = SmartAnswer::Money.new(100)

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -18,7 +18,7 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-07',
               initial_state: {
-                sick_start_date: Date.parse('2015-04-01'),
+                calculator: stub('calculator', sick_start_date: Date.parse('2015-04-01')),
                 sick_start_date_for_awe: Date.parse('2015-01-01'),
                 usual_work_days: '1,2,3,4,5'
               })
@@ -33,7 +33,7 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-31',
               initial_state: {
-                sick_start_date: Date.parse('2015-02-01'),
+                calculator: stub('calculator', sick_start_date: Date.parse('2015-02-01')),
                 sick_start_date_for_awe: Date.parse('2015-01-01'),
                 usual_work_days: '1,2,3,4,5'
               })
@@ -48,7 +48,7 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-03',
               initial_state: {
-                sick_start_date: Date.parse('2015-02-01'),
+                calculator: stub('calculator', sick_start_date: Date.parse('2015-02-01')),
                 sick_start_date_for_awe: Date.parse('2015-01-01'),
                 usual_work_days: '1,2,3,4,5'
               })

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -8,7 +8,40 @@ module SmartAnswer
     include FlowUnitTestHelper
 
     setup do
+      @calculator = Calculators::StatutorySickPayCalculator.new
       @flow = CalculateStatutorySickPayFlow.build
+    end
+
+    context 'when answering last_sick_day? question' do
+      context 'and sickness period is valid period of incapacity for work' do
+        setup do
+          @calculator.stubs(valid_period_of_incapacity_for_work?: true)
+          setup_states_for_question(:last_sick_day?,
+            responding_with: '2015-01-03',
+            initial_state: { calculator: @calculator }
+          )
+        end
+
+        should 'go to has_linked_sickness? question' do
+          assert_equal :has_linked_sickness?, @new_state.current_node
+          assert_node_exists :has_linked_sickness?
+        end
+      end
+
+      context 'and sickness period is not valid period of incapacity for work' do
+        setup do
+          @calculator.stubs(valid_period_of_incapacity_for_work?: false)
+          setup_states_for_question(:last_sick_day?,
+            responding_with: '2015-01-03',
+            initial_state: { calculator: @calculator }
+          )
+        end
+
+        should 'go to must_be_sick_for_4_days outcome' do
+          assert_equal :must_be_sick_for_4_days, @new_state.current_node
+          assert_node_exists :must_be_sick_for_4_days
+        end
+      end
     end
 
     context 'when answering linked_sickness_end_date? question' do

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -19,9 +19,11 @@ module SmartAnswer
               responding_with: '2015-01-07',
               initial_state: {
                 calculator: stub('calculator',
-                  sick_start_date: Date.parse('2015-04-01'),
                   linked_sickness_start_date: Date.parse('2015-01-01'),
-                  days_of_the_week_worked: %w(1 2 3 4 5)
+                  days_of_the_week_worked: %w(1 2 3 4 5),
+                  within_eight_weeks_of_current_sickness_period?: false,
+                  at_least_1_day_before_first_sick_day?: true,
+                  valid_period_of_incapacity_for_work?: true
                 ),
               })
           end
@@ -29,16 +31,18 @@ module SmartAnswer
         end
       end
 
-      context 'and linked sickness end 1 day before sickness starts' do
+      context 'and linked sickness ends the day before sickness starts' do
         should 'raise an exception' do
           exception = assert_raise(SmartAnswer::InvalidResponse) do
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-31',
               initial_state: {
                 calculator: stub('calculator',
-                  sick_start_date: Date.parse('2015-02-01'),
                   linked_sickness_start_date: Date.parse('2015-01-01'),
-                  days_of_the_week_worked: %w(1 2 3 4 5)
+                  days_of_the_week_worked: %w(1 2 3 4 5),
+                  within_eight_weeks_of_current_sickness_period?: true,
+                  at_least_1_day_before_first_sick_day?: false,
+                  valid_period_of_incapacity_for_work?: true
                 ),
               })
           end
@@ -55,7 +59,10 @@ module SmartAnswer
                 calculator: stub('calculator',
                   sick_start_date: Date.parse('2015-02-01'),
                   linked_sickness_start_date: Date.parse('2015-01-01'),
-                  days_of_the_week_worked: %w(1 2 3 4 5)
+                  days_of_the_week_worked: %w(1 2 3 4 5),
+                  within_eight_weeks_of_current_sickness_period?: true,
+                  at_least_1_day_before_first_sick_day?: true,
+                  valid_period_of_incapacity_for_work?: false
                 ),
               })
           end

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -16,10 +16,10 @@ module SmartAnswer
       context 'and sickness period is valid period of incapacity for work' do
         setup do
           @calculator.stubs(valid_period_of_incapacity_for_work?: true)
-          setup_states_for_question(:last_sick_day?,
+          setup_states_for_question(:last_sick_day?, {
             responding_with: '2015-01-03',
             initial_state: { calculator: @calculator }
-          )
+          })
         end
 
         should 'go to has_linked_sickness? question' do
@@ -31,10 +31,10 @@ module SmartAnswer
       context 'and sickness period is not valid period of incapacity for work' do
         setup do
           @calculator.stubs(valid_period_of_incapacity_for_work?: false)
-          setup_states_for_question(:last_sick_day?,
+          setup_states_for_question(:last_sick_day?, {
             responding_with: '2015-01-03',
             initial_state: { calculator: @calculator }
-          )
+          })
         end
 
         should 'go to must_be_sick_for_4_days outcome' do
@@ -51,13 +51,13 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-07',
               initial_state: {
-                calculator: stub('calculator',
+                calculator: stub('calculator', {
                   linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: false,
                   at_least_1_day_before_first_sick_day?: true,
                   valid_linked_period_of_incapacity_for_work?: true
-                ),
+                }),
               })
           end
           assert_equal 'must_be_within_eight_weeks', exception.message
@@ -70,13 +70,13 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-31',
               initial_state: {
-                calculator: stub('calculator',
+                calculator: stub('calculator', {
                   linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: true,
                   at_least_1_day_before_first_sick_day?: false,
                   valid_linked_period_of_incapacity_for_work?: true
-                ),
+                }),
               })
           end
           assert_equal 'must_be_at_least_1_day_before_first_sick_day', exception.message
@@ -89,14 +89,14 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-03',
               initial_state: {
-                calculator: stub('calculator',
+                calculator: stub('calculator', {
                   sick_start_date: Date.parse('2015-02-01'),
                   linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: true,
                   at_least_1_day_before_first_sick_day?: true,
                   valid_linked_period_of_incapacity_for_work?: false
-                ),
+                }),
               })
           end
           assert_equal 'must_be_valid_period_of_incapacity_for_work', exception.message

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -18,9 +18,11 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-07',
               initial_state: {
-                calculator: stub('calculator', sick_start_date: Date.parse('2015-04-01')),
+                calculator: stub('calculator',
+                  sick_start_date: Date.parse('2015-04-01'),
+                  days_of_the_week_worked: %w(1 2 3 4 5)
+                ),
                 sick_start_date_for_awe: Date.parse('2015-01-01'),
-                usual_work_days: '1,2,3,4,5'
               })
           end
           assert_equal 'must_be_within_eight_weeks', exception.message
@@ -33,9 +35,11 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-31',
               initial_state: {
-                calculator: stub('calculator', sick_start_date: Date.parse('2015-02-01')),
+                calculator: stub('calculator',
+                  sick_start_date: Date.parse('2015-02-01'),
+                  days_of_the_week_worked: %w(1 2 3 4 5)
+                ),
                 sick_start_date_for_awe: Date.parse('2015-01-01'),
-                usual_work_days: '1,2,3,4,5'
               })
           end
           assert_equal 'must_be_at_least_1_day_before_first_sick_day', exception.message
@@ -48,9 +52,11 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-03',
               initial_state: {
-                calculator: stub('calculator', sick_start_date: Date.parse('2015-02-01')),
-                sick_start_date_for_awe: Date.parse('2015-01-01'),
-                usual_work_days: '1,2,3,4,5'
+                calculator: stub('calculator',
+                  sick_start_date: Date.parse('2015-02-01'),
+                  days_of_the_week_worked: %w(1 2 3 4 5)
+                ),
+                sick_start_date_for_awe: Date.parse('2015-01-01')
               })
           end
           assert_equal 'must_be_valid_period_of_incapacity_for_work', exception.message

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -23,7 +23,7 @@ module SmartAnswer
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: false,
                   at_least_1_day_before_first_sick_day?: true,
-                  valid_period_of_incapacity_for_work?: true
+                  valid_linked_period_of_incapacity_for_work?: true
                 ),
               })
           end
@@ -42,7 +42,7 @@ module SmartAnswer
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: true,
                   at_least_1_day_before_first_sick_day?: false,
-                  valid_period_of_incapacity_for_work?: true
+                  valid_linked_period_of_incapacity_for_work?: true
                 ),
               })
           end
@@ -62,7 +62,7 @@ module SmartAnswer
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: true,
                   at_least_1_day_before_first_sick_day?: true,
-                  valid_period_of_incapacity_for_work?: false
+                  valid_linked_period_of_incapacity_for_work?: false
                 ),
               })
           end

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -20,9 +20,9 @@ module SmartAnswer
               initial_state: {
                 calculator: stub('calculator',
                   sick_start_date: Date.parse('2015-04-01'),
+                  linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5)
                 ),
-                sick_start_date_for_awe: Date.parse('2015-01-01'),
               })
           end
           assert_equal 'must_be_within_eight_weeks', exception.message
@@ -37,9 +37,9 @@ module SmartAnswer
               initial_state: {
                 calculator: stub('calculator',
                   sick_start_date: Date.parse('2015-02-01'),
+                  linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5)
                 ),
-                sick_start_date_for_awe: Date.parse('2015-01-01'),
               })
           end
           assert_equal 'must_be_at_least_1_day_before_first_sick_day', exception.message
@@ -54,9 +54,9 @@ module SmartAnswer
               initial_state: {
                 calculator: stub('calculator',
                   sick_start_date: Date.parse('2015-02-01'),
+                  linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5)
                 ),
-                sick_start_date_for_awe: Date.parse('2015-01-01')
               })
           end
           assert_equal 'must_be_valid_period_of_incapacity_for_work', exception.message


### PR DESCRIPTION
This PR is an attempt at separating the concerns for `calculate-statutory-sick-pay` as we did in `part-year-profit-tax-credits` as follows:

* The calculator is converted into an `ActiveModel::Model` and instantiated in a `next_node_calculation` in the first question.
* Next node logic is all converted to use `next_node` with a block
* Responses are set as attributes on the calculator in these `next_node` blocks
* All policy & validation logic is moved out of the flow into the calculator
* Only routing logic remains in the flow
* Presentation logic is moved out of the calculator and the flow and into the outcome templates

All these changes should not affect the outwardly observable behaviour as attested by the fact that no changes to the regression test artefacts were needed.

This PR leaves the calculator in a less than ideal state, but given the number of changes, I thought it would be good to get this merged as soon as possible.
