### PR TITLE
Use next_node blocks in overseas-passports

### DIFF
--- a/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
+++ b/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
@@ -1,11 +1,5 @@
 module SmartAnswer::Calculators
   class PassportAndEmbassyDataQuery
-    def ips_application?
-      SmartAnswer::Predicate::VariableMatches.new(:application_type,
-        %w{ips_application_1 ips_application_2 ips_application_3},
-        "IPS")
-    end
-
     include ActionView::Helpers::NumberHelper
 
     ALT_EMBASSIES = {

--- a/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
+++ b/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
@@ -1,9 +1,5 @@
 module SmartAnswer::Calculators
   class PassportAndEmbassyDataQuery
-    def ineligible_country?
-      SmartAnswer::Predicate::RespondedWith.new(%w{iran libya syria yemen})
-    end
-
     def apply_in_neighbouring_countries?
       SmartAnswer::Predicate::RespondedWith.new(
         %w(british-indian-ocean-territory north-korea south-georgia-and-south-sandwich-islands)

--- a/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
+++ b/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
@@ -1,11 +1,5 @@
 module SmartAnswer::Calculators
   class PassportAndEmbassyDataQuery
-    def apply_in_neighbouring_countries?
-      SmartAnswer::Predicate::RespondedWith.new(
-        %w(british-indian-ocean-territory north-korea south-georgia-and-south-sandwich-islands)
-      )
-    end
-
     def ips_application?
       SmartAnswer::Predicate::VariableMatches.new(:application_type,
         %w{ips_application_1 ips_application_2 ips_application_3},

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -141,17 +141,13 @@ module SmartAnswer
 
         save_input_as :child_or_adult
 
-        next_node_calculation :ips_application do
-          is_ips_application == true
-        end
-
         permitted_next_nodes = [
           :country_of_birth?,
           :ips_application_result_online,
           :ips_application_result
         ]
         next_node(permitted: permitted_next_nodes) do
-          if ips_application?
+          if is_ips_application
             if %w(applying renewing_old).include?(application_action)
               :country_of_birth?
             elsif ips_result_type == :ips_application_result_online
@@ -179,16 +175,12 @@ module SmartAnswer
           supporting_documents.split("_")[3]
         end
 
-        next_node_calculation :ips_application do
-          is_ips_application == true
-        end
-
         permitted_next_nodes = [
           :ips_application_result_online,
           :ips_application_result
         ]
         next_node(permitted: permitted_next_nodes) do
-          if ips_application?
+          if is_ips_application
             if ips_result_type == :ips_application_result_online
               :ips_application_result_online
             else

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -91,7 +91,7 @@ module SmartAnswer
           passport_data['type']
         end
         calculate :is_ips_application do
-          data_query.ips_application?.call(self, nil)
+          %w{ips_application_1 ips_application_2 ips_application_3}.include?(application_type)
         end
         calculate :ips_number do
           application_type.split("_")[2] if is_ips_application
@@ -141,7 +141,11 @@ module SmartAnswer
 
         save_input_as :child_or_adult
 
-        on_condition(data_query.ips_application?) do
+        define_predicate :ips_application? do
+          is_ips_application == true
+        end
+
+        on_condition(ips_application?) do
           next_node_if(:country_of_birth?, variable_matches(:application_action, %w(applying renewing_old)))
           next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
           next_node(:ips_application_result)
@@ -164,7 +168,11 @@ module SmartAnswer
           supporting_documents.split("_")[3]
         end
 
-        on_condition(data_query.ips_application?) do
+        define_predicate :ips_application? do
+          is_ips_application == true
+        end
+
+        on_condition(ips_application?) do
           next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
           next_node(:ips_application_result)
         end

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -23,7 +23,11 @@ module SmartAnswer
           loc
         end
 
-        next_node_if(:cannot_apply, data_query.ineligible_country?)
+        define_predicate :ineligible_country? do |response|
+          %w{iran libya syria yemen}.include?(response)
+        end
+
+        next_node_if(:cannot_apply, ineligible_country?)
         next_node_if(:which_opt?, responded_with('the-occupied-palestinian-territories'))
         next_node_if(:apply_in_neighbouring_country, data_query.apply_in_neighbouring_countries?)
         next_node(:renewing_replacing_applying?)

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -27,9 +27,13 @@ module SmartAnswer
           %w{iran libya syria yemen}.include?(response)
         end
 
+        define_predicate :apply_in_neighbouring_countries? do |response|
+          %w(british-indian-ocean-territory north-korea south-georgia-and-south-sandwich-islands).include?(response)
+        end
+
         next_node_if(:cannot_apply, ineligible_country?)
         next_node_if(:which_opt?, responded_with('the-occupied-palestinian-territories'))
-        next_node_if(:apply_in_neighbouring_country, data_query.apply_in_neighbouring_countries?)
+        next_node_if(:apply_in_neighbouring_country, apply_in_neighbouring_countries?)
         next_node(:renewing_replacing_applying?)
       end
 

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -179,13 +179,22 @@ module SmartAnswer
           supporting_documents.split("_")[3]
         end
 
-        define_predicate :ips_application? do
+        next_node_calculation :ips_application do
           is_ips_application == true
         end
 
-        on_condition(ips_application?) do
-          next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
-          next_node(:ips_application_result)
+        permitted_next_nodes = [
+          :ips_application_result_online,
+          :ips_application_result
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if ips_application?
+            if ips_result_type == :ips_application_result_online
+              :ips_application_result_online
+            else
+              :ips_application_result
+            end
+          end
         end
       end
 

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -141,14 +141,25 @@ module SmartAnswer
 
         save_input_as :child_or_adult
 
-        define_predicate :ips_application? do
+        next_node_calculation :ips_application do
           is_ips_application == true
         end
 
-        on_condition(ips_application?) do
-          next_node_if(:country_of_birth?, variable_matches(:application_action, %w(applying renewing_old)))
-          next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
-          next_node(:ips_application_result)
+        permitted_next_nodes = [
+          :country_of_birth?,
+          :ips_application_result_online,
+          :ips_application_result
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if ips_application?
+            if %w(applying renewing_old).include?(application_action)
+              :country_of_birth?
+            elsif ips_result_type == :ips_application_result_online
+              :ips_application_result_online
+            else
+              :ips_application_result
+            end
+          end
         end
       end
 

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/overseas-passports.rb: 613a11e9f07f779dab45b83adb392ff6
+lib/smart_answer_flows/overseas-passports.rb: 2fce49d9be2940d02e6b757c0d90a668
 lib/smart_answer_flows/locales/en/overseas-passports.yml: e3c7aa9bb85ea0e1f34a562f9954e5cd
 test/data/overseas-passports-questions-and-responses.yml: 4c6749fcf0a37deb135fc8c94fa52bc7
 test/data/overseas-passports-responses-and-expected-results.yml: aca0c7e72dfbf84606a47cb7d6d7f758
@@ -38,7 +38,7 @@ lib/smart_answer_flows/overseas-passports/outcomes/making_your_application/_send
 lib/smart_answer_flows/overseas-passports/overseas_passports.govspeak.erb: 7106e947778ef18645fe2b2443253ba1
 lib/smart_answer/overseas_passports_helper.rb: 07df4cd921e62464c2dc9534b4d8cdf8
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063
-lib/smart_answer/calculators/passport_and_embassy_data_query.rb: ae758ea00c73edec5e7b3e6432a645b1
+lib/smart_answer/calculators/passport_and_embassy_data_query.rb: b23c4733dacdb05308a843f3a89afac7
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029
 test/fixtures/worldwide/france_organisations.json: dec146460928937fba71409755f01ba3
 test/fixtures/worldwide/st-martin_organisations.json: 120d85d68f897fc762724a41a4c650a6


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
