### PR TITLE
Require explicit question titles

### DIFF
--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -18,7 +18,7 @@ class QuestionPresenter < NodePresenter
   end
 
   def title
-    translate!('title') || @node.name.to_s.humanize
+    translate!('title', rescue_exception: false)
   end
 
   def error

--- a/lib/smart_answer_flows/locales/en/help-if-you-are-arrested-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/help-if-you-are-arrested-abroad.yml
@@ -1,3 +1,5 @@
 en-GB:
   flow:
     help-if-you-are-arrested-abroad:
+      which_country?:
+        title: Which country?

--- a/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
@@ -66,6 +66,7 @@ en-GB:
         title: When is your employee’s next pay day on or after %{pay_start_date}?
       ## QM9
       when_in_the_month_is_the_employee_paid?:
+        title: When in the month is the employee paid?
         hint: If the pay date is the 29th, 30th or 31st choose 'Last working day of the month'.
         options:
           "first_day_of_the_month": First day of the month

--- a/lib/smart_answer_flows/locales/en/register-a-death.yml
+++ b/lib/smart_answer_flows/locales/en/register-a-death.yml
@@ -26,3 +26,5 @@ en-GB:
           same_country: "In the country where the death happened"
           another_country: "In another country"
           in_the_uk: "In the UK"
+      which_country_are_you_in_now?:
+        title: Which country are you in now?

--- a/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml
+++ b/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml
@@ -2,6 +2,7 @@ en-GB:
   flow:
     report-a-lost-or-stolen-passport:
       where_was_the_passport_lost_or_stolen?:
+        title: Where was the passport lost or stolen?
         options:
           in_the_uk: "In the UK"
           abroad: "Abroad"

--- a/test/data/help-if-you-are-arrested-abroad-files.yml
+++ b/test/data/help-if-you-are-arrested-abroad-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: cc7831e704176ed0a3545425c6e08f2e
-lib/smart_answer_flows/locales/en/help-if-you-are-arrested-abroad.yml: 8dbb908db1cb70bdf47c166d127a3703
+lib/smart_answer_flows/locales/en/help-if-you-are-arrested-abroad.yml: 9351aca046d506eecac320da9389e4a9
 test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml: c007b0dd259d1c09ccc2dd3163fa1e56
 test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml: 3e3aeca8a1af7c147b8f62af365f650d
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/help_if_you_are_arrested_abroad.govspeak.erb: cb923645274b287ba93af8c7118d7f88

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/maternity-paternity-calculator.rb: 2b1b87d4628d5fb9abcc7710b6d35c1c
-lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: cf2abf0778bb38ad017deba521830090
+lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: d4769ae027f958647d004bd1685d4ce1
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 1bf0c803cd8e8a091417b0e1e19d2bd2
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: a59f6821dd5b949861ab6261840e58e4
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: 912bfe601939f1391d5e54b11c146744

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/register-a-death.rb: 941863d243f6fef17176d45b24a2460a
-lib/smart_answer_flows/locales/en/register-a-death.yml: ffcc2f13d596b97a34affddec1e50d60
+lib/smart_answer_flows/locales/en/register-a-death.yml: 04de0b215b1ab22ce4a52a82a185f6f1
 test/data/register-a-death-questions-and-responses.yml: bae21b0a8be1bbaa2dd6febd505382d6
 test/data/register-a-death-responses-and-expected-results.yml: a69c595900ab2d85208c0ac92f186ae8
 lib/smart_answer_flows/register-a-death/outcomes/_footnote_oru_variants.govspeak.erb: 30e012cdde5aa7f4de5856a5db47a54c

--- a/test/data/report-a-lost-or-stolen-passport-files.yml
+++ b/test/data/report-a-lost-or-stolen-passport-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb: a61c798522ee7d07347e9178846b9b0e
-lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml: b3b8d31d025f554b1589e8c33fdd8c15
+lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml: 94978f81dd4c41afec1ff9a772a0d536
 test/data/report-a-lost-or-stolen-passport-questions-and-responses.yml: 307a097c6429f895390b742dda8c9bc8
 test/data/report-a-lost-or-stolen-passport-responses-and-expected-results.yml: 7a5cb860803f433fa2416b7fcaf12f12
 lib/smart_answer_flows/report-a-lost-or-stolen-passport/outcomes/complete_LS01_form.govspeak.erb: 558860c7ddf7b7612af2bf793767f7dc

--- a/test/fixtures/smart_answer_flows/locales/en/checkbox-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/checkbox-sample.yml
@@ -1,8 +1,8 @@
 en-GB:
   flow:
     checkbox-sample:
-
       what_do_you_want_on_your_pizza?:
