### PR TITLE
Use next_node blocks in marriage-abroad

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -203,6 +203,33 @@ module SmartAnswer
           ceremony_country == 'italy'
         }
 
+        on_condition(responded_with('same_sex')) do
+          define_predicate(:ss_marriage_germany_partner_local?) {
+            (ceremony_country == "germany") && (partner_nationality == "partner_local")
+          }
+          define_predicate(:ss_marriage_countries?) {
+            data_query.ss_marriage_countries?(ceremony_country)
+          }
+          define_predicate(:ss_marriage_countries_when_couple_british?) {
+            data_query.ss_marriage_countries_when_couple_british?(ceremony_country) && %w(partner_british).include?(partner_nationality)
+          }
+          define_predicate(:ss_marriage_and_partnership?) {
+            data_query.ss_marriage_and_partnership?(ceremony_country)
+          }
+
+          define_predicate(:ss_marriage_not_possible?) {
+            data_query.ss_marriage_not_possible?(ceremony_country, partner_nationality)
+          }
+
+          define_predicate(:ss_unknown_no_embassies) {
+            data_query.ss_unknown_no_embassies?(ceremony_country)
+          }
+
+          define_predicate(:ss_affirmation) {
+            %w(belgium norway).include?(ceremony_country)
+          }
+        end
+
         next_node_if(:outcome_brazil_not_living_in_the_uk, ceremony_in_brazil_not_resident_in_the_uk)
         next_node_if(:outcome_marriage_via_local_authorities, variable_matches(:ceremony_country, "netherlands"))
         next_node_if(:outcome_portugal, variable_matches(:ceremony_country, "portugal"))
@@ -240,31 +267,6 @@ module SmartAnswer
         end
 
         on_condition(responded_with('same_sex')) do
-          define_predicate(:ss_marriage_germany_partner_local?) {
-            (ceremony_country == "germany") && (partner_nationality == "partner_local")
-          }
-          define_predicate(:ss_marriage_countries?) {
-            data_query.ss_marriage_countries?(ceremony_country)
-          }
-          define_predicate(:ss_marriage_countries_when_couple_british?) {
-            data_query.ss_marriage_countries_when_couple_british?(ceremony_country) && %w(partner_british).include?(partner_nationality)
-          }
-          define_predicate(:ss_marriage_and_partnership?) {
-            data_query.ss_marriage_and_partnership?(ceremony_country)
-          }
-
-          define_predicate(:ss_marriage_not_possible?) {
-            data_query.ss_marriage_not_possible?(ceremony_country, partner_nationality)
-          }
-
-          define_predicate(:ss_unknown_no_embassies) {
-            data_query.ss_unknown_no_embassies?(ceremony_country)
-          }
-
-          define_predicate(:ss_affirmation) {
-            %w(belgium norway).include?(ceremony_country)
-          }
-
           next_node_if(:outcome_ss_affirmation, ss_affirmation)
 
           next_node_if(:outcome_os_no_cni, ss_unknown_no_embassies)

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -88,10 +88,23 @@ module SmartAnswer
           end
         end
 
-        next_node_if(:partner_opposite_or_same_sex?, responded_with('ireland'))
-        next_node_if(:marriage_or_pacs?, responded_with(%w(france monaco new-caledonia wallis-and-futuna)))
-        next_node_if(:outcome_os_france_or_fot, ->(response) { data_query.french_overseas_territories?(response)})
-        next_node(:legal_residency?)
+        permitted_next_nodes = [
+          :legal_residency?,
+          :marriage_or_pacs?,
+          :outcome_os_france_or_fot,
+          :partner_opposite_or_same_sex?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if response == 'ireland'
+            :partner_opposite_or_same_sex?
+          elsif %w(france monaco new-caledonia wallis-and-futuna).include?(response)
+            :marriage_or_pacs?
+          elsif data_query.french_overseas_territories?(response)
+            :outcome_os_france_or_fot
+          else
+            :legal_residency?
+          end
+        end
       end
 
       # Q2

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -203,32 +203,30 @@ module SmartAnswer
           ceremony_country == 'italy'
         }
 
