### PR TITLE
Use next_node blocks in student-finance-forms

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms.rb
+++ b/lib/smart_answer_flows/student-finance-forms.rb
@@ -71,8 +71,18 @@ module SmartAnswer
 
         save_input_as :form_needed_for_2
 
-        next_node_if(:outcome_dsa_expenses, responded_with('dsa-expenses'))
-        next_node(:what_year?)
+        permitted_next_nodes = [
+          :outcome_dsa_expenses,
+          :what_year?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case response
+          when 'dsa-expenses'
+            :outcome_dsa_expenses
+          else
+            :what_year?
+          end
+        end
       end
 
       multiple_choice :what_year? do

--- a/lib/smart_answer_flows/student-finance-forms.rb
+++ b/lib/smart_answer_flows/student-finance-forms.rb
@@ -43,10 +43,24 @@ module SmartAnswer
 
         save_input_as :form_needed_for_1
 
-        next_node_if(:outcome_dsa_expenses, responded_with('dsa-expenses'))
-        next_node_if(:outcome_ccg_expenses, responded_with('ccg-expenses'))
-        next_node_if(:outcome_travel, responded_with('travel-grant'))
-        next_node(:what_year?)
+        permitted_next_nodes = [
+          :outcome_ccg_expenses,
+          :outcome_dsa_expenses,
+          :outcome_travel,
+          :what_year?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case response
+          when 'dsa-expenses'
+            :outcome_dsa_expenses
+          when 'ccg-expenses'
+            :outcome_ccg_expenses
+          when 'travel-grant'
+            :outcome_travel
+          else
+            :what_year?
+          end
+        end
       end
 
       multiple_choice :form_needed_for_2? do

--- a/lib/smart_answer_flows/student-finance-forms.rb
+++ b/lib/smart_answer_flows/student-finance-forms.rb
@@ -250,23 +250,46 @@ module SmartAnswer
         option 'course-start-before-01092012'
         option 'course-start-after-01092012'
 
-        on_condition(variable_matches(:what_year, 'year-1415')) do
-          next_node_if(:outcome_uk_pt_1415_grant, responded_with('course-start-before-01092012'))
-          on_condition(responded_with('course-start-after-01092012')) do
-            next_node_if(:outcome_uk_pt_1415_continuing, variable_matches(:continuing_student, 'continuing-student'))
-            next_node_if(:outcome_uk_pt_1415_new, variable_matches(:continuing_student, 'new-student'))
-          end
-        end
-
-        on_condition(variable_matches(:what_year, 'year-1516')) do
-          on_condition(responded_with('course-start-before-01092012')) do
-            next_node_if(:outcome_uk_ptgc_1516_grant, variable_matches(:continuing_student, 'continuing-student'))
-            next_node_if(:outcome_uk_ptgn_1516_grant, variable_matches(:continuing_student, 'new-student'))
-          end
-
-          on_condition(responded_with('course-start-after-01092012')) do
-            next_node_if(:outcome_uk_pt_1516_continuing, variable_matches(:continuing_student, 'continuing-student'))
-            next_node_if(:outcome_uk_pt_1516_new, variable_matches(:continuing_student, 'new-student'))
+        permitted_next_nodes = [
+          :outcome_uk_pt_1415_continuing,
+          :outcome_uk_pt_1415_grant,
+          :outcome_uk_pt_1415_new,
+          :outcome_uk_pt_1516_continuing,
+          :outcome_uk_pt_1516_new,
+          :outcome_uk_ptgc_1516_grant,
+          :outcome_uk_ptgn_1516_grant
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case what_year
+          when 'year-1415'
+            case response
+            when 'course-start-before-01092012'
+              :outcome_uk_pt_1415_grant
+            when 'course-start-after-01092012'
+              case continuing_student
+              when 'continuing-student'
+                :outcome_uk_pt_1415_continuing
+              when 'new-student'
+                :outcome_uk_pt_1415_new
+              end
+            end
+          when 'year-1516'
+            case response
+            when 'course-start-before-01092012'
+              case continuing_student
+              when 'continuing-student'
+                :outcome_uk_ptgc_1516_grant
+              when 'new-student'
+                :outcome_uk_ptgn_1516_grant
+              end
+            when 'course-start-after-01092012'
+              case continuing_student
+              when 'continuing-student'
+                :outcome_uk_pt_1516_continuing
+              when 'new-student'
+                :outcome_uk_pt_1516_new
+              end
+            end
           end
         end
       end

--- a/lib/smart_answer_flows/student-finance-forms.rb
+++ b/lib/smart_answer_flows/student-finance-forms.rb
@@ -170,44 +170,80 @@ module SmartAnswer
 
         save_input_as :continuing_student
 
-        on_condition(variable_matches(:type_of_student, 'eu-full-time')) do
-          on_condition(variable_matches(:what_year, 'year-1415')) do
-            next_node_if(:outcome_eu_ft_1415_continuing, responded_with('continuing-student'))
-            next_node_if(:outcome_eu_ft_1415_new, responded_with('new-student'))
-          end
-          on_condition(variable_matches(:what_year, 'year-1516')) do
-            next_node_if(:outcome_eu_ft_1516_continuing, responded_with('continuing-student'))
-            next_node_if(:outcome_eu_ft_1516_new, responded_with('new-student'))
-          end
-        end
-
-        on_condition(variable_matches(:type_of_student, 'eu-part-time')) do
-          on_condition(variable_matches(:what_year, 'year-1415')) do
-            next_node_if(:outcome_eu_pt_1415_continuing, responded_with('continuing-student'))
-            next_node_if(:outcome_eu_pt_1415_new, responded_with('new-student'))
-          end
-
-          on_condition(variable_matches(:what_year, 'year-1516')) do
-            next_node_if(:outcome_eu_pt_1516_continuing, responded_with('continuing-student'))
-            next_node_if(:outcome_eu_pt_1516_new, responded_with('new-student'))
-          end
-        end
-
-        on_condition(variable_matches(:type_of_student, 'uk-full-time')) do
-          on_condition(variable_matches(:form_needed_for_1, 'apply-loans-grants')) do
-            on_condition(variable_matches(:what_year, 'year-1415')) do
-              next_node_if(:outcome_uk_ft_1415_continuing, responded_with('continuing-student'))
-              next_node_if(:outcome_uk_ft_1415_new, responded_with('new-student'))
+        permitted_next_nodes = [
+          :outcome_eu_ft_1415_continuing,
+          :outcome_eu_ft_1415_new,
+          :outcome_eu_ft_1516_continuing,
+          :outcome_eu_ft_1516_new,
+          :outcome_eu_pt_1415_continuing,
+          :outcome_eu_pt_1415_new,
+          :outcome_eu_pt_1516_continuing,
+          :outcome_eu_pt_1516_new,
+          :outcome_uk_ft_1415_continuing,
+          :outcome_uk_ft_1415_new,
+          :outcome_uk_ft_1516_continuing,
+          :outcome_uk_ft_1516_new,
+          :pt_course_start?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case type_of_student
+          when 'eu-full-time'
+            case what_year
+            when 'year-1415'
+              case response
+              when 'continuing-student'
+                :outcome_eu_ft_1415_continuing
+              when 'new-student'
+                :outcome_eu_ft_1415_new
+              end
+            when 'year-1516'
+              case response
+              when 'continuing-student'
+                :outcome_eu_ft_1516_continuing
+              when 'new-student'
+                :outcome_eu_ft_1516_new
+              end
             end
-
-            on_condition(variable_matches(:what_year, 'year-1516')) do
-              next_node_if(:outcome_uk_ft_1516_continuing, responded_with('continuing-student'))
-              next_node_if(:outcome_uk_ft_1516_new, responded_with('new-student'))
+          when 'eu-part-time'
+            case what_year
+            when 'year-1415'
+              case response
+              when 'continuing-student'
+                :outcome_eu_pt_1415_continuing
+              when 'new-student'
+                :outcome_eu_pt_1415_new
+              end
+            when 'year-1516'
+              case response
+              when 'continuing-student'
+                :outcome_eu_pt_1516_continuing
+              when 'new-student'
+                :outcome_eu_pt_1516_new
+              end
             end
+          when 'uk-full-time'
+            if form_needed_for_1 == 'apply-loans-grants'
+              case what_year
+              when 'year-1415'
+                case response
+                when 'continuing-student'
+                  :outcome_uk_ft_1415_continuing
+                when 'new-student'
+                  :outcome_uk_ft_1415_new
+                end
+              when 'year-1516'
+                case response
+                when 'continuing-student'
+                  :outcome_uk_ft_1516_continuing
+                when 'new-student'
+                  :outcome_uk_ft_1516_new
+                end
+              end
+            end
+          when 'uk-part-time'
+            :pt_course_start?
           end
         end
-
-        next_node_if(:pt_course_start?, variable_matches(:type_of_student, 'uk-part-time'))
       end
 
       multiple_choice :pt_course_start? do

--- a/lib/smart_answer_flows/student-finance-forms.rb
+++ b/lib/smart_answer_flows/student-finance-forms.rb
@@ -91,46 +91,76 @@ module SmartAnswer
 
         save_input_as :what_year
 
-        next_node_if(:continuing_student?, variable_matches(:type_of_student, %w(eu-full-time eu-part-time)))
-
-        on_condition(variable_matches(:type_of_student, 'uk-full-time')) do
-
-          on_condition(variable_matches(:form_needed_for_1, 'proof-identity')) do
-            next_node_if(:outcome_proof_identity_1415, responded_with('year-1415'))
-            next_node_if(:outcome_proof_identity_1516, responded_with('year-1516'))
+        permitted_next_nodes = [
+          :continuing_student?,
+          :outcome_ccg_1415,
+          :outcome_ccg_1516,
+          :outcome_dsa_1415,
+          :outcome_dsa_1415_pt,
+          :outcome_dsa_1516,
+          :outcome_dsa_1516_pt,
+          :outcome_parent_partner_1415,
+          :outcome_parent_partner_1516,
+          :outcome_proof_identity_1415,
+          :outcome_proof_identity_1516
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case type_of_student
+          when 'eu-full-time', 'eu-part-time'
+            :continuing_student?
+          when 'uk-full-time'
+            case form_needed_for_1
+            when 'proof-identity'
+              case response
+              when 'year-1415'
+                :outcome_proof_identity_1415
+              when 'year-1516'
+                :outcome_proof_identity_1516
+              end
+            when 'income-details'
+              case response
+              when 'year-1415'
+                :outcome_parent_partner_1415
+              when 'year-1516'
+                :outcome_parent_partner_1516
+              end
+            when 'apply-dsa'
+              case response
+              when 'year-1415'
+                :outcome_dsa_1415
+              when 'year-1516'
+                :outcome_dsa_1516
+              end
+            when 'apply-ccg'
+              case response
+              when 'year-1415'
+                :outcome_ccg_1415
+              when 'year-1516'
+                :outcome_ccg_1516
+              end
+            when 'apply-loans-grants'
+              :continuing_student?
+            end
+          when 'uk-part-time'
+            case form_needed_for_2
+            when 'proof-identity'
+              case response
+              when 'year-1415'
+                :outcome_proof_identity_1415
+              when 'year-1516'
+                :outcome_proof_identity_1516
+              end
+            when 'apply-dsa'
+              case response
+              when 'year-1415'
+                :outcome_dsa_1415_pt
+              when 'year-1516'
+                :outcome_dsa_1516_pt
+              end
+            when 'apply-loans-grants'
+              :continuing_student?
+            end
           end
-
-          on_condition(variable_matches(:form_needed_for_1, 'income-details')) do
-            next_node_if(:outcome_parent_partner_1415, responded_with('year-1415'))
-            next_node_if(:outcome_parent_partner_1516, responded_with('year-1516'))
-          end
-
-          on_condition(variable_matches(:form_needed_for_1, 'apply-dsa')) do
-            next_node_if(:outcome_dsa_1415, responded_with('year-1415'))
-            next_node_if(:outcome_dsa_1516, responded_with('year-1516'))
-          end
-
-          on_condition(variable_matches(:form_needed_for_1, 'apply-ccg')) do
-            next_node_if(:outcome_ccg_1415, responded_with('year-1415'))
-            next_node_if(:outcome_ccg_1516, responded_with('year-1516'))
-          end
-
-          next_node_if(:continuing_student?, variable_matches(:form_needed_for_1, 'apply-loans-grants'))
-        end
-
-        on_condition(variable_matches(:type_of_student, 'uk-part-time')) do
-
-          on_condition(variable_matches(:form_needed_for_2, 'proof-identity')) do
-            next_node_if(:outcome_proof_identity_1415, responded_with('year-1415'))
-            next_node_if(:outcome_proof_identity_1516, responded_with('year-1516'))
-          end
-
-          on_condition(variable_matches(:form_needed_for_2, 'apply-dsa')) do
-            next_node_if(:outcome_dsa_1415_pt, responded_with('year-1415'))
-            next_node_if(:outcome_dsa_1516_pt, responded_with('year-1516'))
-          end
-
-          next_node_if(:continuing_student?, variable_matches(:form_needed_for_2, 'apply-loans-grants'))
         end
       end
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/student-finance-forms.rb: 9e03155d1444f42985a24fa5ea7b2fa4
+lib/smart_answer_flows/student-finance-forms.rb: 92307edb6f55e9387eed098927f79da1
 lib/smart_answer_flows/locales/en/student-finance-forms.yml: 2ea8adb5e2808a8a3de5d95ac18f1326
 test/data/student-finance-forms-questions-and-responses.yml: ec2ad38a9df75dd2606b9f979afd5066
 test/data/student-finance-forms-responses-and-expected-results.yml: fb765941838abb1e05b2d874049c7db1


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
