### PR TITLE
Use next_node blocks in register-a-birth

### DIFF
--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -97,13 +97,21 @@ module SmartAnswer
         from { Date.today.end_of_year }
         to { 50.years.ago(Date.today) }
 
-        define_predicate :before_july_2006 do |response|
+        next_node_calculation :before_july_2006 do |response|
           Date.new(2006, 07, 01) > response
         end
 
-        next_node_if(:homeoffice_result, before_july_2006)
-
-        next_node(:where_are_you_now?)
+        permitted_next_nodes = [
+          :homeoffice_result,
+          :where_are_you_now?
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if before_july_2006
+            :homeoffice_result
+          else
+            :where_are_you_now?
+          end
+        end
       end
 
       # Q5

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -27,8 +27,12 @@ module SmartAnswer
           %w(iran syria yemen).include?(response)
         end
 
+        define_predicate :responded_with_commonwealth_country? do |response|
+          Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(response)
+        end
+
         next_node_if(:no_embassy_result, country_has_no_embassy)
-        next_node_if(:commonwealth_result, reg_data_query.responded_with_commonwealth_country?)
+        next_node_if(:commonwealth_result, responded_with_commonwealth_country?)
         next_node(:who_has_british_nationality?)
       end
 

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -9,7 +9,6 @@ module SmartAnswer
       country_name_query = SmartAnswer::Calculators::CountryNameFormatter.new
       reg_data_query = SmartAnswer::Calculators::RegistrationsDataQuery.new
       translator_query = SmartAnswer::Calculators::TranslatorLinks.new
-      country_has_no_embassy = SmartAnswer::Predicate::RespondedWith.new(%w(iran syria yemen))
       exclude_countries = %w(holy-see british-antarctic-territory)
 
       # Q1
@@ -22,6 +21,10 @@ module SmartAnswer
 
         calculate :registration_country_name_lowercase_prefix do
           country_name_query.definitive_article(registration_country)
+        end
+
+        define_predicate :country_has_no_embassy do |response|
+          %w(iran syria yemen).include?(response)
         end
 
         next_node_if(:no_embassy_result, country_has_no_embassy)

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -79,8 +79,17 @@ module SmartAnswer
           response == 'no'
         end
 
-        next_node_if(:childs_date_of_birth?, responded_with('no'), variable_matches(:british_national_parent, 'father'))
-        next_node(:where_are_you_now?)
+        permitted_next_nodes = [
+          :childs_date_of_birth?,
+          :where_are_you_now?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if response == 'no' && british_national_parent == 'father'
+            :childs_date_of_birth?
+          else
+            :where_are_you_now?
+          end
+        end
       end
 
       # Q4

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -23,17 +23,28 @@ module SmartAnswer
           country_name_query.definitive_article(registration_country)
         end
 
-        define_predicate :country_has_no_embassy do |response|
+        next_node_calculation :country_has_no_embassy do |response|
           %w(iran syria yemen).include?(response)
         end
 
-        define_predicate :responded_with_commonwealth_country? do |response|
+        next_node_calculation :responded_with_commonwealth_country do |response|
           Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(response)
         end
 
-        next_node_if(:no_embassy_result, country_has_no_embassy)
-        next_node_if(:commonwealth_result, responded_with_commonwealth_country?)
-        next_node(:who_has_british_nationality?)
+        permitted_next_nodes = [
+          :commonwealth_result,
+          :no_embassy_result,
+          :who_has_british_nationality?
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if country_has_no_embassy
+            :no_embassy_result
+          elsif responded_with_commonwealth_country
+            :commonwealth_result
+          else
+            :who_has_british_nationality?
+          end
+        end
       end
 
       # Q2

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -97,7 +97,7 @@ module SmartAnswer
         from { Date.today.end_of_year }
         to { 50.years.ago(Date.today) }
 
-        before_july_2006 = SmartAnswer::Predicate::Callable.new("before 1 July 2006") do |response|
+        define_predicate :before_july_2006 do |response|
           Date.new(2006, 07, 01) > response
         end
 

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -169,12 +169,21 @@ module SmartAnswer
           country_name_query.definitive_article(registration_country)
         end
 
-        define_predicate(:currently_in_north_korea) {
+        next_node_calculation(:currently_in_north_korea) {
           response == 'north-korea'
         }
 
-        next_node_if(:north_korea_result, currently_in_north_korea)
-        next_node(:oru_result)
+        permitted_next_nodes = [
+          :north_korea_result,
+          :oru_result
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if currently_in_north_korea
+            :north_korea_result
+          else
+            :oru_result
+          end
+        end
       end
 
       # Outcomes

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/register-a-birth.rb: 45ace230da98c9226036bbfc3c6251c7
+lib/smart_answer_flows/register-a-birth.rb: 730dba55e2cc3353cf3982277702d68c
 lib/smart_answer_flows/locales/en/register-a-birth.yml: 30bf7c48f1cd56a55142f3844b348633
 test/data/register-a-birth-questions-and-responses.yml: c59cb1d0c11f3ad29f905b632f7c58bb
 test/data/register-a-birth-responses-and-expected-results.yml: 3ac4372034c86d8cc87665db59ff11d5


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
