### PR TITLE
ErbRenderer should always return an HTML-safe String

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -14,7 +14,7 @@ class OutcomePresenter < NodePresenter
   end
 
   def title
-    @renderer.content_for(:title, html: false).chomp
+    @renderer.single_line_of_content_for(:title)
   end
 
   def body(html: true)

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -8,11 +8,11 @@ class StartNodePresenter < NodePresenter
   end
 
   def title
-    @renderer.content_for(:title, html: false).chomp
+    @renderer.single_line_of_content_for(:title)
   end
 
   def meta_description
-    @renderer.content_for(:meta_description, html: false).chomp
+    @renderer.single_line_of_content_for(:meta_description)
   end
 
   def body(html: true)

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -8,6 +8,10 @@ module SmartAnswer
       helpers.each { |helper| @view.extend(helper) }
     end
 
+    def single_line_of_content_for(key)
+      content_for(key, html: false).chomp.html_safe
+    end
+
     def content_for(key, html: true)
       content = rendered_view.content_for(key) || ''
       content = strip_leading_spaces(content.to_str)

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -11,7 +11,7 @@ module SmartAnswer
     def content_for(key, html: true)
       content = rendered_view.content_for(key) || ''
       content = strip_leading_spaces(content.to_str)
-      html ? GovspeakPresenter.new(content).html : normalize_blank_lines(content)
+      html ? GovspeakPresenter.new(content).html : normalize_blank_lines(content).html_safe
     end
 
     def erb_template_path

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory redundancy pay - GOV.UK</title>
+    <title>Calculate your employee's statutory redundancy pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory redundancy pay
+        Calculate your employee's statutory redundancy pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory redundancy pay - GOV.UK</title>
+    <title>Calculate your employee's statutory redundancy pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory redundancy pay
+        Calculate your employee's statutory redundancy pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21/3.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21/3.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory redundancy pay - GOV.UK</title>
+    <title>Calculate your employee's statutory redundancy pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory redundancy pay
+        Calculate your employee's statutory redundancy pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-employee-redundancy-pay/y.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/y.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory redundancy pay - GOV.UK</title>
+    <title>Calculate your employee's statutory redundancy pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory redundancy pay
+        Calculate your employee's statutory redundancy pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/y.html
+++ b/test/artefacts/calculate-married-couples-allowance/y.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/yes/no.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/no.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/yes/no/1955-01-01.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/no/1955-01-01.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.0/5000.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.0/5000.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your Married Couple&#39;s Allowance - GOV.UK</title>
+    <title>Calculate your Married Couple's Allowance - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your Married Couple&#39;s Allowance
+        Calculate your Married Couple's Allowance
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/200.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/200.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_paternity_pay,statutory_adoption_pay.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_paternity_pay,statutory_adoption_pay.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/calculate-statutory-sick-pay/y.html
+++ b/test/artefacts/calculate-statutory-sick-pay/y.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Calculate your employee&#39;s statutory sick pay - GOV.UK</title>
+    <title>Calculate your employee's statutory sick pay - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Calculate your employee&#39;s statutory sick pay
+        Calculate your employee's statutory sick pay
       </h1>
     </div>
   </header>

--- a/test/artefacts/help-if-you-are-arrested-abroad/y.html
+++ b/test/artefacts/help-if-you-are-arrested-abroad/y.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>Help if you&#39;re arrested abroad - GOV.UK</title>
+    <title>Help if you're arrested abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        Help if you&#39;re arrested abroad
+        Help if you're arrested abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/child_benefit/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/child_benefit/austria.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits/permanent/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits/permanent/austria.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/esa.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/esa.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/iidb.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/iidb.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/no.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/no.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes/no.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes/no.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/jsa.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/jsa.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/jsa/more_than_a_year.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/jsa/more_than_a_year.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan/yes.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan/yes.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/austria.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/ssp/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/ssp/austria.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/artefacts/uk-benefits-abroad/y.html
+++ b/test/artefacts/uk-benefits-abroad/y.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
     <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
-    <title>UK benefits if you&#39;re going or living abroad - GOV.UK</title>
+    <title>UK benefits if you're going or living abroad - GOV.UK</title>
     <script src="/smartanswers/smart-answers.js" defer="defer"></script>
     <meta name="robots" content="noindex">
 
