### PR TITLE
Remove brittle assertion checking non-deterministic behaviour

### DIFF
--- a/test/unit/flow_registry_test.rb
+++ b/test/unit/flow_registry_test.rb
@@ -35,7 +35,6 @@ module SmartAnswer
       flows = registry.flows
       assert_kind_of Enumerable, flows
       assert_kind_of Flow, flows.first
-      assert_equal "flow-sample", flows.first.name
     end
 
     context "without preloaded flows" do


### PR DESCRIPTION
This assertion doesn't seem to be buying us much and has recently started to
cause intermittent CI build failures like [this one][1].

I think the problem is that this test was relying on all fixture flows except
`flow-sample` to be marked as `draft` and/or that the enumeration of files in
the `load_path` directory is deterministic across different filesystems.

The fixture flows recently added for the various `SmartAnswersController`
functional tests are *not* marked as `draft` and I think this is why the builds
have started to fail occasionally.

Since the assertion isn't really buying us much, @chrisroos & I have agreed that
it should be removed.

[1]: https://ci.dev.publishing.service.gov.uk/job/govuk_smartanswers_branches/3376/console