### PR TITLE
Fix FlowRegistrationPresenter to work with both i18n & ERB

### DIFF
--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -46,7 +46,12 @@ class FlowRegistrationPresenter
       text = @flow.questions.inject([start_node.body]) { |acc, node|
         pres = QuestionPresenter.new(@i18n_prefix, node, nil, helpers: [MethodMissingHelper])
         acc.concat(NODE_PRESENTER_METHODS.map { |method|
-          pres.send(method)
+          begin
+            pres.send(method)
+          rescue I18n::MissingInterpolationArgument
+            # We can't do much about this, so we ignore these text nodes
+            nil
+          end
         })
       }.compact.join(" ").gsub(/(?:<[^>]+>|\s)+/, " ")
     )

--- a/test/fixtures/smart_answer_flows/flow-sample.rb
+++ b/test/fixtures/smart_answer_flows/flow-sample.rb
@@ -5,8 +5,6 @@ module SmartAnswer
       satisfies_need 4242
       content_id "f26e566e-2557-4921-b944-9373c32255f1"
 
-      use_erb_templates_for_questions
-
       multiple_choice :hotter_or_colder? do
         option :hotter
         option :colder

--- a/test/fixtures/smart_answer_flows/locales/en/flow-sample-interpolation.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/flow-sample-interpolation.yml
@@ -1,0 +1,11 @@
+en-GB:
+  flow:
+    flow-sample:
+      hotter_or_colder?:
+        title: QUESTION_1_TITLE
+        body: QUESTION_1_BODY %{i_dont_exist}
+        hint: QUESTION_1_HINT
+      frozen?:
+        title: QUESTION_2_TITLE
+        body: QUESTION_2_BODY
+        hint: QUESTION_2_HINT

--- a/test/fixtures/smart_answer_flows/locales/en/flow-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/flow-sample.yml
@@ -1,0 +1,11 @@
+en-GB:
+  flow:
+    flow-sample:
+      hotter_or_colder?:
+        title: QUESTION_1_TITLE
+        body: QUESTION_1_BODY
+        hint: QUESTION_1_HINT
+      frozen?:
+        title: QUESTION_2_TITLE
+        body: QUESTION_2_BODY <a href="/">LINK TEXT</a> &rarr;
+        hint: QUESTION_2_HINT

--- a/test/unit/flow_registration_presenter_with_erb_renderer_test.rb
+++ b/test/unit/flow_registration_presenter_with_erb_renderer_test.rb
@@ -1,25 +1,21 @@
 require_relative "../test_helper"
-require_relative "../helpers/i18n_test_helper"
+require_relative "../helpers/fixture_flows_helper"
 
 require File.expand_path('../../fixtures/smart_answer_flows/flow-sample', __FILE__)
 
-class FlowRegistrationPresenterTest < ActiveSupport::TestCase
-  include I18nTestHelper
+class FlowRegistrationPresenterWithErbRendererTest < ActiveSupport::TestCase
+  include FixtureFlowsHelper
 
   def setup
-    example_translation_file =
-      File.expand_path('../../fixtures/smart_answer_flows/locales/en/flow-sample.yml', __FILE__)
-    use_additional_translation_file(example_translation_file)
-
-    load_path = fixture_file('smart_answer_flows')
-    SmartAnswer::FlowRegistry.instance.stubs(:load_path).returns(load_path)
-
-    @flow = SmartAnswer::FlowSampleFlow.build
+    setup_fixture_flows
+    @flow = SmartAnswer::FlowSampleFlow.new
+    @flow.use_erb_templates_for_questions
+    @flow.define
     @presenter = FlowRegistrationPresenter.new(@flow)
   end
 
   def teardown
-    reset_translation_files
+    teardown_fixture_flows
   end
 
   context "slug" do
@@ -35,7 +31,7 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
   end
 
   context "title" do
-    should "should use the title translation" do
+    should "should use the title from the start node template" do
       assert_equal "FLOW_TITLE", @presenter.title
     end
   end
@@ -59,7 +55,7 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
   end
 
   context "description" do
-    should "use the meta.description translation" do
+    should "use the meta_description from the start node template" do
       assert_equal "FLOW_DESCRIPTION", @presenter.description
     end
   end
@@ -111,14 +107,12 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
     end
 
     should "ignore any interpolation errors" do
-      interpolation_example_translation_file =
-        File.expand_path('../../fixtures/smart_answer_flows/locales/en/flow-sample-interpolation.yml', __FILE__)
-      reset_translation_files
-      use_additional_translation_file(interpolation_example_translation_file)
+      @flow.multiple_choice(:question_with_interpolation)
       @content = @presenter.indexable_content
       assert_match %r{FLOW_BODY}, @content
-      assert_no_match %r{QUESTION_1_BODY}, @content
+      assert_match %r{QUESTION_1_BODY}, @content
       assert_match %r{QUESTION_2_BODY}, @content
+      assert_match %r{QUESTION_WITH_INTERPOLATION_BODY}, @content
     end
   end
 


### PR DESCRIPTION
In #2103 I forgot that we still need to support flows/questions with their
content in i18n YAML files vs ERB templates.

In this commit I've renamed the `FlowRegistrationPresenterTest` to
`FlowRegistrationPresenterWithErbRendererTest` and reinstated the earlier
version of `FlowRegistrationPresenterTest` to give suitable test coverage.

I've also reinstated the two i18n YAML files and use an explicit call to
`Flow#use_erb_templates_for_questions` in
`FlowRegistrationPresenterWithErbRendererTest` to switch over to ERB rendering.

Finally I've also reinstated the handling of
`I18n::MissingInterpolationArgument` so that the tests all pass.

Note that we saw [an exception in preview](https://errbit.preview.alphagov.co.uk/apps/533c2ee40da115303f0129a5/problems/564d91d365786306b4860500) which alerted me to this problem.