### PR TITLE
Make FormattingHelper methods available to question ERB templates

### DIFF
--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -17,7 +17,7 @@ class QuestionPresenter < NodePresenter
         template_directory: @node.template_directory.join('questions'),
         template_name: @node.filesystem_friendly_name,
         locals: @state.to_hash,
-        helpers: helpers
+        helpers: [SmartAnswer::FormattingHelper] + helpers
       )
     else
       @renderer ||= SmartAnswer::I18nRenderer.new(


### PR DESCRIPTION
I need this in order to be able to convert `calculate-statutory-sick-pay` (and probably others) to use ERB templates for questions.