### PR TITLE
Use next_node blocks in register-a-death

### DIFF
--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -75,7 +75,11 @@ module SmartAnswer
           %w(iran syria yemen).include?(response)
         end
 
-        next_node_if(:commonwealth_result, reg_data_query.responded_with_commonwealth_country?)
+        define_predicate :responded_with_commonwealth_country? do |response|
+          Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(response)
+        end
+
+        next_node_if(:commonwealth_result, responded_with_commonwealth_country?)
         next_node_if(:no_embassy_result, country_has_no_embassy)
         next_node(:where_are_you_now?)
       end

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -71,17 +71,28 @@ module SmartAnswer
           current_location_name_lowercase_prefix
         end
 
-        define_predicate :country_has_no_embassy do |response|
+        next_node_calculation :country_has_no_embassy do |response|
           %w(iran syria yemen).include?(response)
         end
 
-        define_predicate :responded_with_commonwealth_country? do |response|
+        next_node_calculation :responded_with_commonwealth_country do |response|
           Calculators::RegistrationsDataQuery::COMMONWEALTH_COUNTRIES.include?(response)
         end
 
-        next_node_if(:commonwealth_result, responded_with_commonwealth_country?)
-        next_node_if(:no_embassy_result, country_has_no_embassy)
-        next_node(:where_are_you_now?)
+        permitted_next_nodes = [
+          :commonwealth_result,
+          :no_embassy_result,
+          :where_are_you_now?
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if responded_with_commonwealth_country
+            :commonwealth_result
+          elsif country_has_no_embassy
+            :no_embassy_result
+          else
+            :where_are_you_now?
+          end
+        end
       end
 
       # Q5

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -109,16 +109,24 @@ module SmartAnswer
           response == 'in_the_uk'
         end
 
-        define_predicate(:died_in_north_korea) {
+        next_node_calculation(:died_in_north_korea) {
           country_of_death == 'north-korea'
         }
 
-        on_condition(responded_with('same_country')) do
-          next_node_if(:north_korea_result, died_in_north_korea)
+        permitted_next_nodes = [
+          :north_korea_result,
+          :oru_result,
+          :which_country_are_you_in_now?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if response == 'same_country' && died_in_north_korea
+            :north_korea_result
+          elsif response == 'another_country'
+            :which_country_are_you_in_now?
+          else
+            :oru_result
+          end
         end
-
-        next_node_if(:which_country_are_you_in_now?, responded_with('another_country'))
-        next_node(:oru_result)
       end
 
       # Q6

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -9,7 +9,6 @@ module SmartAnswer
       country_name_query = SmartAnswer::Calculators::CountryNameFormatter.new
       reg_data_query = SmartAnswer::Calculators::RegistrationsDataQuery.new
       translator_query = SmartAnswer::Calculators::TranslatorLinks.new
-      country_has_no_embassy = SmartAnswer::Predicate::RespondedWith.new(%w(iran syria yemen))
       exclude_countries = %w(holy-see british-antarctic-territory)
 
       # Q1
@@ -70,6 +69,10 @@ module SmartAnswer
 
         calculate :death_country_name_lowercase_prefix do
           current_location_name_lowercase_prefix
+        end
+
+        define_predicate :country_has_no_embassy do |response|
+          %w(iran syria yemen).include?(response)
         end
 
         next_node_if(:commonwealth_result, reg_data_query.responded_with_commonwealth_country?)

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -139,12 +139,21 @@ module SmartAnswer
           country_name_query.definitive_article(current_location)
         end
 
-        define_predicate(:currently_in_north_korea) {
+        next_node_calculation(:currently_in_north_korea) {
           response == 'north-korea'
         }
 
-        next_node_if(:north_korea_result, currently_in_north_korea)
-        next_node(:oru_result)
+        permitted_next_nodes = [
+          :north_korea_result,
+          :oru_result
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if currently_in_north_korea
+            :north_korea_result
+          else
+            :oru_result
+          end
+        end
       end
 
       outcome :commonwealth_result

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/register-a-death.rb: 941863d243f6fef17176d45b24a2460a
+lib/smart_answer_flows/register-a-death.rb: 378f810da11670f93cadef74954fe302
 lib/smart_answer_flows/locales/en/register-a-death.yml: 04de0b215b1ab22ce4a52a82a185f6f1
 test/data/register-a-death-questions-and-responses.yml: bae21b0a8be1bbaa2dd6febd505382d6
 test/data/register-a-death-responses-and-expected-results.yml: a69c595900ab2d85208c0ac92f186ae8


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
