### PR TITLE
Upgrade airbrake gem to version 4.1.0 (as used in alphagov/whitehall).

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.2.3'
 
 gem 'rails', '4.2.5'
 
-gem 'airbrake', '~> 3.1.17'
+gem 'airbrake', '4.1.0'
 gem 'extlib', '0.9.16'
 gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
 gem 'govuk_frontend_toolkit', '3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.7)
-    airbrake (3.1.17)
+    airbrake (4.1.0)
       builder
       multi_json
     arel (6.0.3)
@@ -259,7 +259,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 3.1.17)
+  airbrake (= 4.1.0)
   better_errors
   binding_of_caller
   capybara (= 2.1.0)


### PR DESCRIPTION
Addresses issue #1681 by upgrading to a newer version of the Airbrake gem to ensure Errbit reports ActionController::BadRequest correctly as exceptions, and not notifications.

Whilst not the latest version, its the same version as used in [alphagov/whitehall](https://github.com/alphagov/whitehall/blob/master/Gemfile#L40).

Further details in Trello [card](https://trello.com/c/wAWWo86p/139-upgrade-the-airbrake-gem) (private board).