@@ -22,7 +22,7 @@
   <header class="page-header group">
     <div>
       <h1>
-        UK benefits if you&#39;re going or living abroad
+        UK benefits if you're going or living abroad
       </h1>
     </div>
   </header>

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -161,6 +161,33 @@ Hello world
       end
     end
 
+    test '#single_line_of_content_for removes trailing newline' do
+      erb_template = content_for(:key, "single-line-of-content-for-key\n")
+
+      with_erb_template_file('template-name', erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: 'template-name')
+
+        assert_equal 'single-line-of-content-for-key', renderer.single_line_of_content_for(:key)
+      end
+    end
+
+    test '#single_line_of_content_for returns an HTML-safe string' do
+      erb_template = content_for(:key, 'html-unsafe-string')
+
+      with_erb_template_file('template-name', erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: 'template-name')
+
+        assert renderer.single_line_of_content_for(:key).html_safe?
+      end
+    end
+
+    test '#single_line_of_content_for disables HTML rendering' do
+      erb_template = content_for(:key, 'single-line-of-content-for-key')
+      renderer = ErbRenderer.new(template_directory: nil, template_name: nil)
+      renderer.stubs(:content_for).with(:key, html: false).returns('single-line-of-content-for-key')
+      assert_equal 'single-line-of-content-for-key', renderer.single_line_of_content_for(:key)
+    end
+
     private
 
     def content_for(key, template)

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -130,6 +130,26 @@ Hello world
       end
     end
 
+    test '#content_for returns an HTML-safe string when passed through Govspeak' do
+      erb_template = content_for(:key, 'html-unsafe-string')
+
+      with_erb_template_file('template-name', erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: 'template-name')
+
+        assert renderer.content_for(:key).html_safe?
+      end
+    end
+
+    test '#content_for returns an HTML-safe string when not passed through Govspeak' do
+      erb_template = content_for(:key, 'html-unsafe-string')
+
+      with_erb_template_file('template-name', erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: 'template-name')
+
+        assert renderer.content_for(:key, html: false).html_safe?
+      end
+    end
+
     test '#content_for returns the same content when called multiple times' do
       erb_template = content_for(:key, 'body-content')
 

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -22,14 +22,8 @@ module SmartAnswer
       OutcomePresenter.new('i18n-prefix', outcome)
     end
 
-    test '#title returns content rendered for title block with govspeak processing disabled' do
-      @renderer.stubs(:content_for).with(:title, html: false).returns('title-text')
-
-      assert_equal 'title-text', @presenter.title
-    end
-
-    test '#title removes trailing newline from rendered content' do
-      @renderer.stubs(:content_for).returns("title-text\n")
+    test '#title returns single line of content rendered for title block' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns('title-text')
 
       assert_equal 'title-text', @presenter.title
     end

--- a/test/unit/start_node_presenter_test.rb
+++ b/test/unit/start_node_presenter_test.rb
@@ -21,26 +21,14 @@ module SmartAnswer
       StartNodePresenter.new('i18n-prefix', start_node)
     end
 
-    test '#title returns content rendered for title block with govspeak processing disabled' do
-      @renderer.stubs(:content_for).with(:title, html: false).returns('title-text')
+    test '#title returns single line of content rendered for title block' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns('title-text')
 
       assert_equal 'title-text', @presenter.title
     end
 
-    test '#title removes trailing newline from rendered content' do
-      @renderer.stubs(:content_for).returns("title-text\n")
-
-      assert_equal 'title-text', @presenter.title
-    end
-
-    test '#meta_description returns content rendered for meta_description block with govspeak processing disabled' do
-      @renderer.stubs(:content_for).with(:meta_description, html: false).returns('meta-description-text')
-
-      assert_equal 'meta-description-text', @presenter.meta_description
-    end
-
-    test '#meta_description removes trailing newline from rendered content' do
-      @renderer.stubs(:content_for).returns("meta-description-text\n")
+    test '#meta_description returns single line of content rendered for meta_description block' do
+      @renderer.stubs(:single_line_of_content_for).with(:meta_description).returns('meta-description-text')
 
       assert_equal 'meta-description-text', @presenter.meta_description
     end


### PR DESCRIPTION
Content that has already been rendered through `ErbRenderer` doesn't need to be HTML-escaped, because `ActionView::Base` will have already taken care of that. So we can mark content returned from `ErbRenderer` as being `html_safe`.