### PR TITLE
Use next_node blocks in uk-benefits-abroad

### DIFF
--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -10,10 +10,6 @@ module SmartAnswer
       additional_countries = [OpenStruct.new(slug: "jersey", name: "Jersey"), OpenStruct.new(slug: "guernsey", name: "Guernsey")]
 
       countries_of_former_yugoslavia = %w(bosnia-and-herzegovina kosovo macedonia montenegro serbia).freeze
-      responded_with_former_yugoslavia = SmartAnswer::Predicate::RespondedWith.new(
-        countries_of_former_yugoslavia,
-        "former Yugoslavia"
-      )
 
       # Q1
       multiple_choice :going_or_already_abroad? do
@@ -115,6 +111,10 @@ module SmartAnswer
             finland france germany gibraltar greece hungary iceland ireland italy
             latvia liechtenstein lithuania luxembourg malta netherlands norway
             poland portugal romania slovakia slovenia spain sweden switzerland).include?(response)
+        end
+
+        define_predicate :responded_with_former_yugoslavia do |response|
+          countries_of_former_yugoslavia.include?(response)
         end
 
         define_predicate :social_security_countries_jsa do |response|

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -790,13 +790,24 @@ module SmartAnswer
         option :temporary
         option :permanent
 
-        define_predicate :going_abroad do
+        next_node_calculation :going_abroad do
           going_or_already_abroad == 'going_abroad'
         end
 
-        next_node_if(:which_country?, responded_with('permanent')) # Q25
-        next_node_if(:db_going_abroad_temporary_outcome, going_abroad) # A35 going_abroad
-        next_node(:db_already_abroad_temporary_outcome) # A34 already_abroad
+        permitted_next_nodes = [
+          :db_already_abroad_temporary_outcome,
+          :db_going_abroad_temporary_outcome,
+          :which_country?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if response == 'permanent'
+            :which_country? # Q25
+          elsif going_abroad
+            :db_going_abroad_temporary_outcome # A35 going_abroad
+          else
+            :db_already_abroad_temporary_outcome # A34 already_abroad
+          end
+        end
       end
 
       # Going abroad Q32 going_abroad (Income Support)

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -119,9 +119,9 @@ module SmartAnswer
 
         next_node_calculation :responded_with_eea_country do |response|
           %w(austria belgium bulgaria croatia cyprus czech-republic denmark estonia
-            finland france germany gibraltar greece hungary iceland ireland italy
-            latvia liechtenstein lithuania luxembourg malta netherlands norway
-            poland portugal romania slovakia slovenia spain sweden switzerland).include?(response)
+             finland france germany gibraltar greece hungary iceland ireland italy
+             latvia liechtenstein lithuania luxembourg malta netherlands norway
+             poland portugal romania slovakia slovenia spain sweden switzerland).include?(response)
         end
 
         next_node_calculation :responded_with_former_yugoslavia do |response|

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -34,9 +34,7 @@ module SmartAnswer
         end
 
         calculate :already_abroad_text_two do |response|
-          if already_abroad
-            PhraseList.new(:already_abroad_text_two)
-          end
+          PhraseList.new(:already_abroad_text_two) if already_abroad
         end
 
         next_node :which_benefit?

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -15,7 +15,6 @@ module SmartAnswer
         "former Yugoslavia"
       )
       social_security_countries_jsa = responded_with_former_yugoslavia | SmartAnswer::Predicate::RespondedWith.new(%w(guernsey jersey new-zealand))
-      social_security_countries_iidb = responded_with_former_yugoslavia | SmartAnswer::Predicate::RespondedWith.new(%w(barbados bermuda guernsey jersey israel jamaica mauritius philippines turkey))
 
       # Q1
       multiple_choice :going_or_already_abroad? do
@@ -117,6 +116,11 @@ module SmartAnswer
             finland france germany gibraltar greece hungary iceland ireland italy
             latvia liechtenstein lithuania luxembourg malta netherlands norway
             poland portugal romania slovakia slovenia spain sweden switzerland).include?(response)
+        end
+
+        define_predicate :social_security_countries_iidb do |response|
+          (countries_of_former_yugoslavia +
+          %w(barbados bermuda guernsey jersey israel jamaica mauritius philippines turkey)).include?(response)
         end
 
         define_predicate :social_security_countries_bereavement_benefits do |response|

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -25,10 +25,6 @@ module SmartAnswer
           PhraseList.new(:"why_#{going_or_already_abroad}_title")
         end
 
-        calculate :is_already_abroad do |response|
-          response == 'already_abroad'
-        end
-
         calculate :going_abroad do
           going_or_already_abroad == 'going_abroad'
         end
