### PR TITLE
Remove title fallback for start nodes

### DIFF
--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -9,7 +9,7 @@ class StartNodePresenter < NodePresenter
 
   def title
     title = @renderer.content_for(:title, html: false)
-    title.present? ? title.chomp : @node.name.to_s.humanize
+    title && title.chomp
   end
 
   def meta_description

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample/smart_answers_controller_sample.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample/smart_answers_controller_sample.govspeak.erb
@@ -1,3 +1,7 @@
+<% content_for :title do %>
+  Smart answers controller sample
+<% end %>
+
 <% content_for :meta_description do %>
   This is a test description
 <% end %>

--- a/test/unit/start_node_presenter_test.rb
+++ b/test/unit/start_node_presenter_test.rb
@@ -33,12 +33,6 @@ module SmartAnswer
       assert_equal 'title-text', @presenter.title
     end
 
-    test '#title falls back to humanized node name if not title available in ERB template' do
-      @renderer.stubs(:content_for).returns(nil)
-
-      assert_equal 'Start node name', @presenter.title
-    end
-
     test '#meta_description returns content rendered for meta_description block with govspeak processing disabled' do
       @renderer.stubs(:content_for).with(:meta_description, html: false).returns('meta-description-text')
 


### PR DESCRIPTION
Previously if not title was specified for a start node, we fell back to using
a human-friendly version of the node key. This was a carry over from code
originally in the `NodePresenter` and needlessly complicates the code.

Ideally we'd fail fast if no title was found (as in #2075), but given that the
regression tests render the title of the landing page for each flow, I think
this step is a safe one and it will make something else I'm working on easier.