### PR TITLE
Use next_node blocks in state-pension-topup

### DIFF
--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -14,12 +14,21 @@ module SmartAnswer
 
         save_input_as :date_of_birth
 
-        define_predicate(:too_young?) do |response|
+        next_node_calculation(:too_young) do |response|
           calculator.too_young?(response)
         end
 
-        next_node_if(:outcome_pension_age_not_reached, too_young?)
-        next_node :gender?
+        permitted_next_nodes = [
+          :gender?,
+          :outcome_pension_age_not_reached
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if too_young
+            :outcome_pension_age_not_reached
+          else
+            :gender?
+          end
+        end
       end
 
       #Q2

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -38,12 +38,21 @@ module SmartAnswer
 
         save_input_as :gender
 
-        define_predicate(:male_and_too_young?) do |response|
+        next_node_calculation(:male_and_too_young) do |response|
           calculator.too_young?(date_of_birth, response)
         end
 
-        next_node_if(:outcome_pension_age_not_reached, male_and_too_young?)
-        next_node :how_much_extra_per_week?
+        permitted_next_nodes = [
+          :how_much_extra_per_week?,
+          :outcome_pension_age_not_reached
+        ]
+        next_node(permitted: permitted_next_nodes) do
+          if male_and_too_young
+            :outcome_pension_age_not_reached
+          else
+            :how_much_extra_per_week?
+          end
+        end
       end
 
       #Q3

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/state-pension-topup.rb: 8abc41fb69e3af250612832a8b5a9999
+lib/smart_answer_flows/state-pension-topup.rb: 588abd953a7a80e1ead751394e72ab0c
 lib/smart_answer_flows/locales/en/state-pension-topup.yml: 723be2cd9151b43de550a4972b36f862
 test/data/state-pension-topup-questions-and-responses.yml: f4f609a6e989f166616a05435c6993aa
 test/data/state-pension-topup-responses-and-expected-results.yml: 1207c6118839a3b13810038c57a20d4a


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
