### PR TITLE
Remove unused code dealing with unaccepted_responses

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -86,11 +86,6 @@ private
         responses: @presenter.current_state.responses,
         protocol:  (request.ssl? || Rails.env.production?) ? 'https' : 'http',
       }
-      if @presenter.current_state.unaccepted_responses
-        @presenter.current_state.unaccepted_responses.each_with_index do |unaccepted_response, index|
-          redirect_params["previous_response_#{index+1}".to_sym] = unaccepted_response.to_s
-        end
-      end
       redirect_to redirect_params
     end
   end


### PR DESCRIPTION
These unaccepted_responses were only used by Smartdown flows, and we removed the
final parts of Smartdown in d2138cdd38d6c72a19155242903ff6fb5c138573.

There's definitely more code that can be removed now that Smartdown has gone but
I figured I'd do this as I recently came across it.