### PR TITLE
Spike: Fail fast on missing methods in SmartAnswer::State object

### DIFF
--- a/lib/smart_answer/state.rb
+++ b/lib/smart_answer/state.rb
@@ -6,6 +6,14 @@ module SmartAnswer
       super(current_node: start_node, path: [], responses: [], response: nil, error: nil)
     end
 
+    def method_missing(method_name, *args)
+      if method_name =~ /=$/
+        super
+      else
+        raise NoMethodError.new("undefined method '#{method_name}' for #{self.class}")
+      end
+    end
+
     def transition_to(new_node, input, &blk)
       dup.tap { |new_state|
         new_state.path << self.current_node

--- a/lib/smart_answer/state.rb
+++ b/lib/smart_answer/state.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 module SmartAnswer
   class State < OpenStruct
     def initialize(start_node)
-      super(current_node: start_node, path: [], responses: [])
+      super(current_node: start_node, path: [], responses: [], response: nil, error: nil)
     end
 
     def transition_to(new_node, input, &blk)

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -17,6 +17,10 @@ module SmartAnswer
 
         save_input_as :starch_glucose_weight
 
+        calculate :milk_protein_weight do
+          nil
+        end
+
         permitted_next_nodes = [
           :how_much_sucrose_1?,
           :how_much_sucrose_2?,

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
@@ -12,6 +12,10 @@ module SmartAnswer
         option "same-number-of-days"
         option "different-number-of-days"
 
+        calculate :days_worked_per_week do
+          nil
+        end
+
         permitted_next_nodes = [
           :how_many_days_per_week?,
           :what_date_does_holiday_start?

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -10,6 +10,16 @@ module SmartAnswer
         option :yes
         option :no
 
+        calculate :is_before_april_changes do
+          nil
+        end
+        calculate :gross_pension_contributions do
+          nil
+        end
+        calculate :net_pension_contributions do
+          nil
+        end
+
         calculate :age_related_allowance_chooser do
           rates = SmartAnswer::Calculators::RatesQuery.new('married_couples_allowance').rates
           AgeRelatedAllowanceChooser.new(

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -16,6 +16,16 @@ module SmartAnswer
         option :amount
         option :bus_pass
 
+        calculate :pays_reduced_ni_rate do
+          nil
+        end
+        calculate :lived_or_worked_abroad do
+          nil
+        end
+        calculate :years_of_work_entered do
+          nil
+        end
+
         calculate :weekly_state_pension_rate do
           SmartAnswer::Calculators::RatesQuery.new('state_pension').rates.weekly_rate
         end

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -16,6 +16,16 @@ module SmartAnswer
         option "shift-worker"
         save_input_as :calculation_basis
 
+        calculate :leaving_date do
+          nil
+        end
+        calculate :leave_year_start_date do
+          nil
+        end
+        calculate :start_date do
+          nil
+        end
+
         permitted_next_nodes = [
           :calculation_period?,
           :casual_or_irregular_hours?,

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -24,6 +24,10 @@ module SmartAnswer
       country_select :what_passport_do_you_have?, additional_countries: additional_countries, exclude_countries: exclude_countries do
         save_input_as :passport_country
 
+        calculate :purpose_of_visit_answer do
+          nil
+        end
+
         permitted_next_nodes = [
           :israeli_document_type?,
           :outcome_no_visa_needed,

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -11,6 +11,10 @@ module SmartAnswer
         option :yes
         option :no
 
+        calculate :cost_change_4_weeks do
+          nil
+        end
+
         permitted_next_nodes = [
           :have_costs_changed?,
           :how_often_use_childcare?

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -14,6 +14,22 @@ module SmartAnswer
         option :all_help
         save_input_as :which_help
 
+        calculate :flat_type do
+          nil
+        end
+        calculate :may_qualify_for_affordable_warmth_obligation do
+          nil
+        end
+        calculate :incomesupp_jobseekers_1 do
+          nil
+        end
+        calculate :incomesupp_jobseekers_2 do
+          nil
+        end
+        calculate :age_variant do
+          nil
+        end
+
         calculate :bills_help do |response|
           %w(help_with_fuel_bill).include?(response) ? :bills_help : nil
         end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -24,6 +24,10 @@ module SmartAnswer
       country_select :country_of_ceremony?, exclude_countries: exclude_countries do
         save_input_as :ceremony_country
 
+        calculate :pay_by_cash_or_credit_card_no_cheque do
+          nil
+        end
+
         calculate :location do
           loc = WorldLocation.find(ceremony_country)
           raise InvalidResponse unless loc

--- a/lib/smart_answer_flows/maternity-paternity-calculator.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator.rb
@@ -13,6 +13,47 @@ module SmartAnswer
         option :paternity
         option :adoption
 
+        # For all? Caught by regression tests
+        calculate :leave_spp_claim_link do
+          nil
+        end
+        calculate :notice_of_leave_deadline do
+          nil
+        end
+
+        # For maternity-calculator
+        calculate :monthly_pay_method do
+          nil
+        end
+        calculate :smp_calculation_method do
+          nil
+        end
+        calculate :pay_pattern do
+          nil
+        end
+
+        # For adoption-calculator
+        calculate :sap_calculation_method do
+          nil
+        end
+        calculate :above_lower_earning_limit do
+          nil
+        end
+
+        # For parternity-calculator
+        calculate :paternity_adoption do
+          nil
+        end
+        calculate :spp_calculation_method do
+          nil
+        end
+        calculate :has_contract do
+          nil
+        end
+        calculate :paternity_employment_start do
+          nil
+        end
+
         permitted_next_nodes = [
           :baby_due_date_maternity?,
           :leave_or_pay_for_adoption?,

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -23,6 +23,16 @@ module SmartAnswer
           loc
         end
 
+        calculate :birth_location do
+          nil
+        end
+        calculate :embassy_address do
+          nil
+        end
+        calculate :send_colour_photocopy_bulletpoint do
+          nil
+        end
+
         next_node_calculation :ineligible_country do |response|
           %w{iran libya syria yemen}.include?(response)
         end

--- a/lib/smart_answer_flows/shared_logic/minimum_wage.rb
+++ b/lib/smart_answer_flows/shared_logic/minimum_wage.rb
@@ -3,6 +3,10 @@ multiple_choice :what_would_you_like_to_check? do
   option "current_payment"
   option "past_payment"
 
+  calculate :accommodation_charge do
+    nil
+  end
+
   permitted_next_nodes = [
     :are_you_an_apprentice?,
     :past_payment_date?

--- a/lib/smart_answer_flows/simplified-expenses-checker.rb
+++ b/lib/smart_answer_flows/simplified-expenses-checker.rb
@@ -21,6 +21,37 @@ module SmartAnswer
           !is_new_business
         end
 
+        calculate :capital_allowance_claimed do
+          nil
+        end
+        calculate :simple_vehicle_costs do
+          nil
+        end
+        calculate :simple_motorcycle_costs do
+          nil
+        end
+        calculate :vehicle_costs do
+          nil
+        end
+        calculate :green_vehicle_write_off do
+          nil
+        end
+        calculate :dirty_vehicle_write_off do
+          nil
+        end
+        calculate :simple_business_costs do
+          nil
+        end
+        calculate :is_over_limit do
+          nil
+        end
+        calculate :home_costs do
+          nil
+        end
+        calculate :simple_home_costs do
+          nil
+        end
+
         next_node :type_of_expense?
       end
 

--- a/test/data/additional-commodity-code-files.yml
+++ b/test/data/additional-commodity-code-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/additional-commodity-code.rb: 3408534464ca7ba7317bb02f73497f2e
+lib/smart_answer_flows/additional-commodity-code.rb: 4b0f5a4e9134dc04651da374c15d851b
 lib/smart_answer_flows/locales/en/additional-commodity-code.yml: 417fd0ca1fc4cfb449d334e8c03c0622
 test/data/additional-commodity-code-questions-and-responses.yml: 24243e9af7ed9c7aca5ed6adbfa0c9b7
 test/data/additional-commodity-code-responses-and-expected-results.yml: 3f80e1b92ec7731959b0f8033a4f43c8

--- a/test/data/am-i-getting-minimum-wage-files.yml
+++ b/test/data/am-i-getting-minimum-wage-files.yml
@@ -12,6 +12,6 @@ lib/smart_answer_flows/am-i-getting-minimum-wage/outcomes/past_payment_below.gov
 lib/smart_answer_flows/am-i-getting-minimum-wage/outcomes/under_school_leaving_age.govspeak.erb: 44bf68757d1ef90249d19f5d88ad4bc2
 lib/smart_answer_flows/am-i-getting-minimum-wage/outcomes/under_school_leaving_age_past.govspeak.erb: 2182c103915b753894722760c9a56cf3
 lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb: 0d2f7c4d01e3c928701e7d649663707e
-lib/smart_answer_flows/shared_logic/minimum_wage.rb: 434cb45cdd375590238a8097d34ce987
+lib/smart_answer_flows/shared_logic/minimum_wage.rb: caec9c44ba15d41e0ddf494aafca3da0
 lib/smart_answer/calculators/minimum_wage_calculator.rb: cab354bb2fc0f660d6c6aef70b9fabc5
 lib/data/minimum_wage_data.yml: 3feed11191d68237289203a2c659ecf9

--- a/test/data/calculate-agricultural-holiday-entitlement-files.yml
+++ b/test/data/calculate-agricultural-holiday-entitlement-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb: b7cb688006879c6397a1339e4476de0b
+lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb: 86995ba75ad783a09dc0c62143916faf
 lib/smart_answer_flows/locales/en/calculate-agricultural-holiday-entitlement.yml: 8da4167ac5c1508d876550211cc8ad41
 test/data/calculate-agricultural-holiday-entitlement-questions-and-responses.yml: 4b91e0ca75c21fa5d93abc1944bfa8d4
 test/data/calculate-agricultural-holiday-entitlement-responses-and-expected-results.yml: bbf1e135027230dbab56e67c87206edd

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-married-couples-allowance.rb: c2f1a8f4a451489c549957a181cccbfa
+lib/smart_answer_flows/calculate-married-couples-allowance.rb: d36fd014e01678f20d770c7d57975c8e
 lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml: d3000af873a9c53b2f62719b3d72e91d
 test/data/calculate-married-couples-allowance-questions-and-responses.yml: 3cdcbf373de49fa6383b7dcb1967eb80
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3a6d219be3fceda5e5e091520ab5227f

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-state-pension.rb: 3d27d6261467b5f95c67a4e91e7f8e41
+lib/smart_answer_flows/calculate-state-pension.rb: 93cafbc5dc94b047c10124fff0b52447
 lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 59b2577b5bd537db695a998d82264e7e
 test/data/calculate-state-pension-questions-and-responses.yml: 7637baad3326dc8e39f445684e615da3
 test/data/calculate-state-pension-responses-and-expected-results.yml: 61e8ccba31841f6616cf8b26f3da6ff9

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-your-holiday-entitlement.rb: 3ee6873bb6303774f82525656b7c07c5
+lib/smart_answer_flows/calculate-your-holiday-entitlement.rb: ea477752bd44c3f1cfa092a7f0d8d891
 lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml: 0e0af2f45c9cca757b9d5fcb6fd3cc6d
 test/data/calculate-your-holiday-entitlement-questions-and-responses.yml: a5d687911e6173e74f2b70af6a5ff7bd
 test/data/calculate-your-holiday-entitlement-responses-and-expected-results.yml: 5ff2290223d8188d45a84cde9883acf6

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/check-uk-visa.rb: e57516742f6d8cc125fb83408b54d332
+lib/smart_answer_flows/check-uk-visa.rb: adcd0577188817050122f18e061b64ce
 lib/smart_answer_flows/locales/en/check-uk-visa.yml: a8c595b226b52e2c9b5d7b32723fbdb2
 test/data/check-uk-visa-questions-and-responses.yml: 9994bc5cd128249d65befb525a894b45
 test/data/check-uk-visa-responses-and-expected-results.yml: 603a0b14f2a49a20d01cc4b959fb90b7

--- a/test/data/childcare-costs-for-tax-credits-files.yml
+++ b/test/data/childcare-costs-for-tax-credits-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: 437769752a81fc7d7705183cbe9570aa
+lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: fc8ca281e8befc0a28a51e0cab019a1b
 lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml: 1f9c5671b17aa97b6ea2472634481997
 test/data/childcare-costs-for-tax-credits-questions-and-responses.yml: 626012bfcc3d89170729eb2140fc1aa4
 test/data/childcare-costs-for-tax-credits-responses-and-expected-results.yml: 37aa1c49681770c252fd9ca273d1ba07

--- a/test/data/energy-grants-calculator-files.yml
+++ b/test/data/energy-grants-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/energy-grants-calculator.rb: 55d04a36d23b1777fd5ff0d1c7777fa4
+lib/smart_answer_flows/energy-grants-calculator.rb: 7649654aef35c26316210e41a3600fee
 lib/smart_answer_flows/locales/en/energy-grants-calculator.yml: dd640cd1e93bbdac129b3863552cb554
 test/data/energy-grants-calculator-questions-and-responses.yml: e725aa49320518369f4fdc601cd217b2
 test/data/energy-grants-calculator-responses-and-expected-results.yml: 8b1d6c6350f162a2d4efbc65362b5ae8

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: d1dac943231ed0f02de009288240522f
+lib/smart_answer_flows/marriage-abroad.rb: a84ed159c49f88b5053b6f9b1f8bf37a
 lib/smart_answer_flows/locales/en/marriage-abroad.yml: e8225cc9c281e31a884d41cb7c4482bf
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: 839cce0363e0c51ba4ab9fb1722fc59f

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/maternity-paternity-calculator.rb: 2b1b87d4628d5fb9abcc7710b6d35c1c
+lib/smart_answer_flows/maternity-paternity-calculator.rb: e1b88fd0f876c4696f3c873964476217
 lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: d4769ae027f958647d004bd1685d4ce1
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 1bf0c803cd8e8a091417b0e1e19d2bd2
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: a59f6821dd5b949861ab6261840e58e4

--- a/test/data/minimum-wage-calculator-employers-files.yml
+++ b/test/data/minimum-wage-calculator-employers-files.yml
@@ -12,6 +12,6 @@ lib/smart_answer_flows/minimum-wage-calculator-employers/outcomes/past_payment_b
 lib/smart_answer_flows/minimum-wage-calculator-employers/outcomes/under_school_leaving_age.govspeak.erb: 13de5d10bbbb015df597f78c66da1b67
 lib/smart_answer_flows/minimum-wage-calculator-employers/outcomes/under_school_leaving_age_past.govspeak.erb: 9c56f76e04984f07627efbc1f42b2b63
 lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb: 0d2f7c4d01e3c928701e7d649663707e
-lib/smart_answer_flows/shared_logic/minimum_wage.rb: 434cb45cdd375590238a8097d34ce987
+lib/smart_answer_flows/shared_logic/minimum_wage.rb: caec9c44ba15d41e0ddf494aafca3da0
 lib/smart_answer/calculators/minimum_wage_calculator.rb: cab354bb2fc0f660d6c6aef70b9fabc5
 lib/data/minimum_wage_data.yml: 3feed11191d68237289203a2c659ecf9

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/overseas-passports.rb: 2fce49d9be2940d02e6b757c0d90a668
+lib/smart_answer_flows/overseas-passports.rb: 6b4ae2e611660154032a4709fe077be0
 lib/smart_answer_flows/locales/en/overseas-passports.yml: e3c7aa9bb85ea0e1f34a562f9954e5cd
 test/data/overseas-passports-questions-and-responses.yml: 4c6749fcf0a37deb135fc8c94fa52bc7
 test/data/overseas-passports-responses-and-expected-results.yml: aca0c7e72dfbf84606a47cb7d6d7f758

--- a/test/data/simplified-expenses-checker-files.yml
+++ b/test/data/simplified-expenses-checker-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/simplified-expenses-checker.rb: 08c2a1ffb98fac5e69533e1bdd0b373b
+lib/smart_answer_flows/simplified-expenses-checker.rb: 2c7afb8a135da70c651677f2d3cb80a2
 lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml: ae340f0f515377411d8710468afa4962
 test/data/simplified-expenses-checker-questions-and-responses.yml: de8747e3d768e4095264a214cdb58d0b
 test/data/simplified-expenses-checker-responses-and-expected-results.yml: 239e9c4e6fda064faecff3403fc3033d

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -272,6 +272,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert q.color_red?.is_a?(SmartAnswer::Predicate::Callable)
 
     state = SmartAnswer::State.new(q.name)
+    state.color = nil
     assert q.response_red?.call(state, "red")
     refute q.response_red?.call(state, "green")
 

--- a/test/unit/smart_answer_flows/am_i_getting_minimum_wage_flow_test.rb
+++ b/test/unit/smart_answer_flows/am_i_getting_minimum_wage_flow_test.rb
@@ -191,6 +191,7 @@ module SmartAnswer
           setup do
             @question = @flow.node(accommodation_usage_question_name)
             @state = SmartAnswer::State.new(@question)
+            @state.accommodation_charge = nil
             @calculator = stub('calculator',
               accommodation_adjustment: nil,
               minimum_wage_or_above?: nil,

--- a/test/unit/state_test.rb
+++ b/test/unit/state_test.rb
@@ -18,5 +18,18 @@ module SmartAnswer
         assert_equal [:state1], old_state.path
       end
     end
+
+    should "raise a NoMethodError exception when trying to read a value that hasn't previously been set" do
+      state = State.new(:start_node)
+      assert_raise(NoMethodError) do
+        state.undefined_attribute
+      end
+    end
+
+    should "return the value of an attribute that's previously been set" do
+      state = State.new(:start_node)
+      state.new_attribute = 'new-attribute-value'
+      assert_equal 'new-attribute-value', state.new_attribute
+    end
   end
 end


### PR DESCRIPTION
__This has been superseded by PR #2099__

This is for discussion only and currently contains 4 failing tests that I've not investigated fully.

The `SmartAnswer::State` object is an `OpenStruct` which means that it responds to undefined methods with `nil`. This can lead to hard to find bugs in `next_node` blocks (particularly larger ones, e.g. [this one in pay-leave-for-parents](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/pay-leave-for-parents.rb#L385)) as a simple typo will mean that the program runs but doesn't return the desired result.

The main change in this PR overrides `SmartAnswer::State#method_missing` so that it raises a `NoMethodError` exception if we try to call a method that's not previously been defined.

```
# Behaviour before this change
>> state = SmartAnswer::State.new(start_node = nil)
>> state.foo
=> nil
>> state.foo = 'bar'
>> state.foo
=> 'bar'

# Behaviour after this change
>> state = SmartAnswer::State.new(start_node = nil)
>> state.foo
=> NoMethodError: undefined method 'foo' for SmartAnswer::State
>> state.foo = 'bar'
>> state.foo
=> 'bar'
```

I've also updated all Smart Answer flows where the code was relying on the old behaviour of the `State` object, by explicitly setting the variables to nil that are used later in the flow.

I'm not 100% convinced about this but would like to hear what other people think.
