### PR TITLE
Fix GraphPresenter to work with both i18n & ERB

### DIFF
--- a/lib/graph_presenter.rb
+++ b/lib/graph_presenter.rb
@@ -1,6 +1,7 @@
 class GraphPresenter
   def initialize(flow)
     @flow = flow
+    @i18n_prefix = "flow.#{@flow.name}"
   end
 
   def labels
@@ -81,7 +82,7 @@ private
   end
 
   def node_title(node)
-    presenter = QuestionPresenter.new(nil, node, nil, helpers: [MethodMissingHelper])
+    presenter = QuestionPresenter.new(@i18n_prefix, node, {}, helpers: [MethodMissingHelper])
     presenter.title
   end
 

--- a/test/fixtures/smart_answer_flows/graph.rb
+++ b/test/fixtures/smart_answer_flows/graph.rb
@@ -4,8 +4,6 @@ module SmartAnswer
       name 'graph'
       status :draft
 
-      use_erb_templates_for_questions
-
       multiple_choice :q1? do
         option :yes
         option :no

--- a/test/fixtures/smart_answer_flows/locales/en/graph.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/graph.yml
@@ -1,0 +1,11 @@
+en-GB:
+  flow:
+    graph:
+      q1?:
+        title: "What is the answer to q1?"
+
+      q2?:
+        title: "What is the answer to q2?"
+
+      q_with_interpolation?:
+        title: "Question with %{interpolation}?"

--- a/test/unit/graph_presenter_with_erb_renderer_test.rb
+++ b/test/unit/graph_presenter_with_erb_renderer_test.rb
@@ -1,28 +1,28 @@
 require_relative '../test_helper'
-require_relative '../helpers/i18n_test_helper'
-
-require 'fixtures/smart_answer_flows/graph'
+require_relative '../helpers/fixture_flows_helper'
+require_relative '../fixtures/smart_answer_flows/graph'
 
 module SmartAnswer
-  class GraphPresenterTest < ActiveSupport::TestCase
-    include I18nTestHelper
+  class GraphPresenterWithErbRendererTest < ActiveSupport::TestCase
+    include FixtureFlowsHelper
 
     setup do
-      use_additional_translation_file(fixture_file('smart_answer_flows/locales/en/graph.yml'))
-
-      @flow = SmartAnswer::GraphFlow.build
+      setup_fixture_flows
+      @flow = SmartAnswer::GraphFlow.new
+      @flow.use_erb_templates_for_questions
+      @flow.define
       @presenter = GraphPresenter.new(@flow)
     end
 
     teardown do
-      reset_translation_files
+      teardown_fixture_flows
     end
 
-    test "presents labels of simple graph" do
+    test "presents labels of graph flow" do
       expected_labels = {
         q1?: "MultipleChoice\n-\nWhat is the answer to q1?\n\n( ) yes\n( ) no",
         q2?: "MultipleChoice\n-\nWhat is the answer to q2?\n\n( ) a\n( ) b",
-        q_with_interpolation?: "MultipleChoice\n-\nQuestion with %{interpolation}?\n\n( ) x\n( ) y",
+        q_with_interpolation?: "MultipleChoice\n-\nQuestion with <%= inter.pol.ation %>?\n\n( ) x\n( ) y",
         done_a: "Outcome\n-\ndone_a",
         done_b: "Outcome\n-\ndone_b"
       }


### PR DESCRIPTION
In #2103 I forgot that we still need to support flows/questions with their
content in i18n YAML files vs ERB templates.

In this commit I've renamed the `GraphPresenterTest` to
`GraphPresenterWithErbRendererTest` and reinstated the earlier
version of `GraphPresenterTest` to give suitable test coverage.

I've also reinstated the i18n YAML file and used an explicit call to
`Flow#use_erb_templates_for_questions` in `GraphPresenterWithErbRendererTest` to
switch over to ERB rendering.

I've avoided needing to handle `I18n::MissingInterpolationArgument` by passing
in an empty `Hash` as the `state` when instantiating the `QuestionPresenter`.