### PR TITLE
Child maintenance calculator update for November 2015

### DIFF
--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -13,8 +13,8 @@
 
   ##What you need to know:##
 
-  - the calculator gives an estimate (it won't cover variations for exceptional circumstances)
-  - you need information about your income
+  - the calculator only gives an estimate - it may not give the right result for complicated circumstances
+  - you need information about the income of the parent who'll be paying
   - if you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](/child-support-agency) - they’ll tell you if your child maintenance payments will change
 
   Check the [child maintenance rates](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance) before you use the calculator.

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -15,7 +15,7 @@
 
   Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the [Child Support Agency](/child-maintenance/contact) (CSA).
 
-  ^The calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if the paying parent has children from a different relationship.^
+  ^The calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if the paying parent has children from a different relationship^
 
   ##Before you start
   

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -7,9 +7,9 @@
 <% end %>
 
 <% content_for :body do %>
-  
-  You can use this calculator to estimate your child maintenance. It can help you to:   
-  
+
+  You can use this calculator to estimate your child maintenance. It can help you to:
+
   * agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
   * get an idea of the amount the government would work out for you (including collection and application fees)
 
@@ -18,14 +18,14 @@
   ^The calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if the paying parent also has children from a different relationship.^
 
   ##Before you start
-  
+
   You need information about the income of the parent who'll be paying.
 
   Check the [child maintenance rates](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance) before you use the calculator.
 
   ##If your circumstances have changed
 
-  If you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](https://www.gov.uk/child-maintenance/contact). They’ll tell you if your child maintenance payments will change.   
+  If you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](/child-maintenance/contact). They’ll tell you if your child maintenance payments will change.
 
   *[CSA]: Child Support Agency
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -13,7 +13,7 @@
 
   ##What you need to know:##
 
-  - the calculator only gives an estimate - it may not give the right result for complicated circumstances
+  - the calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if you have children by different partners
   - you need information about the income of the parent who'll be paying
   - if you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](/child-support-agency) - they’ll tell you if your child maintenance payments will change
 

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -7,17 +7,25 @@
 <% end %>
 
 <% content_for :body do %>
-  Use the calculator to agree on a child maintenance amount if [you’re arranging it yourselves](/arranging-child-maintenance-yourself), or to get an idea of the statutory amount the government would work out for you (including collection and application fees).
+  
+  You can use this calculator to estimate your child maintenance. It can help you to:   
+  
+  * agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
+  * get an idea of the amount the government would work out for you (including collection and application fees)
 
-  Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the Child Support Agency (CSA).
+  Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the [Child Support Agency](/child-maintenance/contact) (CSA).
 
-  ##What you need to know:##
+  ^The calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if the paying parent has children from a different relationship.^
 
-  - the calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if you have children by different partners
-  - you need information about the income of the parent who'll be paying
-  - if you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](/child-support-agency) - they’ll tell you if your child maintenance payments will change
+  ##Before you start
+  
+  You need information about the income of the parent who'll be paying.
 
   Check the [child maintenance rates](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance) before you use the calculator.