@@ -38,7 +34,7 @@ module SmartAnswer
         end
 
         calculate :already_abroad_text_two do |response|
-          if is_already_abroad
+          if already_abroad
             PhraseList.new(:already_abroad_text_two)
           end
         end

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -33,6 +33,10 @@ module SmartAnswer
           going_or_already_abroad == 'going_abroad'
         end
 
+        calculate :already_abroad do
+          going_or_already_abroad == 'already_abroad'
+        end
+
         calculate :already_abroad_text_two do |response|
           if is_already_abroad
             PhraseList.new(:already_abroad_text_two)
@@ -65,10 +69,6 @@ module SmartAnswer
           else
             PhraseList.new(:"#{going_or_already_abroad}_how_long_question_title")
           end
-        end
-
-        next_node_calculation :already_abroad do
-          going_or_already_abroad == 'already_abroad'
         end
 
         permitted_next_nodes = [
@@ -121,10 +121,6 @@ module SmartAnswer
 
         calculate :country_name do
           (WorldLocation.all + additional_countries).find { |c| c.slug == country }.name
-        end
-
-        next_node_calculation :already_abroad do
-          going_or_already_abroad == 'already_abroad'
         end
 
         next_node_calculation :responded_with_eea_country do |response|
@@ -364,10 +360,6 @@ module SmartAnswer
         option :yes
         option :no
 
-        next_node_calculation :already_abroad do
-          going_or_already_abroad == 'already_abroad'
-        end
-
         permitted_next_nodes = [
           :eligible_for_smp?,
           :maternity_benefits_not_entitled_outcome,
@@ -434,10 +426,6 @@ module SmartAnswer
       multiple_choice :working_for_uk_employer_ssp? do
         option :yes
         option :no
-
-        next_node_calculation :already_abroad do
-          going_or_already_abroad == 'already_abroad'
-        end
 
         permitted_next_nodes = [
           :ssp_already_abroad_entitled_outcome,
@@ -566,10 +554,6 @@ module SmartAnswer
       multiple_choice :db_claiming_benefits? do
         option :yes
         option :no
-
-        next_node_calculation :already_abroad do
-          going_or_already_abroad == 'already_abroad'
-        end
 
         permitted_next_nodes = [
           :db_already_abroad_eea_outcome,
@@ -738,10 +722,6 @@ module SmartAnswer
         option :esa_under_a_year_medical
         option :esa_under_a_year_other
         option :esa_more_than_a_year
-
-        next_node_calculation :already_abroad do
-          going_or_already_abroad == 'already_abroad'
-        end
 
         permitted_next_nodes = [
           :esa_already_abroad_under_a_year_medical_outcome,

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -9,7 +9,6 @@ module SmartAnswer
       exclude_countries = %w(british-antarctic-territory french-guiana guadeloupe holy-see martinique mayotte reunion st-maarten)
       additional_countries = [OpenStruct.new(slug: "jersey", name: "Jersey"), OpenStruct.new(slug: "guernsey", name: "Guernsey")]
 
-      already_abroad = SmartAnswer::Predicate::VariableMatches.new(:going_or_already_abroad, 'already_abroad', nil, 'already abroad')
       responded_with_eea_country = SmartAnswer::Predicate::RespondedWith.new(
         %w(austria belgium bulgaria croatia cyprus czech-republic denmark estonia
           finland france germany gibraltar greece hungary iceland ireland italy
@@ -82,6 +81,10 @@ module SmartAnswer
           going_or_already_abroad == 'going_abroad'
         end
 
+        define_predicate :already_abroad do
+          going_or_already_abroad == 'already_abroad'
+        end
+
         next_node_if(:which_country?, responded_with(%w{winter_fuel_payment maternity_benefits child_benefit ssp bereavement_benefits}))
         next_node_if(:iidb_already_claiming?, responded_with('iidb'))
         next_node_if(:esa_how_long_abroad?, responded_with('esa'))
@@ -111,6 +114,10 @@ module SmartAnswer
 
         define_predicate :going_abroad do
           going_or_already_abroad == 'going_abroad'
+        end
+
+        define_predicate :already_abroad do
+          going_or_already_abroad == 'already_abroad'
         end
 
       #jsa
@@ -256,6 +263,10 @@ module SmartAnswer
           going_or_already_abroad == 'going_abroad'
         end
 
+        define_predicate :already_abroad do
+          going_or_already_abroad == 'already_abroad'
+        end
+
         #SSP benefits
         on_condition(variable_matches(:benefit, 'ssp')) do
           on_condition(going_abroad) do
@@ -304,6 +315,10 @@ module SmartAnswer
 
         define_predicate :going_abroad do
           going_or_already_abroad == 'going_abroad'
+        end
+
+        define_predicate :already_abroad do
+          going_or_already_abroad == 'already_abroad'
         end
 
         on_condition(going_abroad) do
@@ -423,6 +438,10 @@ module SmartAnswer
 
         define_predicate :going_abroad do
           going_or_already_abroad == 'going_abroad'
+        end
+
+        define_predicate :already_abroad do
+          going_or_already_abroad == 'already_abroad'
         end
 
         on_condition(going_abroad) do
@@ -570,6 +589,10 @@ module SmartAnswer
 
         define_predicate :going_abroad do
           going_or_already_abroad == 'going_abroad'
+        end
+
+        define_predicate :already_abroad do
+          going_or_already_abroad == 'already_abroad'
         end
 
         on_condition(going_abroad) do

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -579,21 +579,34 @@ module SmartAnswer
         option :yes
         option :no
 
-        define_predicate :going_abroad do
+        next_node_calculation :going_abroad do
           going_or_already_abroad == 'going_abroad'
         end
 
-        define_predicate :already_abroad do
+        next_node_calculation :already_abroad do
           going_or_already_abroad == 'already_abroad'
         end
 
-        on_condition(going_abroad) do
-          next_node_if(:db_going_abroad_eea_outcome, responded_with('yes')) # A37 going_abroad
-          next_node(:db_going_abroad_other_outcome) # A36 going_abroad
-        end
-        on_condition(already_abroad) do
-          next_node_if(:db_already_abroad_eea_outcome, responded_with('yes')) # A36 already_abroad
-          next_node(:db_already_abroad_other_outcome) # A35 already_abroad
+        permitted_next_nodes = [
+          :db_already_abroad_eea_outcome,
+          :db_already_abroad_other_outcome,
+          :db_going_abroad_eea_outcome,
+          :db_going_abroad_other_outcome
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if going_abroad
+            if response == 'yes'
+              :db_going_abroad_eea_outcome # A37 going_abroad
+            else
+              :db_going_abroad_other_outcome # A36 going_abroad
+            end
+          elsif already_abroad
+            if response == 'yes'
+              :db_already_abroad_eea_outcome # A36 already_abroad
+            else
+              :db_already_abroad_other_outcome # A35 already_abroad
+            end
+          end
         end
       end
 

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -14,7 +14,6 @@ module SmartAnswer
         countries_of_former_yugoslavia,
         "former Yugoslavia"
       )
-      social_security_countries_jsa = responded_with_former_yugoslavia | SmartAnswer::Predicate::RespondedWith.new(%w(guernsey jersey new-zealand))
 
       # Q1
       multiple_choice :going_or_already_abroad? do
@@ -116,6 +115,10 @@ module SmartAnswer
             finland france germany gibraltar greece hungary iceland ireland italy
             latvia liechtenstein lithuania luxembourg malta netherlands norway
             poland portugal romania slovakia slovenia spain sweden switzerland).include?(response)
+        end
+
+        define_predicate :social_security_countries_jsa do |response|
+          (countries_of_former_yugoslavia + %w(guernsey jersey new-zealand)).include?(response)
         end
 
         define_predicate :social_security_countries_iidb do |response|

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -443,21 +443,34 @@ module SmartAnswer
         option :yes
         option :no
 
-        define_predicate :going_abroad do
+        next_node_calculation :going_abroad do
           going_or_already_abroad == 'going_abroad'
         end
 
-        define_predicate :already_abroad do
+        next_node_calculation :already_abroad do
           going_or_already_abroad == 'already_abroad'
         end
 
-        on_condition(going_abroad) do
-          next_node_if(:ssp_going_abroad_entitled_outcome, responded_with('yes')) # A19 going_abroad
-          next_node(:ssp_going_abroad_not_entitled_outcome) # A20 going_abroad
-        end
-        on_condition(already_abroad) do
-          next_node_if(:ssp_already_abroad_entitled_outcome, responded_with('yes')) # A17 already_abroad
-          next_node(:ssp_already_abroad_not_entitled_outcome) # A18 already_abroad
+        permitted_next_nodes = [
+          :ssp_already_abroad_entitled_outcome,
+          :ssp_already_abroad_not_entitled_outcome,
+          :ssp_going_abroad_entitled_outcome,
+          :ssp_going_abroad_not_entitled_outcome
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if going_abroad
+            if response == 'yes'
+              :ssp_going_abroad_entitled_outcome # A19 going_abroad
+            else
+              :ssp_going_abroad_not_entitled_outcome # A20 going_abroad
+            end
+          elsif already_abroad
+            if response == 'yes'
+              :ssp_already_abroad_entitled_outcome # A17 already_abroad
+            else
+              :ssp_already_abroad_not_entitled_outcome # A18 already_abroad
+            end
+          end
         end
       end
 

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -29,6 +29,10 @@ module SmartAnswer
           response == 'already_abroad'
         end
 
+        calculate :going_abroad do
+          going_or_already_abroad == 'going_abroad'
+        end
+
         calculate :already_abroad_text_two do |response|
           if is_already_abroad
             PhraseList.new(:already_abroad_text_two)
@@ -61,10 +65,6 @@ module SmartAnswer
           else
             PhraseList.new(:"#{going_or_already_abroad}_how_long_question_title")
           end
-        end
-
-        next_node_calculation :going_abroad do
-          going_or_already_abroad == 'going_abroad'
         end
 
         next_node_calculation :already_abroad do
@@ -121,10 +121,6 @@ module SmartAnswer
 
         calculate :country_name do
           (WorldLocation.all + additional_countries).find { |c| c.slug == country }.name
-        end
-
-        next_node_calculation :going_abroad do
-          going_or_already_abroad == 'going_abroad'
         end
 
         next_node_calculation :already_abroad do
@@ -368,10 +364,6 @@ module SmartAnswer
         option :yes
         option :no
 
-        next_node_calculation :going_abroad do
-          going_or_already_abroad == 'going_abroad'
-        end
-
         next_node_calculation :already_abroad do
           going_or_already_abroad == 'already_abroad'
         end
@@ -442,10 +434,6 @@ module SmartAnswer
       multiple_choice :working_for_uk_employer_ssp? do
         option :yes
         option :no
-
-        next_node_calculation :going_abroad do
-          going_or_already_abroad == 'going_abroad'
-        end
 
         next_node_calculation :already_abroad do
           going_or_already_abroad == 'already_abroad'
@@ -578,10 +566,6 @@ module SmartAnswer
       multiple_choice :db_claiming_benefits? do
         option :yes
         option :no
-
-        next_node_calculation :going_abroad do
-          going_or_already_abroad == 'going_abroad'
-        end
 
         next_node_calculation :already_abroad do
           going_or_already_abroad == 'already_abroad'
@@ -755,10 +739,6 @@ module SmartAnswer
         option :esa_under_a_year_other
         option :esa_more_than_a_year
 
-        next_node_calculation :going_abroad do
-          going_or_already_abroad == 'going_abroad'
-        end
-
         next_node_calculation :already_abroad do
           going_or_already_abroad == 'already_abroad'
         end
@@ -789,10 +769,6 @@ module SmartAnswer
       multiple_choice :db_how_long_abroad? do
         option :temporary
         option :permanent
-
-        next_node_calculation :going_abroad do
-          going_or_already_abroad == 'going_abroad'
-        end
 
         permitted_next_nodes = [
           :db_already_abroad_temporary_outcome,

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -9,7 +9,6 @@ module SmartAnswer
       exclude_countries = %w(british-antarctic-territory french-guiana guadeloupe holy-see martinique mayotte reunion st-maarten)
       additional_countries = [OpenStruct.new(slug: "jersey", name: "Jersey"), OpenStruct.new(slug: "guernsey", name: "Guernsey")]
 
-      going_abroad = SmartAnswer::Predicate::VariableMatches.new(:going_or_already_abroad, 'going_abroad', nil, 'going abroad')
       already_abroad = SmartAnswer::Predicate::VariableMatches.new(:going_or_already_abroad, 'already_abroad', nil, 'already abroad')
       responded_with_eea_country = SmartAnswer::Predicate::RespondedWith.new(
         %w(austria belgium bulgaria croatia cyprus czech-republic denmark estonia
@@ -79,6 +78,10 @@ module SmartAnswer
           end
         end
 
+        define_predicate :going_abroad do
+          going_or_already_abroad == 'going_abroad'
+        end
+
         next_node_if(:which_country?, responded_with(%w{winter_fuel_payment maternity_benefits child_benefit ssp bereavement_benefits}))
         next_node_if(:iidb_already_claiming?, responded_with('iidb'))
         next_node_if(:esa_how_long_abroad?, responded_with('esa'))
@@ -104,6 +107,10 @@ module SmartAnswer
 
         calculate :country_name do
           (WorldLocation.all + additional_countries).find { |c| c.slug == country }.name
+        end
+
+        define_predicate :going_abroad do
+          going_or_already_abroad == 'going_abroad'
         end
 
       #jsa
@@ -245,6 +252,10 @@ module SmartAnswer
         option :yes
         option :no
 
+        define_predicate :going_abroad do
+          going_or_already_abroad == 'going_abroad'
+        end
+
         #SSP benefits
         on_condition(variable_matches(:benefit, 'ssp')) do
           on_condition(going_abroad) do
@@ -290,6 +301,10 @@ module SmartAnswer
       multiple_choice :working_for_uk_employer_ssp? do
         option :yes
         option :no
+
+        define_predicate :going_abroad do
+          going_or_already_abroad == 'going_abroad'
+        end
 
         on_condition(going_abroad) do
           next_node_if(:ssp_going_abroad_entitled_outcome, responded_with('yes')) # A19 going_abroad
@@ -405,6 +420,10 @@ module SmartAnswer
       multiple_choice :db_claiming_benefits? do
         option :yes
         option :no
+
+        define_predicate :going_abroad do
+          going_or_already_abroad == 'going_abroad'
+        end
 
         on_condition(going_abroad) do
           next_node_if(:db_going_abroad_eea_outcome, responded_with('yes')) # A37 going_abroad
@@ -549,6 +568,10 @@ module SmartAnswer
         option :esa_under_a_year_other
         option :esa_more_than_a_year
 
+        define_predicate :going_abroad do
+          going_or_already_abroad == 'going_abroad'
+        end
+
         on_condition(going_abroad) do
           next_node_if(:esa_going_abroad_under_a_year_medical_outcome, responded_with('esa_under_a_year_medical')) # A27 going_abroad
           next_node_if(:esa_going_abroad_under_a_year_other_outcome, responded_with('esa_under_a_year_other')) # A28 going_abroad
@@ -564,6 +587,10 @@ module SmartAnswer
       multiple_choice :db_how_long_abroad? do
         option :temporary
         option :permanent
+
+        define_predicate :going_abroad do
+          going_or_already_abroad == 'going_abroad'
+        end
 
         next_node_if(:which_country?, responded_with('permanent')) # Q25
         next_node_if(:db_going_abroad_temporary_outcome, going_abroad) # A35 going_abroad

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -755,23 +755,34 @@ module SmartAnswer
         option :esa_under_a_year_other
         option :esa_more_than_a_year
 
-        define_predicate :going_abroad do
+        next_node_calculation :going_abroad do
           going_or_already_abroad == 'going_abroad'
         end
 
-        define_predicate :already_abroad do
+        next_node_calculation :already_abroad do
           going_or_already_abroad == 'already_abroad'
         end
 
-        on_condition(going_abroad) do
-          next_node_if(:esa_going_abroad_under_a_year_medical_outcome, responded_with('esa_under_a_year_medical')) # A27 going_abroad
-          next_node_if(:esa_going_abroad_under_a_year_other_outcome, responded_with('esa_under_a_year_other')) # A28 going_abroad
+        permitted_next_nodes = [
+          :esa_already_abroad_under_a_year_medical_outcome,
+          :esa_already_abroad_under_a_year_other_outcome,
+          :esa_going_abroad_under_a_year_medical_outcome,
+          :esa_going_abroad_under_a_year_other_outcome,
+          :which_country?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          if going_abroad && response == 'esa_under_a_year_medical'
+            :esa_going_abroad_under_a_year_medical_outcome # A27 going_abroad
+          elsif going_abroad && response == 'esa_under_a_year_other'
+            :esa_going_abroad_under_a_year_other_outcome # A28 going_abroad
+          elsif already_abroad && response == 'esa_under_a_year_medical'
+            :esa_already_abroad_under_a_year_medical_outcome # A25 already_abroad
+          elsif already_abroad && response == 'esa_under_a_year_other'
+            :esa_already_abroad_under_a_year_other_outcome # A26 already_abroad
+          else
+            :which_country?
+          end
         end
-        on_condition(already_abroad) do
-          next_node_if(:esa_already_abroad_under_a_year_medical_outcome, responded_with('esa_under_a_year_medical')) # A25 already_abroad
-          next_node_if(:esa_already_abroad_under_a_year_other_outcome, responded_with('esa_under_a_year_other')) # A26 already_abroad
-        end
-        next_node(:which_country?)
       end
 
       # Going abroad Q28 going_abroad (Disability Benefits) and Q27 already_abroad

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -16,7 +16,6 @@ module SmartAnswer
       )
       social_security_countries_jsa = responded_with_former_yugoslavia | SmartAnswer::Predicate::RespondedWith.new(%w(guernsey jersey new-zealand))
       social_security_countries_iidb = responded_with_former_yugoslavia | SmartAnswer::Predicate::RespondedWith.new(%w(barbados bermuda guernsey jersey israel jamaica mauritius philippines turkey))
-      social_security_countries_bereavement_benefits = responded_with_former_yugoslavia | SmartAnswer::Predicate::RespondedWith.new(%w(barbados bermuda canada guernsey jersey israel jamaica mauritius new-zealand philippines turkey usa))
 
       # Q1
       multiple_choice :going_or_already_abroad? do
@@ -118,6 +117,11 @@ module SmartAnswer
             finland france germany gibraltar greece hungary iceland ireland italy
             latvia liechtenstein lithuania luxembourg malta netherlands norway
             poland portugal romania slovakia slovenia spain sweden switzerland).include?(response)
+        end
+
+        define_predicate :social_security_countries_bereavement_benefits do |response|
+          (countries_of_former_yugoslavia +
+          %w(barbados bermuda canada guernsey jersey israel jamaica mauritius new-zealand philippines turkey usa)).include?(response)
         end
 
       #jsa

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -714,9 +714,21 @@ module SmartAnswer
 
         save_input_as :how_long_abroad_jsa
 
-        next_node_if(:jsa_less_than_a_year_medical_outcome, responded_with("less_than_a_year_medical")) # A3 going_abroad
-        next_node_if(:jsa_less_than_a_year_other_outcome, responded_with("less_than_a_year_other")) # A4 going_abroad
-        next_node_if(:which_country?, responded_with("more_than_a_year"))
+        permitted_next_nodes = [
+          :jsa_less_than_a_year_medical_outcome,
+          :jsa_less_than_a_year_other_outcome,
+          :which_country?
+        ]
+        next_node(permitted: permitted_next_nodes) do |response|
+          case response
+          when 'less_than_a_year_medical'
+            :jsa_less_than_a_year_medical_outcome # A3 going_abroad
+          when 'less_than_a_year_other'
+            :jsa_less_than_a_year_other_outcome # A4 going_abroad
+          when 'more_than_a_year'
+            :which_country?
+          end
+        end
       end
       # Going abroad Q18 (tax credits) and Q17 already_abroad
       multiple_choice :tax_credits_how_long_abroad? do

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -9,13 +9,6 @@ module SmartAnswer
       exclude_countries = %w(british-antarctic-territory french-guiana guadeloupe holy-see martinique mayotte reunion st-maarten)
       additional_countries = [OpenStruct.new(slug: "jersey", name: "Jersey"), OpenStruct.new(slug: "guernsey", name: "Guernsey")]
 
-      responded_with_eea_country = SmartAnswer::Predicate::RespondedWith.new(
-        %w(austria belgium bulgaria croatia cyprus czech-republic denmark estonia
-          finland france germany gibraltar greece hungary iceland ireland italy
-          latvia liechtenstein lithuania luxembourg malta netherlands norway
-          poland portugal romania slovakia slovenia spain sweden switzerland),
-        "EEA country"
-      )
       countries_of_former_yugoslavia = %w(bosnia-and-herzegovina kosovo macedonia montenegro serbia).freeze
       responded_with_former_yugoslavia = SmartAnswer::Predicate::RespondedWith.new(
         countries_of_former_yugoslavia,
@@ -118,6 +111,13 @@ module SmartAnswer
 
         define_predicate :already_abroad do
           going_or_already_abroad == 'already_abroad'
+        end
+
+        define_predicate :responded_with_eea_country do |response|
+          %w(austria belgium bulgaria croatia cyprus czech-republic denmark estonia
+            finland france germany gibraltar greece hungary iceland ireland italy
+            latvia liechtenstein lithuania luxembourg malta netherlands norway
+            poland portugal romania slovakia slovenia spain sweden switzerland).include?(response)
         end
 
       #jsa

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_entitled_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_entitled_outcome.govspeak.erb
@@ -3,5 +3,5 @@
 
   You may also be able to claim [Guardian's Allowance](/guardians-allowance), if you're looking after  a [child whose parents have died](/child-benefit-child-parent-dies/if-one-or-both-parents-die) and you're getting Child Benefit for them.
 
-  Contact [HMRC](/child-benefit/further-information) to get Child Benefit or Guardian's Allowance<% if is_already_abroad %> while you're abroad <% end %>.
+  Contact [HMRC](/child-benefit/further-information) to get Child Benefit or Guardian's Allowance<% if already_abroad %> while you're abroad <% end %>.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_maybe_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_maybe_outcome.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You may be able to get [Industrial Injuries Disablement Benefit](/industrial-injuries-disablement-benefit) if you <% if is_already_abroad %>continued to<% end %> pay UK National Insurance while working in an [EEA country](/claiming-benefits-move-travel-abroad/where-you-can-claim-benefits).
+  You may be able to get [Industrial Injuries Disablement Benefit](/industrial-injuries-disablement-benefit) if you <% if already_abroad %>continued to<% end %> pay UK National Insurance while working in an [EEA country](/claiming-benefits-move-travel-abroad/where-you-can-claim-benefits).
 
   This benefit is also covered by social security agreements. Your UK social security payments may help you qualify for benefits in:
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/maternity_benefits_maternity_allowance_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/maternity_benefits_maternity_allowance_outcome.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You can't get Statutory Maternity Pay <% if is_already_abroad %> while you're abroad <% end %>.
+  You can't get Statutory Maternity Pay <% if already_abroad %> while you're abroad <% end %>.
 
   You may be able to get [Maternity Allowance](/maternity-allowance).
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_cross_border_worker_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_cross_border_worker_outcome.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  <% if is_already_abroad %>
+  <% if already_abroad %>
     You may be able to claim tax credits while you're abroad.
   <% else %>
     You may be able to get tax credits while you're abroad.
@@ -24,7 +24,7 @@
 
   Contact the Tax Credits Helpline to claim.
 
-  <% if is_already_abroad %>
+  <% if already_abroad %>
     <%= render partial: 'tax_credits_already_abroad_helpline.govspeak.erb' -%>
   <% else %>
     <%= render partial: 'tax_credits_going_abroad_helpline.govspeak.erb' -%>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_crown_servant_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_crown_servant_outcome.govspeak.erb
@@ -3,7 +3,7 @@
 
   Contact the Tax Credits Helpline to claim.
 
-  <% if is_already_abroad %>
+  <% if already_abroad %>
     <%= render partial: 'tax_credits_already_abroad_helpline.govspeak.erb' -%>
   <% else %>
     <%= render partial: 'tax_credits_going_abroad_helpline.govspeak.erb' -%>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_holiday_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_holiday_outcome.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  <% if is_already_abroad %>
+  <% if already_abroad %>
     You can carry on getting tax credits for up to 8 weeks after leaving the UK if you were already receiving them before you left.
   <% else %>
     You may be able to carry on getting tax credits for up to 8 weeks.
@@ -9,7 +9,7 @@
 
   You can receive tax credits for longer in some circumstances. You can be fined £300 if you receive credits you shouldn't have.
 
-  <% if is_already_abroad %>
+  <% if already_abroad %>
     <%= render partial: 'tax_credits_already_abroad_helpline.govspeak.erb' -%>
   <% else %>
     <%= render partial: 'tax_credits_going_abroad_helpline.govspeak.erb' -%>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_medical_death_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_medical_death_outcome.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  <% if is_already_abroad %>
+  <% if already_abroad %>
     You can carry on getting tax credits for up to 12 weeks after leaving the UK if you were already receiving them before you left.
   <% else %>
     You may be able to carry on getting tax credits for up to 12 weeks.
@@ -9,7 +9,7 @@
 
   You can receive tax credits for longer in some circumstances. You can be fined £300 if you receive credits you shouldn't have.
 
-  <% if is_already_abroad %>
+  <% if already_abroad %>
     <%= render partial: 'tax_credits_already_abroad_helpline.govspeak.erb' -%>
   <% else %>
     <%= render partial: 'tax_credits_going_abroad_helpline.govspeak.erb' -%>

--- a/test/data/uk-benefits-abroad-files.yml
+++ b/test/data/uk-benefits-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/uk-benefits-abroad.rb: 6130c063e243527dc29593a5d70499c7
+lib/smart_answer_flows/uk-benefits-abroad.rb: d7fb35d59cc32581358008761f530743
 lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml: 3883941cbccbef17e1d93a456777bc08
 test/data/uk-benefits-abroad-questions-and-responses.yml: 279454ec0916c13ac09ed5a90ad58777
 test/data/uk-benefits-abroad-responses-and-expected-results.yml: dbf714c4de3ed03f81c868c354aa9c81
@@ -11,7 +11,7 @@ lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_already_abroad_ss_outcome.
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_going_abroad_eea_outcome.govspeak.erb: d8f37862228393566e009028657b3655
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_going_abroad_other_outcome.govspeak.erb: 5aa3ed5f2f889dc9790edeb00b44210d
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_going_abroad_ss_outcome.govspeak.erb: 4310b9a964020df9e3692e00e0616c20
-lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_entitled_outcome.govspeak.erb: 3a11cdb7460ff7e54e58a7be9ba9c98d
+lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_entitled_outcome.govspeak.erb: e707890342c01fc8fc9fe875f9fc6f63
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_fy_already_abroad_outcome.govspeak.erb: 051700eff950ad35c63c2dc4e3b73a09
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_fy_going_abroad_outcome.govspeak.erb: 9bbb7acafd83a9411505e1efff696024
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_jtu_outcome.govspeak.erb: 054a2b10a978bf152dc1b9ae31568200
@@ -38,7 +38,7 @@ lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_already_abroad_ss_outcom
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_going_abroad_eea_outcome.govspeak.erb: 236ce2a6fb99782ff64c5aad671292a6
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_going_abroad_other_outcome.govspeak.erb: 97ae1d5cc847389e7e9bde842e1bdceb
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_going_abroad_ss_outcome.govspeak.erb: 6c47242e27cc810456d645d6cd42617e
-lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_maybe_outcome.govspeak.erb: ecc7fe823f962c75c4d014e5dbabed5c
+lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_maybe_outcome.govspeak.erb: 251477f07ad4aedfd0422522d93c1e90
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/is_abroad_for_treatment_outcome.govspeak.erb: a065ce2b160e64211f8feb5dafb4bdbf
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/is_already_abroad_outcome.govspeak.erb: f008f87a87354bfbb7ea76f4a505ba2e
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/is_claiming_benefits_outcome.govspeak.erb: 49cce70f0eb755e46cfc42bec019b37f
@@ -53,7 +53,7 @@ lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_not_entitled_outcome.govs
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_social_security_already_abroad_outcome.govspeak.erb: 2017f6b40edc99e50d71e810f8def153
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_social_security_going_abroad_outcome.govspeak.erb: 36a5cc684b174919870abb5a7a8882c8
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/maternity_benefits_eea_entitled_outcome.govspeak.erb: 7fbd56269e1fb54710a8e7fbc6ef2a98
-lib/smart_answer_flows/uk-benefits-abroad/outcomes/maternity_benefits_maternity_allowance_outcome.govspeak.erb: f6de120e0823b2252c956d0de141aa1b
+lib/smart_answer_flows/uk-benefits-abroad/outcomes/maternity_benefits_maternity_allowance_outcome.govspeak.erb: 60a0bef72f8d4ed32617756df9921d47
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/maternity_benefits_not_entitled_outcome.govspeak.erb: 04040a7c0e67752cba8f79caea8740c8
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/maternity_benefits_social_security_already_abroad_outcome.govspeak.erb: 0dac95c5890b3451f2c304469b9e9e32
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/maternity_benefits_social_security_going_abroad_outcome.govspeak.erb: a5794bcbc9964665a1e5a5578d881477
@@ -63,11 +63,11 @@ lib/smart_answer_flows/uk-benefits-abroad/outcomes/ssp_already_abroad_entitled_o
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/ssp_already_abroad_not_entitled_outcome.govspeak.erb: b7cec978058cd75a81a27c569c38950d
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/ssp_going_abroad_entitled_outcome.govspeak.erb: 1eaa2f9fb537ea773c1664e9b5919baa
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/ssp_going_abroad_not_entitled_outcome.govspeak.erb: 5bc25469193cb725728f0f926e6d67b5
-lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_cross_border_worker_outcome.govspeak.erb: 44fb2a4b58b59873f9e9cb51d3d6e05c
-lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_crown_servant_outcome.govspeak.erb: 5578e62ffbae01b7aa19b3fff8fec378
+lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_cross_border_worker_outcome.govspeak.erb: 232b82c725e7d49c1712c1f7837fd5b5
+lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_crown_servant_outcome.govspeak.erb: 74fdac34f607ac705ed076983973c004
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_eea_entitled_outcome.govspeak.erb: 9fe763f3a8335a09529a05d13a258921
-lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_holiday_outcome.govspeak.erb: cc5492edfaa6a01466e30eafe683e68d
-lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_medical_death_outcome.govspeak.erb: d093dd2e8c9cd1c2a2ef5e1942e3c42c
+lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_holiday_outcome.govspeak.erb: 632b24a3c07266a4db47b004bb340799
+lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_medical_death_outcome.govspeak.erb: e97564c22d48654d47cb8e663821cbfc
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/tax_credits_unlikely_outcome.govspeak.erb: 8c655001ccc3a4ed319607e6a97f04f0
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/wfp_eea_eligible_outcome.govspeak.erb: 1a5e3a180f7952388fd4e0ee20cb38f1
 lib/smart_answer_flows/uk-benefits-abroad/outcomes/wfp_going_abroad_outcome.govspeak.erb: f1d113905a298592ccb21fadb3a6570a


### PR DESCRIPTION
We've agreed to consistently use `next_node {}` to define our next node rules. Having a single way of defining the rules will hopefully make Smart Answers easier to develop and maintain.

This will ultimately allow us to remove the predicate code (`define_predicate`, `on_condition`, `next_node_if` etc).
