### PR TITLE
Avoid relying on old fallback behaviour for question title

### DIFF
--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -502,7 +502,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
         assert_match /Smart answers controller sample/, doc.css('h1').first.to_s
         assert_equal 0, doc.css('head').size, "Should not have layout"
         assert_equal '/smart-answers-controller-sample/y/no', doc.css('form').first.attributes['action'].to_s
-        assert_equal @flow.node(:do_you_like_jam?).name.to_s.humanize, data['title']
+        assert_equal 'Do you like jam?', data['title']
       end
     end
 


### PR DESCRIPTION
Since [this commit][1] we no longer fallback to the humanized version of the question name,
so it doesn't make sense to rely on that behaviour.

Also by asserting against a string literal we can avoid delving into the
internals of the flow.

[1]: aad10d5b0b0dbd1826c68523e9c69d8f70e38687