### PR TITLE
Improve unit tests for QuestionPresenter#error

### DIFF
--- a/test/fixtures/smart_answer_flows/locales/en/question-presenter-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/question-presenter-sample.yml
@@ -17,9 +17,11 @@ en-GB:
         title: "Is today a %{day}?"
         body: "Today is %{day}"
       question_with_custom_error_message:
-        custom_error_message: custom error message
+        custom_error_message_key: custom error message
       question_with_default_error_message:
-        error_message: default error message
+        error_message: default error message for the question
+      question_with_interpolated_default_error_message:
+        error_message: "%{error}"
       question_with_no_custom_or_default_error_message:
       question_with_post_body:
         post_body: post body for question

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -31,45 +31,69 @@ module SmartAnswer
       assert_equal 'Is today a Monday?', presenter.title
     end
 
-    test '#error returns nil if there is no error set on the state' do
-      flow = nil
-      question = Question::Date.new(flow, :example_question?)
-      state = State.new(question.name)
-      state.error = nil
-      presenter = QuestionPresenter.new('flow.test', question, state)
+    context 'no error set on state' do
+      setup do
+        @question = Question::Date.new(nil, :example_question?)
+        @state = State.new(@question.name)
+        @state.error = nil
+      end
 
-      assert_nil presenter.error
+      should 'return no error message' do
+        presenter = QuestionPresenter.new('flow.test', @question, @state)
+        assert_nil presenter.error
+      end
     end
 
-    test '#error uses the error key to lookup a custom error message for the question in the YAML file' do
-      flow = nil
-      question = Question::Date.new(flow, :question_with_custom_error_message)
-      state = State.new(question.name)
-      state.error = :custom_error_message
-      presenter = QuestionPresenter.new('flow.test', question, state)
+    context 'error message key exists for question' do
+      setup do
+        @question = Question::Date.new(nil, :question_with_custom_error_message)
+        @state = State.new(@question.name)
+        @state.error = 'custom_error_message_key'
+      end
 
-      assert_equal 'custom error message', presenter.error
+      should 'return error message for key' do
+        presenter = QuestionPresenter.new('flow.test', @question, @state)
+        assert_equal 'custom error message', presenter.error
+      end
     end
 
-    test '#error falls back to the default error message for the question in the YAML file' do
-      flow = nil
-      question = Question::Date.new(flow, :question_with_default_error_message)
-      state = State.new(question.name)
-      state.error = :non_existent_custom_error_message
-      presenter = QuestionPresenter.new('flow.test', question, state)
+    context 'error message key does not exist for question' do
+      setup do
+        @question = Question::Date.new(nil, :question_with_default_error_message)
+        @state = State.new(@question.name)
+        @state.error = 'non_existent_custom_error_message_key'
+      end
 
-      assert_equal 'default error message', presenter.error
+      should 'return default error message for the question' do
+        presenter = QuestionPresenter.new('flow.test', @question, @state)
+        assert_equal 'default error message for the question', presenter.error
+      end
     end
 
-    test '#error falls back to the default error message for the flow' do
-      flow = nil
-      question_name = :question_with_no_custom_or_default_error_message
-      question = Question::Date.new(flow, question_name)
-      state = State.new(question.name)
-      state.error = "SmartAnswer::InvalidResponse"
-      presenter = QuestionPresenter.new('flow.test', question, state)
+    context 'error is exception message and default error message interpolates it' do
+      setup do
+        @question = Question::Date.new(nil, :question_with_interpolated_default_error_message)
+        @state = State.new(@question.name)
+        @state.error = 'Raw message from InvalidResponse exception'
+      end
 
-      assert_equal 'Please answer this question', presenter.error
+      should 'return interpolated error message i.e. raw exception message' do
+        presenter = QuestionPresenter.new('flow.test', @question, @state)
+        assert_equal 'Raw message from InvalidResponse exception', presenter.error
+      end
+    end
+
+    context 'neither error key nor default error key exist for question' do
+      setup do
+        @question = Question::Date.new(nil, :question_with_no_custom_or_default_error_message)
+        @state = State.new(@question.name)
+        @state.error = 'unknown_error_message_key'
+      end
+
+      should 'fallback to the system-wide default error message' do
+        presenter = QuestionPresenter.new('flow.test', @question, @state)
+        assert_equal I18n.translate('flow.defaults.error_message'), presenter.error
+      end
     end
 
     test "Node hint looked up from translation file" do


### PR DESCRIPTION
My main objective here was to cover the behaviour when an
`SmartAnswer::InvalidResponse` is raised with a text message and the default
error message in the i18n YAML file interpolates this error. Currently this
behaviour is only tested in the `InputValidationTest` integration test, but
there's so much going on in there it's hard to see the wood for the trees.

I'm not convinced that this behaviour is very sensible nor do I think it is used
anywhere in the published smart answer flows. However, it does appear as if
there are quite a few places where a custom `String` is set as the exception
message rather than an error message key. Since I believe the mechanism
described above is the only way such messages could currently be displayed to
the user, I'm loathe to remove it without providing a replacement.

I've also clarified that the final fallback error message is system-wide and not
just for the question's flow.