-        on_condition(responded_with('same_sex')) do
-          define_predicate(:ss_marriage_germany_partner_local?) {
-            (ceremony_country == "germany") && (partner_nationality == "partner_local")
-          }
-          define_predicate(:ss_marriage_countries?) {
-            data_query.ss_marriage_countries?(ceremony_country)
-          }
-          define_predicate(:ss_marriage_countries_when_couple_british?) {
-            data_query.ss_marriage_countries_when_couple_british?(ceremony_country) && %w(partner_british).include?(partner_nationality)
-          }
-          define_predicate(:ss_marriage_and_partnership?) {
-            data_query.ss_marriage_and_partnership?(ceremony_country)
-          }
+        define_predicate(:ss_marriage_germany_partner_local?) { |response|
+          response == 'same_sex' && (ceremony_country == "germany") && (partner_nationality == "partner_local")
+        }
+        define_predicate(:ss_marriage_countries?) { |response|
+          response == 'same_sex' && data_query.ss_marriage_countries?(ceremony_country)
+        }
+        define_predicate(:ss_marriage_countries_when_couple_british?) { |response|
+          response == 'same_sex' && data_query.ss_marriage_countries_when_couple_british?(ceremony_country) && %w(partner_british).include?(partner_nationality)
+        }
+        define_predicate(:ss_marriage_and_partnership?) { |response|
+          response == 'same_sex' && data_query.ss_marriage_and_partnership?(ceremony_country)
+        }
 
-          define_predicate(:ss_marriage_not_possible?) {
-            data_query.ss_marriage_not_possible?(ceremony_country, partner_nationality)
-          }
+        define_predicate(:ss_marriage_not_possible?) { |response|
+          response == 'same_sex' && data_query.ss_marriage_not_possible?(ceremony_country, partner_nationality)
+        }
 
-          define_predicate(:ss_unknown_no_embassies) {
-            data_query.ss_unknown_no_embassies?(ceremony_country)
-          }
+        define_predicate(:ss_unknown_no_embassies) { |response|
+          response == 'same_sex' && data_query.ss_unknown_no_embassies?(ceremony_country)
+        }
 
-          define_predicate(:ss_affirmation) {
-            %w(belgium norway).include?(ceremony_country)
-          }
-        end
+        define_predicate(:ss_affirmation) { |response|
+          response == 'same_sex' && %w(belgium norway).include?(ceremony_country)
+        }
 
         next_node_if(:outcome_brazil_not_living_in_the_uk, ceremony_in_brazil_not_resident_in_the_uk)
         next_node_if(:outcome_marriage_via_local_authorities, variable_matches(:ceremony_country, "netherlands"))

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -167,135 +167,180 @@ module SmartAnswer
 
         save_input_as :sex_of_your_partner
 
