### PR TITLE
Use FormattingHelper#format_money in entitled_to_sick_pay outcome in SSP

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
@@ -11,7 +11,7 @@
   Week ending | SSP amount
   -|-
   <% calculator.weekly_payments.each do |week_ending, ssp_amount| %>
-    <%= format_date(week_ending) %>|<%= sprintf("£%.2f", ssp_amount) %>
+    <%= format_date(week_ending) %>|<%= format_money(ssp_amount) %>
   <% end %>
    | **Total SSP: <%= format_money(ssp_payment) %>**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,8 +8,8 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,7 +8,7 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 | **Total SSP: £57.80**
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -6,8 +6,8 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
-13 April 2013|£0.00
+6 April 2013|£0
+13 April 2013|£0
 20 April 2013|£86.70
 27 April 2013|£86.70
 4 May 2013|£86.70

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -6,7 +6,7 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
-6 April 2013|£0.00
+6 April 2013|£0
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -6,7 +6,7 @@ test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: b4251
 lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: f91dc1d321c164a06271889100875600
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/_esa.govspeak.erb: 660031398fda690ed7b3e2186ba64060
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/already_getting_maternity.govspeak.erb: 258fd4422c4ae665c83d5ee1e061bbff
-lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb: ed74ac72ff6fc4fb4f814bcb16d1d44d
+lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb: eb78b429bca4ded3befcd1411edaa91c
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/maximum_entitlement_reached.govspeak.erb: eb12d5290c873df20fd23ff9eb06c273
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/must_be_sick_for_4_days.govspeak.erb: 17b34a7463bcbbf7e2a5c417ec5452f9
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_earned_enough.govspeak.erb: 1e5cd1c6d99b6bd3145578416d62e7c5


### PR DESCRIPTION
We're trying to standardize on using this method to format money objects.

The effect of this is to leave off the decimal point and the pence when the
value is a whole number of pounds.

@lutgendorff confirmed that this was probably just an accidental difference and
so I'm fixing it here.
