### PR TITLE
Reduce dependencies on I18nRenderer

### DIFF
--- a/app/presenters/money_question_presenter.rb
+++ b/app/presenters/money_question_presenter.rb
@@ -1,5 +1,8 @@
 class MoneyQuestionPresenter < QuestionPresenter
+  include ActionView::Helpers::NumberHelper
+
   def response_label(value)
-    value_for_interpolation(SmartAnswer::Money.new(value))
+    money = SmartAnswer::Money.new(value)
+    number_to_currency(money, precision: ((money.to_f == money.to_f.round) ? 0 : 2))
   end
 end

--- a/app/presenters/money_question_presenter.rb
+++ b/app/presenters/money_question_presenter.rb
@@ -1,8 +1,7 @@
 class MoneyQuestionPresenter < QuestionPresenter
-  include ActionView::Helpers::NumberHelper
+  include SmartAnswer::FormattingHelper
 
   def response_label(value)
-    money = SmartAnswer::Money.new(value)
-    number_to_currency(money, precision: ((money.to_f == money.to_f.round) ? 0 : 2))
+    format_money(SmartAnswer::Money.new(value))
   end
 end

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -6,7 +6,7 @@ class OutcomePresenter < NodePresenter
       template_name: @node.name.to_s,
       locals: @state.to_hash,
       helpers: [
-        SmartAnswer::OutcomeHelper,
+        SmartAnswer::FormattingHelper,
         SmartAnswer::OverseasPassportsHelper,
         SmartAnswer::MarriageAbroadHelper
       ]

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -4,7 +4,6 @@ class QuestionPresenter < NodePresenter
     :translate!,
     :translate_and_render,
     :translate_option,
-    :value_for_interpolation,
     :number_with_delimiter
   ] => :@renderer
 

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -3,8 +3,7 @@ class QuestionPresenter < NodePresenter
   delegate [
     :translate!,
     :translate_and_render,
-    :translate_option,
-    :number_with_delimiter
+    :translate_option
   ] => :@renderer
 
   def initialize(i18n_prefix, node, state = nil, options = {})

--- a/app/presenters/salary_question_presenter.rb
+++ b/app/presenters/salary_question_presenter.rb
@@ -1,8 +1,7 @@
 class SalaryQuestionPresenter < QuestionPresenter
-  include ActionView::Helpers::NumberHelper
+  include SmartAnswer::FormattingHelper
 
   def response_label(value)
-    salary = SmartAnswer::Salary.new(value)
-    number_to_currency(salary.amount, precision: 0) + " per " + salary.period
+    format_salary(SmartAnswer::Salary.new(value))
   end
 end

--- a/app/presenters/salary_question_presenter.rb
+++ b/app/presenters/salary_question_presenter.rb
@@ -1,5 +1,8 @@
 class SalaryQuestionPresenter < QuestionPresenter
+  include ActionView::Helpers::NumberHelper
+
   def response_label(value)
-    value_for_interpolation(SmartAnswer::Salary.new(value))
+    salary = SmartAnswer::Salary.new(value)
+    number_to_currency(salary.amount, precision: 0) + " per " + salary.period
   end
 end

--- a/app/presenters/value_question_presenter.rb
+++ b/app/presenters/value_question_presenter.rb
@@ -1,4 +1,6 @@
 class ValueQuestionPresenter < QuestionPresenter
+  include ActionView::Helpers::NumberHelper
+
   def response_label(value)
     number_with_delimiter(value)
   end

--- a/lib/smart_answer/formatting_helper.rb
+++ b/lib/smart_answer/formatting_helper.rb
@@ -1,5 +1,7 @@
 module SmartAnswer
   module FormattingHelper
+    include ActionView::Helpers::NumberHelper
+
     def format_money(amount)
       number_to_currency(amount, precision: ((amount.to_f == amount.to_f.round) ? 0 : 2))
     end

--- a/lib/smart_answer/formatting_helper.rb
+++ b/lib/smart_answer/formatting_helper.rb
@@ -1,5 +1,5 @@
 module SmartAnswer
-  module OutcomeHelper
+  module FormattingHelper
     def format_money(amount)
       number_to_currency(amount, precision: ((amount.to_f == amount.to_f.round) ? 0 : 2))
     end

--- a/lib/smart_answer/formatting_helper.rb
+++ b/lib/smart_answer/formatting_helper.rb
@@ -6,6 +6,10 @@ module SmartAnswer
       number_to_currency(amount, precision: ((amount.to_f == amount.to_f.round) ? 0 : 2))
     end
 
+    def format_salary(salary)
+      number_to_currency(salary.amount, precision: 0) + " per " + salary.period
+    end
+
     def format_date(date)
       return nil unless date
       date.strftime('%e %B %Y')

--- a/lib/smart_answer/i18n_renderer.rb
+++ b/lib/smart_answer/i18n_renderer.rb
@@ -25,6 +25,8 @@ module SmartAnswer
       nil
     end
 
+    private
+
     def value_for_interpolation(value, nested = false)
       case value
       when Date then I18n.localize(value, format: :long)
@@ -49,8 +51,6 @@ module SmartAnswer
       else value
       end
     end
-
-    private
 
     def i18n_node_prefix
       "#{@i18n_prefix}.#{@node.name}"

--- a/test/unit/formatting_helper_test.rb
+++ b/test/unit/formatting_helper_test.rb
@@ -2,7 +2,6 @@ require_relative '../test_helper'
 
 module SmartAnswer
   class FormattingHelperTest < ActiveSupport::TestCase
-    include ActionView::Helpers::NumberHelper
     include FormattingHelper
 
     test "#format_money doesn't add pence for amounts in whole pounds" do

--- a/test/unit/formatting_helper_test.rb
+++ b/test/unit/formatting_helper_test.rb
@@ -19,5 +19,9 @@ module SmartAnswer
     test '#format_date returns nil when the value is nil' do
       assert_equal nil, format_date(nil)
     end
+
+    test '#format_salary returns whole number of pounds plus the period in which it was earned' do
+      assert_equal '£123 per week', format_salary(Salary.new('123.45', 'week'))
+    end
   end
 end

--- a/test/unit/formatting_helper_test.rb
+++ b/test/unit/formatting_helper_test.rb
@@ -1,9 +1,9 @@
 require_relative '../test_helper'
 
 module SmartAnswer
-  class OutcomeHelperTest < ActiveSupport::TestCase
+  class FormattingHelperTest < ActiveSupport::TestCase
     include ActionView::Helpers::NumberHelper
-    include OutcomeHelper
+    include FormattingHelper
 
     test "#format_money doesn't add pence for amounts in whole pounds" do
       assert_equal '£1', format_money('1.00')


### PR DESCRIPTION
I want to be able to change the `SmartAnswer::QuestionPresenter` to use the `SmartAnswer::ErbRenderer` instead of the `SmartAnswer::I18nRenderer` and so anything I can do to reduce the dependencies on the `I18nRenderer` will make this easier.