### PR TITLE
Update check-uk-visa Taiwan transit outcome

### DIFF
--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -138,6 +138,7 @@ module SmartAnswer
           :outcome_transit_not_leaving_airport,
           :outcome_transit_refugee_not_leaving_airport,
           :outcome_transit_taiwan,
+          :outcome_transit_taiwan_through_border_control,
           :outcome_transit_venezuela,
           :outcome_visit_waiver
         ]
@@ -146,7 +147,7 @@ module SmartAnswer
 
           if calculator.passing_through_uk_border_control?
             if calculator.passport_country_is_taiwan?
-              :outcome_transit_taiwan
+              :outcome_transit_taiwan_through_border_control
             elsif calculator.passport_country_in_visa_national_list?
               :outcome_transit_leaving_airport
             elsif calculator.passport_country_in_datv_list?
@@ -243,6 +244,7 @@ module SmartAnswer
       outcome :outcome_transit_not_leaving_airport
       outcome :outcome_transit_refugee_not_leaving_airport
       outcome :outcome_transit_taiwan
+      outcome :outcome_transit_taiwan_through_border_control
       outcome :outcome_transit_venezuela
       outcome :outcome_visit_waiver
       outcome :outcome_work_m

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -144,16 +144,18 @@ module SmartAnswer
         next_node(permitted: permitted_next_nodes) do |response|
           calculator.passing_through_uk_border_control_answer = response
 
-          next :outcome_transit_taiwan if calculator.passport_country_is_taiwan?
-
           if calculator.passing_through_uk_border_control?
-            if calculator.passport_country_in_visa_national_list?
+            if calculator.passport_country_is_taiwan?
+              :outcome_transit_taiwan
+            elsif calculator.passport_country_in_visa_national_list?
               :outcome_transit_leaving_airport
             elsif calculator.passport_country_in_datv_list?
               :outcome_transit_leaving_airport_datv
             end
           else
-            if calculator.passport_country_is_venezuela?
+            if calculator.passport_country_is_taiwan?
+              :outcome_transit_taiwan
+            elsif calculator.passport_country_is_venezuela?
               :outcome_transit_venezuela
             elsif calculator.applicant_is_stateless_or_a_refugee?
               :outcome_transit_refugee_not_leaving_airport

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan.govspeak.erb
@@ -1,29 +1,3 @@
 <% content_for :title do %>
-  <% if calculator.passing_through_uk_border_control? %>
-    You won't need a visa if your passport has a personal ID number on the bio data page.
-  <% else %>
-    You won't need a visa to come to the UK
-  <% end %>
-<% end %>
-
-<% content_for :body do %>
-  <% if calculator.passing_through_uk_border_control? %>
-
-    However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
-
-    ^ If the bio data page in your passport doesn't include a personal ID number, you should apply for a [Visitor in Transit](/transit-visa) visa.
-
-    ## Transiting without a visa
-
-    Even if you don't have a personal ID number, you might be eligible for the 'transit without visa concession' if:
-
-    - you arrive and depart by air
-
-    - have a confirmed onward flight which leaves within 24 hours
-
-    - have the correct documents for your destination (eg a visa for that country)
-
-    ^ The 'transit without visa concession' is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
-
-  <% end %>
+  You won't need a visa to come to the UK
 <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb
@@ -9,7 +9,7 @@
 
   ## Transiting without a visa
 
-  Even if you don't have a personal ID number, you might be eligible for the 'transit without visa concession' if:
+  Even if you don’t have a personal ID number, you might be eligible to transit without visa if:
 
   - you arrive and depart by air
 
@@ -41,5 +41,5 @@
 
   Australian paper confirmation slips are not accepted.
 
-  ^ The 'transit without visa concession' is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
+  ^ Transiting without a visa is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
 <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb
@@ -1,0 +1,29 @@
+<% content_for :title do %>
+  <% if calculator.passing_through_uk_border_control? %>
+    You won't need a visa if your passport has a personal ID number on the bio data page.
+  <% else %>
+    You won't need a visa to come to the UK
+  <% end %>
+<% end %>
+
+<% content_for :body do %>
+  <% if calculator.passing_through_uk_border_control? %>
+
+    However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
+
+    ^ If the bio data page in your passport doesn't include a personal ID number, you should apply for a [Visitor in Transit](/transit-visa) visa.
+
+    ## Transiting without a visa
+
+    Even if you don't have a personal ID number, you might be eligible for the 'transit without visa concession' if:
+
+    - you arrive and depart by air
+
+    - have a confirmed onward flight which leaves within 24 hours
+
+    - have the correct documents for your destination (eg a visa for that country)
+
+    ^ The 'transit without visa concession' is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
+
+  <% end %>
+<% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb
@@ -17,5 +17,29 @@
 
   - have the correct documents for your destination (eg a visa for that country)
 
