### PR TITLE
Remove deprecated Flow#section & #subsection_slug

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -48,16 +48,6 @@ module SmartAnswer
       @status
     end
 
-    def section_slug(s = nil)
-      ActiveSupport::Deprecation.warn("Sections are no longer handled within smartanswers.", caller(1))
-      nil
-    end
-
-    def subsection_slug(s = nil)
-      ActiveSupport::Deprecation.warn("Sections are no longer handled within smartanswers.", caller(1))
-      nil
-    end
-
     def multiple_choice(name, options = {}, &block)
       add_node Question::MultipleChoice.new(self, name, options, &block)
     end


### PR DESCRIPTION
Most of the code relating to these methods was removed in 2012 in the
following two commits:

* 8bee67ea43dc4de5e024342931c8028785d10f4d
* d397d13352b3832d263867ba742f256955272374

The deprecation warnings were left in place in case any un-merged flows used
either of the methods. I think it's safe to say that this danger has passed and
it's now safe to removed these methods.