### PR TITLE
Make QuestionPresenterTest more realistic

### DIFF
--- a/lib/smart_answer/i18n_renderer.rb
+++ b/lib/smart_answer/i18n_renderer.rb
@@ -38,7 +38,7 @@ module SmartAnswer
             begin
               I18n.translate!("#{@i18n_prefix}.phrases.#{phrase_key}", state_for_interpolation(true))
             rescue => e
-              Rails.logger.warn("[Missing phrase] The phrase being rendered is not present: #{e.key}\tResponses: #{@state.responses.join('/')}") if @node.outcome?
+              Rails.logger.warn("[Missing phrase] The phrase being rendered is not present: #{e.key}\tResponses: #{@state.responses.join('/')}")
               phrase_key
             end
           end

--- a/test/fixtures/smart_answer_flows/locales/en/question-presenter-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/question-presenter-sample.yml
@@ -26,8 +26,8 @@ en-GB:
       question_with_post_body:
         post_body: post body for question
       question_with_no_post_body:
-      outcome_with_interpolated_phrase_list:
-        title: "All done"
+      question_with_interpolated_phrase_list:
+        title: "Question with interpolated phrase list"
         body: |
           Here are the phrases:
 

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -89,10 +89,10 @@ module SmartAnswer
     end
 
     test "Interpolated phrase lists are localized and interpreted as govspeak" do
-      outcome = Outcome.new(nil, :outcome_with_interpolated_phrase_list)
-      state = State.new(outcome.name)
+      question = Question::Base.new(nil, :question_with_interpolated_phrase_list)
+      state = State.new(question.name)
       state.phrases = PhraseList.new(:one, :two, :three)
-      presenter = QuestionPresenter.new("flow.test", outcome, state)
+      presenter = QuestionPresenter.new("flow.test", question, state)
 
       assert_match Regexp.new("<p>Here are the phrases:</p>
 
@@ -105,10 +105,10 @@ module SmartAnswer
     end
 
     test "Phrase lists notify developers and fallback gracefully when no translation can be found" do
-      outcome = Outcome.new(nil, :outcome_with_interpolated_phrase_list)
-      state = State.new(outcome.name)
+      question = Question::Base.new(nil, :question_with_interpolated_phrase_list)
+      state = State.new(question.name)
       state.phrases = PhraseList.new(:four, :one, :two, :three)
-      presenter = QuestionPresenter.new("flow.test", outcome, state)
+      presenter = QuestionPresenter.new("flow.test", question, state)
 
       Rails.logger.expects(:warn).with("[Missing phrase] The phrase being rendered is not present: flow.test.phrases.four\tResponses: ").once
 


### PR DESCRIPTION
Since phrase lists are now *only* interpolated for question nodes, these tests
didn't make much sense. Especially as they were using the `QuestionPresenter`
with an `Outcome` node.

Also I'm not sure why the log statement was only being executed for outcome
nodes. If anything the opposite is now true and in any case the code in
`SmartAnswer::I18nRenderer#value_for_interpolation` will only ever be executed
for question nodes.