### PR TITLE
Use next_node blocks in report-a-lost-or-stolen-passport

### DIFF
--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
@@ -42,8 +42,17 @@ module SmartAnswer
 
         end
 
-        next_node_if(:contact_the_embassy_canada, responded_with('canada'))
-        next_node :contact_the_embassy
+        permitted_next_nodes = [
+          :contact_the_embassy,
+          :contact_the_embassy_canada
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if response == 'canada'
+            :contact_the_embassy_canada
+          else
+            :contact_the_embassy
+          end
+        end
       end
 
       outcome :contact_the_embassy

--- a/test/data/report-a-lost-or-stolen-passport-files.yml
+++ b/test/data/report-a-lost-or-stolen-passport-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb: a61c798522ee7d07347e9178846b9b0e
+lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb: 55d1d72e3aa14151bd575a5e6fe46efd
 lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml: 94978f81dd4c41afec1ff9a772a0d536
 test/data/report-a-lost-or-stolen-passport-questions-and-responses.yml: 307a097c6429f895390b742dda8c9bc8
 test/data/report-a-lost-or-stolen-passport-responses-and-expected-results.yml: 7a5cb860803f433fa2416b7fcaf12f12


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
