### PR TITLE
Remove unnecessary guard conditions before calls to String#chomp in node presenters

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -14,8 +14,7 @@ class OutcomePresenter < NodePresenter
   end
 
   def title
-    title = @renderer.content_for(:title, html: false)
-    title && title.chomp
+    @renderer.content_for(:title, html: false).chomp
   end
 
   def body(html: true)

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -8,13 +8,11 @@ class StartNodePresenter < NodePresenter
   end
 
   def title
-    title = @renderer.content_for(:title, html: false)
-    title && title.chomp
+    @renderer.content_for(:title, html: false).chomp
   end
 
   def meta_description
-    meta_description = @renderer.content_for(:meta_description, html: false)
-    meta_description && meta_description.chomp
+    @renderer.content_for(:meta_description, html: false).chomp
   end
 
   def body(html: true)


### PR DESCRIPTION
`SmartAnswer::ErbRenderer#content_for` never returns `nil` - it always returns
a `String` even if it's an empty one. Thus the guard condition before each
call to `String#chomp` in the `OutcomePresenter` & `StartNodePresenter` is
unnecessary and can be removed.