### PR TITLE
Updates production log stash configuration option.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,6 +70,6 @@ SmartAnswers::Application.configure do
     # Enable JSON-style logging
     config.logstasher.enabled = true
     config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
-    config.logstasher.supress_app_log = true
+    config.logstasher.suppress_app_logs = true
   end
 end


### PR DESCRIPTION
Small update to the log stasher configuration in production, correcting a typo in the option name (both this correct, and previous, misspelling are supported), as detailed in issue #1593.

Furter details in Trello [ticket](https://trello.com/c/7BJlhRv0) (private)