+  One of the following must also apply:
+
+  - you’re travelling to (or on part of a reasonable journey to) Australia, Canada, New Zealand or the USA and have a valid visa for that country <%= render partial: 'b1_b2_visa_exception.govspeak.erb', locals: {calculator: calculator} %>
+  - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and have a valid visa for that country <%= render partial: 'b1_b2_visa_exception.govspeak.erb', locals: {calculator: calculator} %>
+  - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and it’s less than 6 months since you last entered that country with a valid entry visa <%= render partial: 'b1_b2_visa_exception.govspeak.erb', locals: {calculator: calculator} %>
+  - you have a residence permit issued by Australia or New Zealand
+  - you have a common format residence permit issued by an European Economic Area (EEA) country or Switzerland
+  - you have a residence permit issued by Canada issued after 28 June 2002
+  - you have a uniform format category D visa for entry to a country in the EEA or Switzerland
+  - you have an Irish biometric visa and an onward flight ticket to the Republic of Ireland
+  - you’re travelling from the Republic of Ireland and it’s less than 3 months since you were last given permission, on the basis of holding a valid Irish biometric visa, to land or be in Ireland
+  - you have a valid USA permanent residence card issued by the USA on or after 21 April 1998
+  - you have a valid USA I-551 Temporary Immigrant visa issued by the USA (a wet-ink stamp version will not be accepted)
+  - you have an expired USA I-551 Permanent Residence card issued by the USA on or after 21 April 1998, with a valid I-797 letter authorising extension
+  - you have a valid standalone US Immigration Form 155A/155B issued by the USA (attached to a sealed brown envelope)
+
+  You won’t be able to transit without a visa if a Border Force officer decides you don’t qualify under the immigration rules. You can apply for a transit visa (/transit-visa) before you travel if you’re unsure whether you qualify for transiting without a visa.
+
+  E-visas or e-residence permits are not acceptable for transiting through immigration control without a visa.
+
+  All visas and residence permits must be valid.
+
+  Australian paper confirmation slips are not accepted.
+
   ^ The 'transit without visa concession' is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
 <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb
@@ -1,29 +1,21 @@
 <% content_for :title do %>
-  <% if calculator.passing_through_uk_border_control? %>
-    You won't need a visa if your passport has a personal ID number on the bio data page.
-  <% else %>
-    You won't need a visa to come to the UK
-  <% end %>
+  You won't need a visa if your passport has a personal ID number on the bio data page.
 <% end %>
 
 <% content_for :body do %>
-  <% if calculator.passing_through_uk_border_control? %>
+  However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
 
-    However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
+  ^ If the bio data page in your passport doesn't include a personal ID number, you should apply for a [Visitor in Transit](/transit-visa) visa.
 
-    ^ If the bio data page in your passport doesn't include a personal ID number, you should apply for a [Visitor in Transit](/transit-visa) visa.
+  ## Transiting without a visa
 
-    ## Transiting without a visa
+  Even if you don't have a personal ID number, you might be eligible for the 'transit without visa concession' if:
 
-    Even if you don't have a personal ID number, you might be eligible for the 'transit without visa concession' if:
+  - you arrive and depart by air
 
-    - you arrive and depart by air
+  - have a confirmed onward flight which leaves within 24 hours
 
-    - have a confirmed onward flight which leaves within 24 hours
+  - have the correct documents for your destination (eg a visa for that country)
 
-    - have the correct documents for your destination (eg a visa for that country)
-
-    ^ The 'transit without visa concession' is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
-
-  <% end %>
+  ^ The 'transit without visa concession' is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
 <% end %>

--- a/test/artefacts/check-uk-visa/taiwan/transit/yes.txt
+++ b/test/artefacts/check-uk-visa/taiwan/transit/yes.txt
@@ -1,6 +1,5 @@
 You won't need a visa if your passport has a personal ID number on the bio data page.
 
-
 However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
 
 ^ If the bio data page in your passport doesn't include a personal ID number, you should apply for a [Visitor in Transit](/transit-visa) visa.

