### PR TITLE
Remove flow-level options from i18n fixtures

### DIFF
--- a/test/fixtures/smart_answer_flows/locales/en/bridge-of-death.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/bridge-of-death.yml
@@ -1,10 +1,6 @@
 en-GB:
   flow:
     bridge-of-death:
-      options:
-        "no": "No"
-        "yes": "Yes"
-
       what_is_your_name?:
         title: "What...is your name?"
         label: "Name:"

--- a/test/fixtures/smart_answer_flows/locales/en/graph.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/graph.yml
@@ -1,10 +1,6 @@
 en-GB:
   flow:
     graph:
-      options:
-        "no": "No"
-        "yes": "Yes"
-
       q1?:
         title: "What is the answer to q1?"
 

--- a/test/fixtures/smart_answer_flows/locales/en/question-presenter-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/question-presenter-sample.yml
@@ -1,8 +1,6 @@
 en-GB:
   flow:
     test:
-      options:
-        maybe: Mebbe
       phrases:
         one: This is the first one
         two: This is **the** second


### PR DESCRIPTION
Since #2005, flow-level options are no longer used as a fallback, so we can
safely remove these.