### PR TITLE
Memoize node presenters

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -95,7 +95,7 @@ class FlowPresenter
 
   def start_node
     node = SmartAnswer::Node.new(@flow, @flow.name.underscore.to_sym)
-    StartNodePresenter.new(node)
+    @start_node ||= StartNodePresenter.new(node)
   end
 
   def change_collapsed_question_link(question_number)

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -14,6 +14,7 @@ class FlowPresenter
     @request = request
     @params = request.params
     @flow = flow
+    @node_presenters = {}
   end
 
   def artefact
@@ -77,7 +78,7 @@ class FlowPresenter
                       else
                         NodePresenter
                       end
-    presenter_class.new(node, current_state)
+    @node_presenters[node.name] ||= presenter_class.new(node, current_state)
   end
 
   def current_question_number

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -74,7 +74,8 @@ class FlowPresenter
                         QuestionPresenter
                       when SmartAnswer::Outcome
                         OutcomePresenter
-                      else NodePresenter
+                      else
+                        NodePresenter
                       end
     presenter_class.new(node, current_state)
   end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -1,0 +1,69 @@
+require_relative "../test_helper"
+
+class FlowPresenterTest < ActiveSupport::TestCase
+  setup do
+    @flow = SmartAnswer::Flow.new { value_question :first_question_key }
+    @request = ActionDispatch::TestRequest.new
+    @flow_presenter = FlowPresenter.new(@request, @flow)
+  end
+
+  test '#presenter_for returns presenter for Date question' do
+    question = @flow.date_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of DateQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for CountrySelect question' do
+    question = @flow.country_select(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of CountrySelectQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for MultipleChoice question' do
+    question = @flow.multiple_choice(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of MultipleChoiceQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for Checkbox question' do
+    question = @flow.checkbox_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of CheckboxQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for Value question' do
+    question = @flow.value_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of ValueQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for Money question' do
+    question = @flow.money_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of MoneyQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for Salary question' do
+    question = @flow.salary_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of SalaryQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for other question types' do
+    question = @flow.send(:add_question, SmartAnswer::Question::Base, :question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of QuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for outcome' do
+    outcome = @flow.outcome(:outcome_key).last
+    node_presenter = @flow_presenter.presenter_for(outcome)
+    assert_instance_of OutcomePresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for other node types' do
+    node = @flow.send(:add_question, SmartAnswer::Node, :node_key).last
+    node_presenter = @flow_presenter.presenter_for(node)
+    assert_instance_of NodePresenter, node_presenter
+  end
+end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -66,4 +66,11 @@ class FlowPresenterTest < ActiveSupport::TestCase
     node_presenter = @flow_presenter.presenter_for(node)
     assert_instance_of NodePresenter, node_presenter
   end
+
+  test '#presenter_for always returns same presenter for a given question' do
+    question = @flow.multiple_choice(:question_key).last
+    node_presenter_1 = @flow_presenter.presenter_for(question)
+    node_presenter_2 = @flow_presenter.presenter_for(question)
+    assert_same node_presenter_1, node_presenter_2
+  end
 end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -81,4 +81,10 @@ class FlowPresenterTest < ActiveSupport::TestCase
     start_node = @flow_presenter.start_node
     assert_instance_of StartNodePresenter, start_node
   end
+
+  test '#start_node always returns same presenter for landing page node' do
+    start_node_1 = @flow_presenter.start_node
+    start_node_2 = @flow_presenter.start_node
+    assert_same start_node_1, start_node_2
+  end
 end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -2,7 +2,10 @@ require_relative "../test_helper"
 
 class FlowPresenterTest < ActiveSupport::TestCase
   setup do
-    @flow = SmartAnswer::Flow.new { value_question :first_question_key }
+    @flow = SmartAnswer::Flow.new do
+      name 'flow-name'
+      value_question :first_question_key
+    end
     @request = ActionDispatch::TestRequest.new
     @flow_presenter = FlowPresenter.new(@request, @flow)
   end
@@ -72,5 +75,10 @@ class FlowPresenterTest < ActiveSupport::TestCase
     node_presenter_1 = @flow_presenter.presenter_for(question)
     node_presenter_2 = @flow_presenter.presenter_for(question)
     assert_same node_presenter_1, node_presenter_2
+  end
+
+  test '#start_node returns presenter for landing page node' do
+    start_node = @flow_presenter.start_node
+    assert_instance_of StartNodePresenter, start_node
   end
 end


### PR DESCRIPTION
We were creating far more instances of `NodePresenter` and its subclasses than we needed. This in turn meant we were creating far more instances of `SmartAnswer::ErbRenderer` and thence `ActionView::Base` than necessary. It may well also have meant that we were unnecessarily re-rendering the same template multiple times.

In a recent release, all flows were converted to use ERB rendering for questions instead of YAML I18n rendering. This release coincided with the app using a lot more memory ([private link](https://trello.com/c/qhSd3VPD/162-investigate-memory-leak)). We have some evidence to suggest that making this change will (at the very least) reduce memory usage of the app somewhat. However, we haven't been able to unambiguously reproduce the memory usage problem we're seeing in production, so it's difficult to know whether this will actually resolve the problem.

In working on this change, it's highlighted how tangled an inefficient this area of the codebase is (e.g. `FlowPresenter#collapsed_questions` indirectly calls `Flow#process` multiple times). I'm convinced that the code could be considerably simplified, but that's going to have to wait for another day.
