### PR TITLE
ErbRenderer should always return HTML-safe string for option labels

### DIFF
--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -31,7 +31,7 @@ module SmartAnswer
 
     def option_text(key)
       rendered_view
-      @view.options.fetch(key)
+      @view.options.fetch(key).html_safe
     end
 
     def erb_template_path

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -199,7 +199,7 @@ Hello world
       end
     end
 
-    test '#option_text raises KeyError if no option key does not exist' do
+    test '#option_text raises KeyError if option key does not exist' do
       erb_template = "<% options(option_one: 'option-one-text', option_two: 'option-two-text') %>"
 
       with_erb_template_file('template-name', erb_template) do |erb_template_directory|

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -223,6 +223,16 @@ Hello world
       end
     end
 
+    test '#option_text returns an HTML-safe string' do
+      erb_template = "<% options(option_one: 'html-unsafe-option-one-text') %>"
+
+      with_erb_template_file('template-name', erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: 'template-name')
+
+        assert renderer.option_text(:option_one).html_safe?
+      end
+    end
+
     private
 
     def content_for(key, template)


### PR DESCRIPTION
The option label text is all provided by developers; none of it is supplied by external users. This means we can legitimately mark all option label text as HTML-safe. c.f. #2098

There's no need to update any regression test artefacts, because this change only affects the options in question pages and these are all currently rendered by the `I18nRenderer`.