+        title: "What do you want on your pizza?"
         options:
           ham: "Ham"
           peppers: "Peppers"

--- a/test/fixtures/smart_answer_flows/locales/en/country-and-date-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/country-and-date-sample.yml
@@ -1,4 +1,9 @@
 en-GB:
   flow:
     country-and-date-sample:
-
+      which_country_do_you_live_in?:
+        title: "Which country do you live in?"
+      what_date_did_you_move_there?:
+        title: "What date did you move there?"
+      which_country_were_you_born_in?:
+        title: "Which country were you born in?"

--- a/test/fixtures/smart_answer_flows/locales/en/country-legacy-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/country-legacy-sample.yml
@@ -1,3 +1,7 @@
 en-GB:
   flow:
     country-legacy-sample:
+      which_country_do_you_live_in?:
+        title: "Which country do you live in?"
+      which_country_were_you_born_in?:
+        title: "Which country were you born in?"

--- a/test/fixtures/smart_answer_flows/locales/en/data-partial-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/data-partial-sample.yml
@@ -2,6 +2,7 @@ en-GB:
   flow:
     data-partial-sample:
       what_are_you_testing?:
+        title: "What are you testing?"
         options:
           data_partial_with_scalar: 'Data partial with scalar'
           data_partial_with_array: 'Data partial with array'

--- a/test/fixtures/smart_answer_flows/locales/en/money-and-salary-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/money-and-salary-sample.yml
@@ -1,6 +1,8 @@
 en-GB:
   flow:
     money-and-salary-sample:
-
+      how_much_do_you_earn?:
+        title: "How much do you earn?"
       what_size_bonus_do_you_want?:
+        title: "What size bonus do you want?"
         error_message: "%{error}"

--- a/test/fixtures/smart_answer_flows/locales/en/postcode-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/postcode-sample.yml
@@ -1,0 +1,5 @@
+en-GB:
+  flow:
+    postcode-sample:
+      user_input?:
+        title: "User input?"

--- a/test/fixtures/smart_answer_flows/locales/en/precalculation-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/precalculation-sample.yml
@@ -2,6 +2,8 @@ en-GB:
   flow:
     precalculation-sample:
       how_much_wood_would_a_woodchuck_chuck_if_a_woodchuck_could_chuck_wood?:
+        title: "How much wood would a woodchuck chuck if a woodchuck could chuck wood?"
         label: "Amount:"
       how_many_woodchucks_do_you_have?:
+        title: "How many woodchucks do you have?"
         label: "Amount:"

--- a/test/fixtures/smart_answer_flows/locales/en/smart-answers-controller-cheese.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/smart-answers-controller-cheese.yml
@@ -2,5 +2,8 @@ en-GB:
   flow:
     smart-answers-controller-cheese:
       what?:
+        title: "What?"
         options:
           "cheese": "Cheese"
+      when?:
+        title: "When?"

--- a/test/fixtures/smart_answer_flows/locales/en/smart-answers-controller-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/smart-answers-controller-sample.yml
@@ -2,10 +2,18 @@ en-GB:
   flow:
     smart-answers-controller-sample:
       do_you_like_chocolate?:
+        title: "Do you like chocolate?"
         options:
           "yes": "Yes"
           "no": "No"
       do_you_like_jam?:
+        title: "Do you like jam?"
         options:
           "yes": "Yes"
           "no": "No"
+      when?:
+        title: "When?"
+      how_much?:
+        title: "How much?"
+      how_many_green_bottles?:
+        title: "How many green bottles?"

--- a/test/fixtures/smart_answer_flows/locales/en/value-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/value-sample.yml
@@ -2,6 +2,7 @@ en-GB:
   flow:
     value-sample:
       user_input?:
+        title: "User input?"
         label: "User input:"
       outcome_with_template:
         title: "Outcome with template"

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -55,6 +55,11 @@ class SmartAnswersControllerTest < ActionController::TestCase
     end
     load_path = fixture_file('smart_answer_flows')
     SmartAnswer::FlowRegistry.stubs(:instance).returns(stub("Flow registry", find: @flow, load_path: load_path))
+    use_additional_translation_file(fixture_file('smart_answer_flows/locales/en/smart-answers-controller-sample.yml'))
+  end
+
+  def teardown
+    reset_translation_files
   end
 
   def submit_response(response = nil, other_params = {})


### PR DESCRIPTION
Supersedes #2072.

Fail fast if no explicit question title is specified.

We think it's dangerous/surprising that the code was falling back to a human-friendly version of the question key for the question title.

I implemented the change to fail fast first and then ran all the regression tests to identify the small number of questions which did not have an explicitly defined title. I then moved the change to fail fast to be the last commit.

There are no expected changes in behaviour - hence no change to the regression test artefacts.
