### PR TITLE
Improve test coverage for FormattingHelper#format_money

### DIFF
--- a/test/unit/formatting_helper_test.rb
+++ b/test/unit/formatting_helper_test.rb
@@ -6,10 +6,12 @@ module SmartAnswer
 
     test "#format_money doesn't add pence for amounts in whole pounds" do
       assert_equal '£1', format_money('1.00')
+      assert_equal '£1', format_money(Money.new('1.00'))
     end
 
     test "#format_money adds pence for amounts that aren't whole pounds" do
       assert_equal '£1.23', format_money('1.23')
+      assert_equal '£1.23', format_money(Money.new('1.23'))
     end
 
     test '#format_date returns the date formatted using "%e %B %Y"' do


### PR DESCRIPTION
I believe that the origin of the code in `FormattingHelper#format_money` was
from the [code which is now in `SmartAnswer::I18nRenderer#value_for_interpolation`][1].
Thus at least in some scenarios I would expect a `SmartAnswer::Money` object to be
passed in rather than a `String`. This commit adds assertions for the former.

[1]: https://github.com/alphagov/smart-answers/blob/7e26c554be106b2888f44bf92746e5fc7f6d819f/lib/smart_answer/i18n_renderer.rb#L33-L34