--- a/test/artefacts/check-uk-visa/taiwan/transit/yes.txt
+++ b/test/artefacts/check-uk-visa/taiwan/transit/yes.txt
@@ -6,7 +6,7 @@ However, you should bring the [same documents](/government/publications/visitor-
 
 ## Transiting without a visa
 
-Even if you don't have a personal ID number, you might be eligible for the 'transit without visa concession' if:
+Even if you don’t have a personal ID number, you might be eligible to transit without visa if:
 
 - you arrive and depart by air
 
@@ -38,5 +38,5 @@ All visas and residence permits must be valid.
 
 Australian paper confirmation slips are not accepted.
 
-^ The 'transit without visa concession' is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
+^ Transiting without a visa is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
 

--- a/test/artefacts/check-uk-visa/taiwan/transit/yes.txt
+++ b/test/artefacts/check-uk-visa/taiwan/transit/yes.txt
@@ -14,5 +14,29 @@ Even if you don't have a personal ID number, you might be eligible for the 'tran
 
 - have the correct documents for your destination (eg a visa for that country)
 
+One of the following must also apply:
+
+- you’re travelling to (or on part of a reasonable journey to) Australia, Canada, New Zealand or the USA and have a valid visa for that country 
+- you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and have a valid visa for that country 
+- you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and it’s less than 6 months since you last entered that country with a valid entry visa 
+- you have a residence permit issued by Australia or New Zealand
+- you have a common format residence permit issued by an European Economic Area (EEA) country or Switzerland
+- you have a residence permit issued by Canada issued after 28 June 2002
+- you have a uniform format category D visa for entry to a country in the EEA or Switzerland
+- you have an Irish biometric visa and an onward flight ticket to the Republic of Ireland
+- you’re travelling from the Republic of Ireland and it’s less than 3 months since you were last given permission, on the basis of holding a valid Irish biometric visa, to land or be in Ireland
+- you have a valid USA permanent residence card issued by the USA on or after 21 April 1998
+- you have a valid USA I-551 Temporary Immigrant visa issued by the USA (a wet-ink stamp version will not be accepted)
+- you have an expired USA I-551 Permanent Residence card issued by the USA on or after 21 April 1998, with a valid I-797 letter authorising extension
+- you have a valid standalone US Immigration Form 155A/155B issued by the USA (attached to a sealed brown envelope)
+
+You won’t be able to transit without a visa if a Border Force officer decides you don’t qualify under the immigration rules. You can apply for a transit visa (/transit-visa) before you travel if you’re unsure whether you qualify for transiting without a visa.
+
+E-visas or e-residence permits are not acceptable for transiting through immigration control without a visa.
+
+All visas and residence permits must be valid.
+
+Australian paper confirmation slips are not accepted.
+
 ^ The 'transit without visa concession' is decided by the immigration officer at the border. You won't be allowed to transit if they decide you need a visa, so you might want to apply for a transit visa before you travel.
 

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,7 +1,7 @@
 ---
-lib/smart_answer_flows/check-uk-visa.rb: 102a55efaa689d2d0ae8dc1d4bada310
+lib/smart_answer_flows/check-uk-visa.rb: 39209fe763decf718a50df08cd353003
 test/data/check-uk-visa-questions-and-responses.yml: 1c812e8d00a9dc8525848e643f1ae0e0
-test/data/check-uk-visa-responses-and-expected-results.yml: db29eb80b3205754f015032719de9774
+test/data/check-uk-visa-responses-and-expected-results.yml: e4ece324545e65d70a904c58b811a14f
 lib/smart_answer_flows/check-uk-visa/check_uk_visa.govspeak.erb: a442b4ddd169b26a401c70d145e5b44e
 lib/smart_answer_flows/check-uk-visa/outcomes/_b1_b2_visa_exception.govspeak.erb: 410e39d565d0a5caed2d1b8c20c1ca77
 lib/smart_answer_flows/check-uk-visa/outcomes/_stateless_or_refugee.govspeak.erb: a14d7807087e4f05e9fada8ac755ee2e
@@ -23,7 +23,8 @@ lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_leaving_airport.go
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_leaving_airport_datv.govspeak.erb: 1d0ce7899e540d7a21023613cfab48e7
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_not_leaving_airport.govspeak.erb: 3ea6330e57bb70c6fa07ef0c949f24ab
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_refugee_not_leaving_airport.govspeak.erb: a344b0c62367eac3e00d048563b636dd
-lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan.govspeak.erb: f08df194085f5fb41077a7e0815dcb5c
+lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan.govspeak.erb: 72a43a01e16942fd7ffce864e5b1bdee
+lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb: ee519450526cc90ead79ee29021f04a6
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_venezuela.govspeak.erb: bae2c1566964317ca3d92b5b1d8a21f3
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver.govspeak.erb: 7a56f0a6b714bb114cb3f966497d9b4e
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_m.govspeak.erb: 2a2021fec2f3a63d873bb1f48206349d

--- a/test/data/check-uk-visa-responses-and-expected-results.yml
+++ b/test/data/check-uk-visa-responses-and-expected-results.yml
@@ -973,7 +973,7 @@
   - taiwan
   - transit
   - 'yes'
-  :next_node: :outcome_transit_taiwan
+  :next_node: :outcome_transit_taiwan_through_border_control
   :outcome_node: true
 - :current_node: :passing_through_uk_border_control?
   :responses:


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/108940222

I've split the "outcome_transit_taiwan" into two: one for visitors passing through UK Border Control and one for visitors not passing through UK Border Control. I've then made the requested changes to the outcome shown when visitors from Taiwan are transiting and passing through UK Border Control.

## Factcheck

* [Taiwan - Transiting and passing through UK Border Control](https://smart-answers-pr-2164.herokuapp.com/check-uk-visa/y/taiwan/transit/yes)

## Expected changes

* [URL on gov.uk](https://www.gov.uk/check-uk-visa/y/taiwan/transit/yes)
  * Multiple changes to "Transiting without a visa"

### Before

![pr-2164-before](https://cloud.githubusercontent.com/assets/6556/11372531/f4f678d4-92c5-11e5-9641-e5e4df18e291.png)

### After

![pr-2164-after](https://cloud.githubusercontent.com/assets/6556/11372541/fb271916-92c5-11e5-927b-69fd5c48672e.png)