-        define_predicate(:ceremony_in_laos_partners_not_local) {
+        next_node_calculation(:ceremony_in_laos_partners_not_local) {
           (ceremony_country == "laos") && (partner_nationality != "partner_local")
         }
 
-        define_predicate(:ceremony_in_finland_uk_resident) {
+        next_node_calculation(:ceremony_in_finland_uk_resident) {
           (ceremony_country == "finland") && (resident_of == "uk")
         }
 
-        define_predicate(:ceremony_in_norway_uk_resident) {
+        next_node_calculation(:ceremony_in_norway_uk_resident) {
           (ceremony_country == "norway") && (resident_of == "uk")
         }
 
-        define_predicate(:ceremony_in_brazil_not_resident_in_the_uk) {
+        next_node_calculation(:ceremony_in_brazil_not_resident_in_the_uk) {
           (ceremony_country == 'brazil') && (resident_of != 'uk')
         }
 
-        define_predicate(:os_marriage_with_local_in_japan) {
+        next_node_calculation(:os_marriage_with_local_in_japan) {
           ceremony_country == 'japan' && resident_of == 'ceremony_country' && partner_nationality == 'partner_local'
         }
 
-        define_predicate(:consular_cni_residing_in_third_country) {
+        next_node_calculation(:consular_cni_residing_in_third_country) {
           resident_of == 'third_country' && (data_query.os_consular_cni_countries?(ceremony_country) || %w(kosovo).include?(ceremony_country) || data_query.os_consular_cni_in_nearby_country?(ceremony_country))
         }
 
-        define_predicate(:marriage_in_norway_third_country) {
+        next_node_calculation(:marriage_in_norway_third_country) {
           ceremony_country == 'norway' && resident_of == 'third_country'
         }
 
-        define_predicate(:marriage_via_local_authorities) {
+        next_node_calculation(:marriage_via_local_authorities) {
           data_query.os_marriage_via_local_authorities?(ceremony_country)
         }
 
-        define_predicate(:marriage_in_italy) {
+        next_node_calculation(:marriage_in_italy) {
           ceremony_country == 'italy'
         }
 
-        define_predicate(:ss_marriage_germany_partner_local?) { |response|
+        next_node_calculation(:ss_marriage_germany_partner_local) { |response|
           response == 'same_sex' && (ceremony_country == "germany") && (partner_nationality == "partner_local")
         }
-        define_predicate(:ss_marriage_countries?) { |response|
+        next_node_calculation(:ss_marriage_countries) { |response|
           response == 'same_sex' && data_query.ss_marriage_countries?(ceremony_country)
         }
-        define_predicate(:ss_marriage_countries_when_couple_british?) { |response|
+        next_node_calculation(:ss_marriage_countries_when_couple_british) { |response|
           response == 'same_sex' && data_query.ss_marriage_countries_when_couple_british?(ceremony_country) && %w(partner_british).include?(partner_nationality)
         }
-        define_predicate(:ss_marriage_and_partnership?) { |response|
+        next_node_calculation(:ss_marriage_and_partnership) { |response|
           response == 'same_sex' && data_query.ss_marriage_and_partnership?(ceremony_country)
         }
 
-        define_predicate(:ss_marriage_not_possible?) { |response|
+        next_node_calculation(:ss_marriage_not_possible) { |response|
           response == 'same_sex' && data_query.ss_marriage_not_possible?(ceremony_country, partner_nationality)
         }
 
-        define_predicate(:ss_unknown_no_embassies) { |response|
+        next_node_calculation(:ss_unknown_no_embassies) { |response|
           response == 'same_sex' && data_query.ss_unknown_no_embassies?(ceremony_country)
         }
 
-        define_predicate(:ss_affirmation) { |response|
+        next_node_calculation(:ss_affirmation) { |response|
           response == 'same_sex' && %w(belgium norway).include?(ceremony_country)
         }
 
-        next_node_if(:outcome_brazil_not_living_in_the_uk, ceremony_in_brazil_not_resident_in_the_uk)
-        next_node_if(:outcome_marriage_via_local_authorities, variable_matches(:ceremony_country, "netherlands"))
-        next_node_if(:outcome_portugal, variable_matches(:ceremony_country, "portugal"))
-        next_node_if(:outcome_ireland, variable_matches(:ceremony_country, "ireland"))
-        next_node_if(:outcome_switzerland, variable_matches(:ceremony_country, "switzerland"))
-        next_node_if(:outcome_spain, variable_matches(:ceremony_country, "spain"))
-
-        on_condition(responded_with('opposite_sex')) do
-          next_node_if(:outcome_os_hong_kong, variable_matches(:ceremony_country, 'hong-kong'))
-          next_node_if(:outcome_consular_cni_os_residing_in_third_country, consular_cni_residing_in_third_country)
-          next_node_if(:outcome_consular_cni_os_residing_in_third_country, marriage_in_norway_third_country)
-          next_node_if(:outcome_os_italy, marriage_in_italy)
-          next_node_if(:outcome_os_local_japan, os_marriage_with_local_in_japan)
-          next_node_if(:outcome_os_cambodia, variable_matches(:ceremony_country, 'cambodia'))
-          next_node_if(:outcome_os_colombia, variable_matches(:ceremony_country, "colombia"))
-          next_node_if(:outcome_os_kosovo, variable_matches(:ceremony_country, "kosovo"))
-          next_node_if(:outcome_os_indonesia, variable_matches(:ceremony_country, "indonesia"))
-          next_node_if(:outcome_os_marriage_impossible_no_laos_locals, ceremony_in_laos_partners_not_local)
-          next_node_if(:outcome_os_laos, variable_matches(:ceremony_country, "laos"))
-          next_node_if(:outcome_os_consular_cni, -> {
-            data_query.os_consular_cni_countries?(ceremony_country) || (resident_of == 'uk' && data_query.os_no_marriage_related_consular_services?(ceremony_country)) || data_query.os_consular_cni_in_nearby_country?(ceremony_country)
-          })
-          next_node_if(:outcome_os_consular_cni, ceremony_in_finland_uk_resident)
-          next_node_if(:outcome_os_consular_cni, ceremony_in_norway_uk_resident)
-          next_node_if(:outcome_os_affirmation, -> { data_query.os_affirmation_countries?(ceremony_country) })
-          next_node_if(:outcome_os_commonwealth, -> { data_query.commonwealth_country?(ceremony_country) || ceremony_country == 'zimbabwe' })
-          next_node_if(:outcome_os_bot, -> { data_query.british_overseas_territories?(ceremony_country) })
-          next_node_if(:outcome_os_no_cni, -> {
-            data_query.os_no_consular_cni_countries?(ceremony_country) || (resident_of != 'uk' && data_query.os_no_marriage_related_consular_services?(ceremony_country))
-          })
-          next_node_if(:outcome_marriage_via_local_authorities, marriage_via_local_authorities)
-          next_node_if(:outcome_os_other_countries, -> {
-            data_query.os_other_countries?(ceremony_country)
-          })
-        end
-
-        on_condition(responded_with('same_sex')) do
-          next_node_if(:outcome_ss_affirmation, ss_affirmation)
-
-          next_node_if(:outcome_os_no_cni, ss_unknown_no_embassies)
-
-          next_node_if(:outcome_ss_marriage_malta, -> {ceremony_country == "malta"})
-
-          next_node_if(:outcome_ss_marriage_not_possible, ss_marriage_not_possible?)
-
-          next_node_if(:outcome_cp_or_equivalent, ss_marriage_germany_partner_local?)
-
-          next_node_if(:outcome_ss_marriage,
-            ss_marriage_countries? | ss_marriage_countries_when_couple_british? | ss_marriage_and_partnership?
-          )
-
-          next_node_if(:outcome_cp_or_equivalent, -> {
-            data_query.cp_equivalent_countries?(ceremony_country)
-          })
-
-          next_node_if(:outcome_cp_no_cni, -> {
-            data_query.cp_cni_not_required_countries?(ceremony_country)
-          })
-
-          next_node_if(:outcome_cp_commonwealth_countries, -> {
-            %w(canada south-africa).include?(ceremony_country)
-          })
-
-          next_node_if(:outcome_cp_consular, -> {
-            data_query.cp_consular_countries?(ceremony_country)
-          })
-
-          next_node(:outcome_cp_all_other_countries)
+        permitted_next_nodes = [
+          :outcome_brazil_not_living_in_the_uk,
+          :outcome_consular_cni_os_residing_in_third_country,
+          :outcome_cp_all_other_countries,
+          :outcome_cp_commonwealth_countries,
+          :outcome_cp_consular,
+          :outcome_cp_no_cni,
+          :outcome_cp_or_equivalent,
+          :outcome_ireland,
+          :outcome_marriage_via_local_authorities,
+          :outcome_os_affirmation,
+          :outcome_os_bot,
+          :outcome_os_cambodia,
+          :outcome_os_colombia,
+          :outcome_os_commonwealth,
+          :outcome_os_consular_cni,
+          :outcome_os_hong_kong,
+          :outcome_os_indonesia,
+          :outcome_os_italy,
+          :outcome_os_kosovo,
+          :outcome_os_laos,
+          :outcome_os_local_japan,
+          :outcome_os_marriage_impossible_no_laos_locals,
+          :outcome_os_no_cni,
+          :outcome_os_other_countries,
+          :outcome_portugal,
+          :outcome_spain,
+          :outcome_ss_affirmation,
+          :outcome_ss_marriage,
+          :outcome_ss_marriage_malta,
+          :outcome_ss_marriage_not_possible,
+          :outcome_switzerland
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if ceremony_in_brazil_not_resident_in_the_uk
+            :outcome_brazil_not_living_in_the_uk
+          elsif ceremony_country == "netherlands"
+            :outcome_marriage_via_local_authorities
+          elsif ceremony_country == "portugal"
+            :outcome_portugal
+          elsif ceremony_country == "ireland"
+            :outcome_ireland
+          elsif ceremony_country == "switzerland"
+            :outcome_switzerland
+          elsif ceremony_country == "spain"
+            :outcome_spain
+          elsif response == 'opposite_sex'
+            if ceremony_country == 'hong-kong'
+              :outcome_os_hong_kong
+            elsif consular_cni_residing_in_third_country
+              :outcome_consular_cni_os_residing_in_third_country
+            elsif marriage_in_norway_third_country
+              :outcome_consular_cni_os_residing_in_third_country
+            elsif marriage_in_italy
+              :outcome_os_italy
+            elsif os_marriage_with_local_in_japan
+              :outcome_os_local_japan
+            elsif ceremony_country == 'cambodia'
+              :outcome_os_cambodia
+            elsif ceremony_country == "colombia"
+              :outcome_os_colombia
+            elsif ceremony_country == "kosovo"
+              :outcome_os_kosovo
+            elsif ceremony_country == "indonesia"
+              :outcome_os_indonesia
+            elsif ceremony_in_laos_partners_not_local
+              :outcome_os_marriage_impossible_no_laos_locals
+            elsif ceremony_country == "laos"
+              :outcome_os_laos
+            elsif data_query.os_consular_cni_countries?(ceremony_country) || (resident_of == 'uk' && data_query.os_no_marriage_related_consular_services?(ceremony_country)) || data_query.os_consular_cni_in_nearby_country?(ceremony_country)
+              :outcome_os_consular_cni
+            elsif ceremony_in_finland_uk_resident
+              :outcome_os_consular_cni
+            elsif ceremony_in_norway_uk_resident
+              :outcome_os_consular_cni
+            elsif data_query.os_affirmation_countries?(ceremony_country)
+              :outcome_os_affirmation
+            elsif data_query.commonwealth_country?(ceremony_country) || ceremony_country == 'zimbabwe'
+              :outcome_os_commonwealth
+            elsif data_query.british_overseas_territories?(ceremony_country)
+              :outcome_os_bot
+            elsif data_query.os_no_consular_cni_countries?(ceremony_country) || (resident_of != 'uk' && data_query.os_no_marriage_related_consular_services?(ceremony_country))
+              :outcome_os_no_cni
+            elsif marriage_via_local_authorities
+              :outcome_marriage_via_local_authorities
+            elsif data_query.os_other_countries?(ceremony_country)
+              :outcome_os_other_countries
+            end
+          elsif response == 'same_sex'
+            if ss_affirmation
+              :outcome_ss_affirmation
+            elsif ss_unknown_no_embassies
+              :outcome_os_no_cni
+            elsif ceremony_country == "malta"
+              :outcome_ss_marriage_malta
+            elsif ss_marriage_not_possible
+              :outcome_ss_marriage_not_possible
+            elsif ss_marriage_germany_partner_local
+              :outcome_cp_or_equivalent
+            elsif ss_marriage_countries | ss_marriage_countries_when_couple_british | ss_marriage_and_partnership
+              :outcome_ss_marriage
+            elsif data_query.cp_equivalent_countries?(ceremony_country)
+              :outcome_cp_or_equivalent
+            elsif data_query.cp_cni_not_required_countries?(ceremony_country)
+              :outcome_cp_no_cni
+            elsif %w(canada south-africa).include?(ceremony_country)
+              :outcome_cp_commonwealth_countries
+            elsif data_query.cp_consular_countries?(ceremony_country)
+              :outcome_cp_consular
+            else
+              :outcome_cp_all_other_countries
+            end
+          end
         end
       end
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -115,8 +115,17 @@ module SmartAnswer
 
         save_input_as :resident_of
 
-        next_node_if(:partner_opposite_or_same_sex?, variable_matches(:ceremony_country, 'switzerland'))
-        next_node(:what_is_your_partners_nationality?)
+        permitted_next_nodes = [
+          :partner_opposite_or_same_sex?,
+          :what_is_your_partners_nationality?
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if ceremony_country == 'switzerland'
+            :partner_opposite_or_same_sex?
+          else
+            :what_is_your_partners_nationality?
+          end
+        end
       end
 
       # Q3a

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -134,9 +134,20 @@ module SmartAnswer
         option :pacs
         save_input_as :marriage_or_pacs
 
-        next_node_if(:outcome_monaco, variable_matches(:ceremony_country, "monaco"))
-        next_node_if(:outcome_os_france_or_fot, responded_with('marriage'))
-        next_node(:outcome_cp_france_pacs)
+        permitted_next_nodes = [
+          :outcome_cp_france_pacs,
+          :outcome_monaco,
+          :outcome_os_france_or_fot
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if ceremony_country == 'monaco'
+            :outcome_monaco
+          elsif response == 'marriage'
+            :outcome_os_france_or_fot
+          else
+            :outcome_cp_france_pacs
+          end
+        end
       end
 
       # Q4

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: dbde56ad3ab43dc06db3bb96803a6861
+lib/smart_answer_flows/marriage-abroad.rb: d1dac943231ed0f02de009288240522f
 lib/smart_answer_flows/locales/en/marriage-abroad.yml: e8225cc9c281e31a884d41cb7c4482bf
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: 839cce0363e0c51ba4ab9fb1722fc59f


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