+
+  ##If your circumstances have changed
+
+  If you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](https://www.gov.uk/child-maintenance/contact). They’ll tell you if your child maintenance payments will change.   
 
   *[CSA]: Child Support Agency
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -15,7 +15,7 @@
 
   Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the [Child Support Agency](/child-maintenance/contact) (CSA).
 
-  ^The calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if the paying parent has children from a different relationship^
+  ^The calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if the paying parent also has children from a different relationship.^
 
   ##Before you start
   

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
@@ -4,9 +4,7 @@
   else
     fees_title = 'Fees | Total amount you’ll receive'
   end %>
-  Based on your answers the child maintenance payment is the flat rate of £<%= flat_rate_amount %> per week.
-
-  This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
+  Based on your answers the child maintenance payment is the flat rate of £<%= flat_rate_amount %> per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
   This is the total weekly amount, not the amount per child.  
 

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
@@ -12,7 +12,7 @@
 
   Payment type | Weekly flat rate payment | <%= fees_title %> | Application fee  - you only pay this once
   - | -
-  [Collect and pay](/child-maintenance/how-to-pay) | £<%= flat_rate_amount %> | £<%= collect_fees %> | £<%= total_fees %> | £20.00
+  [Collect and Pay](/child-maintenance/how-to-pay) | £<%= flat_rate_amount %> | £<%= collect_fees %> | £<%= total_fees %> | £20.00
   [Direct pay](/child-maintenance/how-to-pay) | £<%= flat_rate_amount %> | No fees | £<%= flat_rate_amount %> | £20.00
   [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £<%= flat_rate_amount %> | No fees | £<%= flat_rate_amount %> | No fee
 
@@ -25,5 +25,5 @@
     You may also have to pay an enforcement charge if you don’t make your full payments on time.
   <% end %>
 
-  Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+  Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
@@ -6,7 +6,9 @@
   end %>
   Based on your answers the child maintenance payment is the flat rate of £<%= flat_rate_amount %> per week.
 
-  This is the total weekly amount, not the amount per child.
+  This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
+
+  This is the total weekly amount, not the amount per child.  
 
   Depending on how child maintenance is arranged, fees may be added to this amount.
 
@@ -24,8 +26,6 @@
   <% if paying_or_receiving == 'pay' %>
     You may also have to pay an enforcement charge if you don’t make your full payments on time.
   <% end %>
-
-  The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
   Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
@@ -8,7 +8,9 @@
 
   This is the total weekly amount, not the amount per child.  
 
+  <% if paying_or_receiving == 'pay' %>
   Depending on how child maintenance is arranged, fees may be added to this amount.
+  <% end %>
 
   Payment type | Weekly flat rate payment | <%= fees_title %> | Application fee  - you only pay this once
   - | -

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb
@@ -6,10 +6,10 @@
   end %>
   Based on your answers the child maintenance payment is the flat rate of £<%= flat_rate_amount %> per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-  This is the total weekly amount, not the amount per child.  
+  This is the total weekly amount, not the amount per child.
 
   <% if paying_or_receiving == 'pay' %>
-  Depending on how child maintenance is arranged, fees may be added to this amount.
+    Depending on how child maintenance is arranged, fees may be added to this amount.
   <% end %>
 
   Payment type | Weekly flat rate payment | <%= fees_title %> | Application fee  - you only pay this once

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/nil_rate_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/nil_rate_result.govspeak.erb
@@ -9,5 +9,5 @@
 
   The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-  Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+  Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
@@ -6,6 +6,8 @@
   end %>
   Based on your answers the child maintenance payment is the <%= rate_type_formatted %> rate of £<%= child_maintenance_payment %> per week.
 
+  The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.<% if paying_or_receiving == 'receive' %> For example, if the paying parent supports other children, the amount you receive may be less than this.<% end %>
+
   This is the total weekly amount, not the amount per child.
 
   Depending on how child maintenance is arranged, fees may be added to this amount.
@@ -25,7 +27,6 @@
     You may also have to pay an enforcement charge if you don’t make your full payments on time.
   <% end %>
 
-  The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
   Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
@@ -6,15 +6,15 @@
   end %>
   Based on your answers the child maintenance payment is the <%= rate_type_formatted %> rate of £<%= child_maintenance_payment %> per week.
 
-  The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.<% if paying_or_receiving == 'receive' %> For example, if the paying parent supports other children, the amount you receive may be less than this.<% end %>
+  ^This is the total weekly amount, not the amount per child.^
 
-  This is the total weekly amount, not the amount per child.
+  The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.<% if paying_or_receiving == 'receive' %> For example, if the paying parent supports other children, the amount you receive may be less than this.<% end %>
 
   Depending on how child maintenance is arranged, fees may be added to this amount.
 
   Payment type | Weekly payment | <%= fees_title %> | Application fee  - you only pay this once
   - | -
-  [Collect and pay](/child-maintenance/how-to-pay) | £<%= child_maintenance_payment %> | £<%= collect_fees %> | £<%= total_fees %> | £20.00
+  [Collect and Pay](/child-maintenance/how-to-pay) | £<%= child_maintenance_payment %> | £<%= collect_fees %> | £<%= total_fees %> | £20.00
   [Direct pay](/child-maintenance/how-to-pay) | £<%= child_maintenance_payment %> | No fees | £<%= child_maintenance_payment %> | £20.00
   [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £<%= child_maintenance_payment %> | No fees | £<%= child_maintenance_payment %> | No fee
 
@@ -28,5 +28,5 @@
   <% end %>
 
 
-  Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+  Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
@@ -8,10 +8,12 @@
 
   ^This is the total weekly amount, not the amount per child.^
 
-  The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.<% if paying_or_receiving == 'receive' %> For example, if the paying parent supports other children, the amount you receive may be less than this.<% end %>
+  The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.<% if paying_or_receiving == 'receive' %> For example, if the paying parent also supports other children, the amount you receive may be less than this.<% end %>
 
+  <% if paying_or_receiving == 'pay' %>
   Depending on how child maintenance is arranged, fees may be added to this amount.
-
+  <% end %>
+  
   Payment type | Weekly payment | <%= fees_title %> | Application fee  - you only pay this once
   - | -
   [Collect and Pay](/child-maintenance/how-to-pay) | £<%= child_maintenance_payment %> | £<%= collect_fees %> | £<%= total_fees %> | £20.00

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
@@ -8,7 +8,10 @@
 
   ^This is the total weekly amount, not the amount per child.^
 
-  The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.<% if paying_or_receiving == 'receive' %> For example, if the paying parent also supports other children, the amount you receive may be less than this.<% end %>
+  The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+  <% if paying_or_receiving == 'receive' %>
+    For example, if the paying parent also supports other children, the amount you receive may be less than this.
+  <% end %>
 
   <% if paying_or_receiving == 'pay' %>
     Depending on how child maintenance is arranged, fees may be added to this amount.

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb
@@ -11,9 +11,9 @@
   The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.<% if paying_or_receiving == 'receive' %> For example, if the paying parent also supports other children, the amount you receive may be less than this.<% end %>
 
   <% if paying_or_receiving == 'pay' %>
-  Depending on how child maintenance is arranged, fees may be added to this amount.
+    Depending on how child maintenance is arranged, fees may be added to this amount.
   <% end %>
-  
+
   Payment type | Weekly payment | <%= fees_title %> | Application fee  - you only pay this once
   - | -
   [Collect and Pay](/child-maintenance/how-to-pay) | £<%= child_maintenance_payment %> | £<%= collect_fees %> | £<%= total_fees %> | £20.00

--- a/test/artefacts/calculate-your-child-maintenance/calculate-your-child-maintenance.txt
+++ b/test/artefacts/calculate-your-child-maintenance/calculate-your-child-maintenance.txt
@@ -1,16 +1,24 @@
 Child maintenance calculator
 
-Use the calculator to agree on a child maintenance amount if [you’re arranging it yourselves](/arranging-child-maintenance-yourself), or to get an idea of the statutory amount the government would work out for you (including collection and application fees).
 
-Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the Child Support Agency (CSA).
+You can use this calculator to estimate your child maintenance. It can help you to:
 
-##What you need to know:##
+* agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
+* get an idea of the amount the government would work out for you (including collection and application fees)
 
-- the calculator gives an estimate (it won't cover variations for exceptional circumstances)
-- you need information about your income
-- if you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](/child-support-agency) - they’ll tell you if your child maintenance payments will change
+Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the [Child Support Agency](/child-maintenance/contact) (CSA).
+
+^The calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if the paying parent also has children from a different relationship.^
+
+##Before you start
+
+You need information about the income of the parent who'll be paying.
 
 Check the [child maintenance rates](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance) before you use the calculator.
+
+##If your circumstances have changed
+
+If you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](/child-maintenance/contact). They’ll tell you if your child maintenance payments will change.
 
 *[CSA]: Child Support Agency
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/0.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £100.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £100.00 | £20.00 | £120.00 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £100.00 | £20.00 | £120.00 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £100.00 | No fees | £100.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £100.00 | No fees | £100.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £1040.00 in fees per year if you pay child maintenance throu
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/1.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £85.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £85.00 | £17.00 | £102.00 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £85.00 | £17.00 | £102.00 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £85.00 | No fees | £85.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £85.00 | No fees | £85.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £884.00 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/2.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £71.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £71.00 | £14.20 | £85.20 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £71.00 | £14.20 | £85.20 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £71.00 | No fees | £71.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £71.00 | No fees | £71.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £738.40 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/3.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £57.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £57.00 | £11.40 | £68.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £57.00 | £11.40 | £68.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £57.00 | No fees | £57.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £57.00 | No fees | £57.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £592.80 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/1000.0/3/4.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £43.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £43.00 | £8.60 | £51.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £43.00 | £8.60 | £51.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £43.00 | No fees | £43.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £43.00 | No fees | £43.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £447.20 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/0.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £13.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £13.00 | £2.60 | £15.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £13.00 | £2.60 | £15.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £13.00 | No fees | £13.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £13.00 | No fees | £13.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £135.20 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/1.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £11.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £11.00 | £2.20 | £13.20 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £11.00 | £2.20 | £13.20 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £11.00 | No fees | £11.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £11.00 | No fees | £11.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £114.40 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/2.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £9.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £9.00 | £1.80 | £10.80 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £9.00 | £1.80 | £10.80 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £9.00 | No fees | £9.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £9.00 | No fees | £9.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £93.60 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/3.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £8.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £8.00 | £1.60 | £9.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £8.00 | £1.60 | £9.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £8.00 | No fees | £8.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £8.00 | No fees | £8.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £83.20 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.0/3/4.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/0.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £20.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £20.00 | £4.00 | £24.00 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £20.00 | £4.00 | £24.00 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £20.00 | No fees | £20.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £20.00 | No fees | £20.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £208.00 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/1.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £17.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £17.00 | £3.40 | £20.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £17.00 | £3.40 | £20.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £17.00 | No fees | £17.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £17.00 | No fees | £17.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £176.80 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/2.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £14.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £14.00 | £2.80 | £16.80 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £14.00 | £2.80 | £16.80 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £14.00 | No fees | £14.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £14.00 | No fees | £14.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £145.60 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/3.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £12.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £12.00 | £2.40 | £14.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £12.00 | £2.40 | £14.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £12.00 | No fees | £12.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £12.00 | No fees | £12.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £124.80 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/200.0/3/4.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/5.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/5.txt
@@ -6,5 +6,5 @@ This is because the income of the parent paying child maintenance is too low.
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/90.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/90.txt
@@ -1,6 +1,6 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
@@ -8,7 +8,7 @@ Depending on how child maintenance is arranged, fees may be added to this amount
 
 Payment type | Weekly flat rate payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +18,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/0.txt
@@ -1,6 +1,6 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
@@ -8,7 +8,7 @@ Depending on how child maintenance is arranged, fees may be added to this amount
 
 Payment type | Weekly flat rate payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +18,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/1.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/2.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/3.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes/4.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/0.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £133.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £133.00 | £26.60 | £159.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £133.00 | £26.60 | £159.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £133.00 | No fees | £133.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £133.00 | No fees | £133.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £1383.20 in fees per year if you pay child maintenance throu
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/1.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £114.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £114.00 | £22.80 | £136.80 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £114.00 | £22.80 | £136.80 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £114.00 | No fees | £114.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £114.00 | No fees | £114.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £1185.60 in fees per year if you pay child maintenance throu
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/2.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £95.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £95.00 | £19.00 | £114.00 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £95.00 | £19.00 | £114.00 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £95.00 | No fees | £95.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £95.00 | No fees | £95.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £988.00 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/3.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £76.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £76.00 | £15.20 | £91.20 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £76.00 | £15.20 | £91.20 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £76.00 | No fees | £76.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £76.00 | No fees | £76.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £790.40 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/1000.0/3/4.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £52.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £52.00 | £10.40 | £62.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £52.00 | £10.40 | £62.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £52.00 | No fees | £52.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £52.00 | No fees | £52.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £540.80 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/0.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £16.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £16.00 | £3.20 | £19.20 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £16.00 | £3.20 | £19.20 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £16.00 | No fees | £16.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £16.00 | No fees | £16.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £166.40 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/1.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £14.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £14.00 | £2.80 | £16.80 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £14.00 | £2.80 | £16.80 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £14.00 | No fees | £14.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £14.00 | No fees | £14.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £145.60 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/2.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £12.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £12.00 | £2.40 | £14.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £12.00 | £2.40 | £14.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £12.00 | No fees | £12.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £12.00 | No fees | £12.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £124.80 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/3.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £9.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £9.00 | £1.80 | £10.80 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £9.00 | £1.80 | £10.80 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £9.00 | No fees | £9.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £9.00 | No fees | £9.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £93.60 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/150.0/3/4.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/0.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £27.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £27.00 | £5.40 | £32.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £27.00 | £5.40 | £32.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £27.00 | No fees | £27.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £27.00 | No fees | £27.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £280.80 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/1.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £23.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £23.00 | £4.60 | £27.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £23.00 | £4.60 | £27.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £23.00 | No fees | £23.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £23.00 | No fees | £23.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £239.20 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/2.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £19.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £19.00 | £3.80 | £22.80 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £19.00 | £3.80 | £22.80 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £19.00 | No fees | £19.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £19.00 | No fees | £19.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £197.60 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/3.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £15.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £15.00 | £3.00 | £18.00 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £15.00 | £3.00 | £18.00 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £15.00 | No fees | £15.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £15.00 | No fees | £15.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £156.00 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/200.0/3/4.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/5.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/5.txt
@@ -6,5 +6,5 @@ This is because the income of the parent paying child maintenance is too low.
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/90.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/no/90.txt
@@ -1,6 +1,6 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
@@ -8,7 +8,7 @@ Depending on how child maintenance is arranged, fees may be added to this amount
 
 Payment type | Weekly flat rate payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +18,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/0.txt
@@ -1,6 +1,6 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
@@ -8,7 +8,7 @@ Depending on how child maintenance is arranged, fees may be added to this amount
 
 Payment type | Weekly flat rate payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +18,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/1.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/2.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/3.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/2_children/yes/4.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/0.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £158.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £158.00 | £31.60 | £189.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £158.00 | £31.60 | £189.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £158.00 | No fees | £158.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £158.00 | No fees | £158.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £1643.20 in fees per year if you pay child maintenance throu
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/1.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £135.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £135.00 | £27.00 | £162.00 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £135.00 | £27.00 | £162.00 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £135.00 | No fees | £135.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £135.00 | No fees | £135.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £1404.00 in fees per year if you pay child maintenance throu
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/2.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £113.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £113.00 | £22.60 | £135.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £113.00 | £22.60 | £135.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £113.00 | No fees | £113.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £113.00 | No fees | £113.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £1175.20 in fees per year if you pay child maintenance throu
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/3.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £90.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £90.00 | £18.00 | £108.00 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £90.00 | £18.00 | £108.00 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £90.00 | No fees | £90.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £90.00 | No fees | £90.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £936.00 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/1000.0/3/4.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £58.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £58.00 | £11.60 | £69.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £58.00 | £11.60 | £69.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £58.00 | No fees | £58.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £58.00 | No fees | £58.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £603.20 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/0.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £19.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £19.00 | £3.80 | £22.80 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £19.00 | £3.80 | £22.80 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £19.00 | No fees | £19.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £19.00 | No fees | £19.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £197.60 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/1.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £16.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £16.00 | £3.20 | £19.20 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £16.00 | £3.20 | £19.20 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £16.00 | No fees | £16.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £16.00 | No fees | £16.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £166.40 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/2.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £13.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £13.00 | £2.60 | £15.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £13.00 | £2.60 | £15.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £13.00 | No fees | £13.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £13.00 | No fees | £13.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £135.20 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/3.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £11.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £11.00 | £2.20 | £13.20 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £11.00 | £2.20 | £13.20 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £11.00 | No fees | £11.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £11.00 | No fees | £11.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £114.40 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/150.0/3/4.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/0.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £32.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £32.00 | £6.40 | £38.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £32.00 | £6.40 | £38.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £32.00 | No fees | £32.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £32.00 | No fees | £32.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £332.80 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/1.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £27.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £27.00 | £5.40 | £32.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £27.00 | £5.40 | £32.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £27.00 | No fees | £27.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £27.00 | No fees | £27.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £280.80 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/2.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £23.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £23.00 | £4.60 | £27.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £23.00 | £4.60 | £27.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £23.00 | No fees | £23.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £23.00 | No fees | £23.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £239.20 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/3.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £18.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £18.00 | £3.60 | £21.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £18.00 | £3.60 | £21.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £18.00 | No fees | £18.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £18.00 | No fees | £18.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £187.20 in fees per year if you pay child maintenance throug
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/200.0/3/4.txt
@@ -2,13 +2,15 @@
 
 Based on your answers the child maintenance payment is the basic rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
+
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
 
 Depending on how child maintenance is arranged, fees may be added to this amount.
 
 Payment type | Weekly payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +20,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/5.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/5.txt
@@ -6,5 +6,5 @@ This is because the income of the parent paying child maintenance is too low.
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/90.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/no/90.txt
@@ -1,6 +1,6 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
@@ -8,7 +8,7 @@ Depending on how child maintenance is arranged, fees may be added to this amount
 
 Payment type | Weekly flat rate payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +18,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/0.txt
@@ -1,6 +1,6 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
@@ -8,7 +8,7 @@ Depending on how child maintenance is arranged, fees may be added to this amount
 
 Payment type | Weekly flat rate payment | Additional weekly fees | Total amount to pay per week | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £1.40 | £8.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -18,7 +18,5 @@ You will pay up to £72.80 in fees per year if you pay child maintenance through
 
 You may also have to pay an enforcement charge if you don’t make your full payments on time.
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/1.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/2.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/3.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/3_children/yes/4.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/0.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £100.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £100.00 | £4.00 | £96.00 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £100.00 | £4.00 | £96.00 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £100.00 | No fees | £100.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £100.00 | No fees | £100.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £208.00 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/1.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £85.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £85.00 | £3.40 | £81.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £85.00 | £3.40 | £81.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £85.00 | No fees | £85.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £85.00 | No fees | £85.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £176.80 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/2.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £71.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £71.00 | £2.84 | £68.16 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £71.00 | £2.84 | £68.16 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £71.00 | No fees | £71.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £71.00 | No fees | £71.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £147.68 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/3.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £57.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £57.00 | £2.28 | £54.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £57.00 | £2.28 | £54.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £57.00 | No fees | £57.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £57.00 | No fees | £57.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £118.56 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/1000.0/3/4.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £43.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £43.00 | £1.72 | £41.28 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £43.00 | £1.72 | £41.28 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £43.00 | No fees | £43.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £43.00 | No fees | £43.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £89.44 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/0.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £13.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £13.00 | £0.52 | £12.48 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £13.00 | £0.52 | £12.48 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £13.00 | No fees | £13.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £13.00 | No fees | £13.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £27.04 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/1.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £11.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £11.00 | £0.44 | £10.56 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £11.00 | £0.44 | £10.56 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £11.00 | No fees | £11.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £11.00 | No fees | £11.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £22.88 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/2.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £9.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £9.00 | £0.36 | £8.64 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £9.00 | £0.36 | £8.64 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £9.00 | No fees | £9.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £9.00 | No fees | £9.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £18.72 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/3.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £8.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £8.00 | £0.32 | £7.68 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £8.00 | £0.32 | £7.68 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £8.00 | No fees | £8.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £8.00 | No fees | £8.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £16.64 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/150.0/3/4.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/0.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £20.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £20.00 | £0.80 | £19.20 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £20.00 | £0.80 | £19.20 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £20.00 | No fees | £20.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £20.00 | No fees | £20.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £41.60 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/1.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £17.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £17.00 | £0.68 | £16.32 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £17.00 | £0.68 | £16.32 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £17.00 | No fees | £17.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £17.00 | No fees | £17.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £35.36 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/2.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £14.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £14.00 | £0.56 | £13.44 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £14.00 | £0.56 | £13.44 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £14.00 | No fees | £14.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £14.00 | No fees | £14.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £29.12 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/3.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £12.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £12.00 | £0.48 | £11.52 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £12.00 | £0.48 | £11.52 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £12.00 | No fees | £12.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £12.00 | No fees | £12.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £24.96 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/200.0/3/4.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/5.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/5.txt
@@ -6,5 +6,5 @@ This is because the income of the parent paying child maintenance is too low.
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/90.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/no/90.txt
@@ -1,14 +1,12 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
-
 Payment type | Weekly flat rate payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +14,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/0.txt
@@ -1,14 +1,12 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
-
 Payment type | Weekly flat rate payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +14,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/1.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/2.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/3.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/1_child/yes/4.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/0.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £133.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £133.00 | £5.32 | £127.68 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £133.00 | £5.32 | £127.68 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £133.00 | No fees | £133.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £133.00 | No fees | £133.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £276.64 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/1.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £114.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £114.00 | £4.56 | £109.44 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £114.00 | £4.56 | £109.44 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £114.00 | No fees | £114.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £114.00 | No fees | £114.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £237.12 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/2.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £95.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £95.00 | £3.80 | £91.20 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £95.00 | £3.80 | £91.20 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £95.00 | No fees | £95.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £95.00 | No fees | £95.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £197.60 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/3.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £76.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £76.00 | £3.04 | £72.96 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £76.00 | £3.04 | £72.96 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £76.00 | No fees | £76.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £76.00 | No fees | £76.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £158.08 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/1000.0/3/4.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £52.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £52.00 | £2.08 | £49.92 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £52.00 | £2.08 | £49.92 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £52.00 | No fees | £52.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £52.00 | No fees | £52.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £108.16 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/0.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £16.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £16.00 | £0.64 | £15.36 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £16.00 | £0.64 | £15.36 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £16.00 | No fees | £16.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £16.00 | No fees | £16.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £33.28 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/1.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £14.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £14.00 | £0.56 | £13.44 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £14.00 | £0.56 | £13.44 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £14.00 | No fees | £14.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £14.00 | No fees | £14.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £29.12 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/2.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £12.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £12.00 | £0.48 | £11.52 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £12.00 | £0.48 | £11.52 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £12.00 | No fees | £12.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £12.00 | No fees | £12.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £24.96 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/3.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £9.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £9.00 | £0.36 | £8.64 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £9.00 | £0.36 | £8.64 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £9.00 | No fees | £9.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £9.00 | No fees | £9.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £18.72 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/150.0/3/4.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/0.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £27.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £27.00 | £1.08 | £25.92 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £27.00 | £1.08 | £25.92 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £27.00 | No fees | £27.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £27.00 | No fees | £27.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £56.16 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/1.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £23.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £23.00 | £0.92 | £22.08 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £23.00 | £0.92 | £22.08 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £23.00 | No fees | £23.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £23.00 | No fees | £23.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £47.84 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/2.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £19.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £19.00 | £0.76 | £18.24 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £19.00 | £0.76 | £18.24 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £19.00 | No fees | £19.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £19.00 | No fees | £19.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £39.52 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/3.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £15.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £15.00 | £0.60 | £14.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £15.00 | £0.60 | £14.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £15.00 | No fees | £15.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £15.00 | No fees | £15.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £31.20 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/200.0/3/4.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/5.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/5.txt
@@ -6,5 +6,5 @@ This is because the income of the parent paying child maintenance is too low.
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/90.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/no/90.txt
@@ -1,14 +1,12 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
-
 Payment type | Weekly flat rate payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +14,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/0.txt
@@ -1,14 +1,12 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
-
 Payment type | Weekly flat rate payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +14,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/1.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/2.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/3.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/2_children/yes/4.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/0.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £158.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £158.00 | £6.32 | £151.68 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £158.00 | £6.32 | £151.68 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £158.00 | No fees | £158.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £158.00 | No fees | £158.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £328.64 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/1.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £135.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £135.00 | £5.40 | £129.60 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £135.00 | £5.40 | £129.60 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £135.00 | No fees | £135.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £135.00 | No fees | £135.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £280.80 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/2.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £113.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £113.00 | £4.52 | £108.48 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £113.00 | £4.52 | £108.48 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £113.00 | No fees | £113.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £113.00 | No fees | £113.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £235.04 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/3.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £90.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £90.00 | £3.60 | £86.40 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £90.00 | £3.60 | £86.40 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £90.00 | No fees | £90.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £90.00 | No fees | £90.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £187.20 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/1000.0/3/4.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic plus rate of £58.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £58.00 | £2.32 | £55.68 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £58.00 | £2.32 | £55.68 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £58.00 | No fees | £58.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £58.00 | No fees | £58.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £120.64 in fees per year if you receive child maintenance th
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/0.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £19.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £19.00 | £0.76 | £18.24 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £19.00 | £0.76 | £18.24 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £19.00 | No fees | £19.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £19.00 | No fees | £19.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £39.52 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/1.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £16.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £16.00 | £0.64 | £15.36 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £16.00 | £0.64 | £15.36 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £16.00 | No fees | £16.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £16.00 | No fees | £16.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £33.28 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/2.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £13.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £13.00 | £0.52 | £12.48 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £13.00 | £0.52 | £12.48 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £13.00 | No fees | £13.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £13.00 | No fees | £13.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £27.04 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/3.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £11.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £11.00 | £0.44 | £10.56 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £11.00 | £0.44 | £10.56 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £11.00 | No fees | £11.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £11.00 | No fees | £11.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £22.88 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/150.0/3/4.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the reduced rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/0.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £32.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £32.00 | £1.28 | £30.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £32.00 | £1.28 | £30.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £32.00 | No fees | £32.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £32.00 | No fees | £32.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £66.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/1.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £27.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £27.00 | £1.08 | £25.92 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £27.00 | £1.08 | £25.92 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £27.00 | No fees | £27.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £27.00 | No fees | £27.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £56.16 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/2.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £23.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £23.00 | £0.92 | £22.08 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £23.00 | £0.92 | £22.08 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £23.00 | No fees | £23.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £23.00 | No fees | £23.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £47.84 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/3.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £18.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £18.00 | £0.72 | £17.28 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £18.00 | £0.72 | £17.28 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £18.00 | No fees | £18.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £18.00 | No fees | £18.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £37.44 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/200.0/3/4.txt
@@ -2,13 +2,14 @@
 
 Based on your answers the child maintenance payment is the basic rate of £7.00 per week.
 
-This is the total weekly amount, not the amount per child.
+^This is the total weekly amount, not the amount per child.^
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
+The calculator gives an estimate. The exact amount the Child Maintenance Service calculates might be different.
+For example, if the paying parent also supports other children, the amount you receive may be less than this.
 
 Payment type | Weekly payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +17,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/5.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/5.txt
@@ -6,5 +6,5 @@ This is because the income of the parent paying child maintenance is too low.
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/90.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/no/90.txt
@@ -1,14 +1,12 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
-
 Payment type | Weekly flat rate payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +14,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/0.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/0.txt
@@ -1,14 +1,12 @@
 
 
-Based on your answers the child maintenance payment is the flat rate of £7.00 per week.
+Based on your answers the child maintenance payment is the flat rate of £7.00 per week. This is an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
 This is the total weekly amount, not the amount per child.
 
-Depending on how child maintenance is arranged, fees may be added to this amount.
-
 Payment type | Weekly flat rate payment | Fees | Total amount you’ll receive | Application fee  - you only pay this once
 - | -
-[Collect and pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
+[Collect and Pay](/child-maintenance/how-to-pay) | £7.00 | £0.28 | £6.72 | £20.00
 [Direct pay](/child-maintenance/how-to-pay) | £7.00 | No fees | £7.00 | £20.00
 [Arranging child maintenance yourself](/arranging-child-maintenance-yourself) | £7.00 | No fees | £7.00 | No fee
 
@@ -16,7 +14,5 @@ You will pay up to £14.56 in fees per year if you receive child maintenance thr
 
 ^You don’t have to pay an application fee if you’re in Northern Ireland.^
 
-The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
-
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/child-maintenance-rates)
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/child-maintenance-rates).
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/1.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/1.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/2.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/2.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/3.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/3.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/4.txt
+++ b/test/artefacts/calculate-your-child-maintenance/receive/3_children/yes/4.txt
@@ -6,5 +6,5 @@ This is because the parent paying child maintenance is receiving benefits and th
 
 The calculator gives an estimate. The exact amount the Child Maintenance Service would calculate might be different.
 
-Read more about [how child maintenance is worked out.](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out")
+Read more about [how child maintenance is worked out](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance "How child maintenance is worked out").
 

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -2,10 +2,10 @@
 lib/smart_answer_flows/calculate-your-child-maintenance.rb: b05aeb72fdad417824cadc0d184db5f8
 test/data/calculate-your-child-maintenance-questions-and-responses.yml: 4534340cf82c2d7f24a865a8b70855fd
 test/data/calculate-your-child-maintenance-responses-and-expected-results.yml: e5f2d15987daf89c77c28fc4b4b82042
-lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: db4b69fb1cc09b84be5cd2b9d274a306
-lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb: c27b2a2ec4a8ebe045d0375776b53d65
-lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/nil_rate_result.govspeak.erb: a2f84eae46c14b8df94802f46fb31ba5
-lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb: 30eb046dfea51fa4bb5e3a3bb55f7a7a
+lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: 54774b8368ca04904d29c4857b8178ef
+lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb: 265d9046a5d9930abeb2785a883d4153
+lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/nil_rate_result.govspeak.erb: 8bf658fa6479d48ba90ea9d6d7023f30
+lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb: f6c0a3e3e162fc10d9663610c2fb9db0
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/are_you_paying_or_receiving.govspeak.erb: 3a72cdea5e6d683193abc2b1df1f464e
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/gets_benefits.govspeak.erb: 0355ce7a559ff039789bff7a0656caff
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/gross_income_of_payee.govspeak.erb: 620f7cba7bbc806883834aff8ea49e00


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/103405692

Updates the calculator start page and two of the outcomes to include a note that the calculator gives an estimate rather than exact figure.

## Factcheck

https://fierce-sands-8457.herokuapp.com/calculate-your-child-maintenance

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/calculate-your-child-maintenance)
  * Updates content on start page
  * Adds a callout with the text "The calculator only gives an estimate - it may not give the right result for complicated circumstances, eg if the paying parent has children from a different relationship"

### Before
![screen shot 2015-12-15 at 5 26 00 pm](https://cloud.githubusercontent.com/assets/351763/11818208/f174bb76-a350-11e5-940c-8a43e8e71ab3.png)

### After
![screen shot 2015-12-15 at 5 26 05 pm](https://cloud.githubusercontent.com/assets/351763/11818215/f73fb218-a350-11e5-9862-4372ae58d449.png)

This PR supersedes #2165 #2193 and #2249 