### PR TITLE
WIP: Spike into using single ActionView::Base for all node presenters

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -69,7 +69,7 @@ private
   def find_smart_answer
     @name = params[:id].to_sym
     @smart_answer = flow_registry.find(@name.to_s)
-    @presenter = SmartAnswerPresenter.new(request, @smart_answer)
+    @presenter = FlowPresenter.new(request, @smart_answer)
   end
 
   def flow_registry

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -95,7 +95,7 @@ class FlowPresenter
 
   def start_node
     node = SmartAnswer::Node.new(@flow, @flow.name.underscore.to_sym)
-    StartNodePresenter.new(node)
+    @start_node ||= StartNodePresenter.new(node)
   end
 
   def change_collapsed_question_link(question_number)

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -1,7 +1,7 @@
 require 'node_presenter'
 require 'gds_api/helpers'
 
-class SmartAnswerPresenter
+class FlowPresenter
   include GdsApi::Helpers
   extend Forwardable
   include Rails.application.routes.url_helpers

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -78,7 +78,28 @@ class FlowPresenter
                       else
                         NodePresenter
                       end
-    @node_presenters[node.name] ||= presenter_class.new(node, current_state)
+    @node_presenters[node.name] ||= presenter_class.new(node, action_view, current_state)
+  end
+
+  HELPERS = [
+    SmartAnswer::FormattingHelper,
+    SmartAnswer::OverseasPassportsHelper,
+    SmartAnswer::MarriageAbroadHelper,
+    SmartAnswer::ErbRenderer::QuestionOptionsHelper
+  ]
+
+  def action_view
+    @action_view ||= ActionView::Base.new(view_paths).tap do |view|
+      HELPERS.each { |h| view.extend(h) }
+    end
+  end
+
+  def view_paths
+    [
+      @flow.template_directory,
+      @flow.template_directory.join('questions'),
+      @flow.template_directory.join('outcomes')
+    ]
   end
 
   def current_question_number
@@ -95,7 +116,7 @@ class FlowPresenter
 
   def start_node
     node = SmartAnswer::Node.new(@flow, @flow.name.underscore.to_sym)
-    @start_node ||= StartNodePresenter.new(node)
+    @start_node ||= StartNodePresenter.new(node, action_view)
   end
 
   def change_collapsed_question_link(question_number)

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -124,9 +124,7 @@ class FlowPresenter
 
   def all_responses
     normalize_responses_param.dup.tap do |responses|
-      if params[:next]
-        responses << params[:response]
-      end
+      responses << params[:response] if params[:next]
     end
   end
 

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -14,6 +14,7 @@ class FlowPresenter
     @request = request
     @params = request.params
     @flow = flow
+    @node_presenters = {}
   end
 
   def artefact
@@ -77,7 +78,7 @@ class FlowPresenter
                       else
                         NodePresenter
                       end
-    presenter_class.new(node, current_state)
+    @node_presenters[node.name] ||= presenter_class.new(node, current_state)
   end
 
   def current_question_number

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -74,7 +74,8 @@ class FlowPresenter
                         QuestionPresenter
                       when SmartAnswer::Outcome
                         OutcomePresenter
-                      else NodePresenter
+                      else
+                        NodePresenter
                       end
     presenter_class.new(node, current_state)
   end

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -1,15 +1,10 @@
 class OutcomePresenter < NodePresenter
-  def initialize(node, state = nil, options = {})
+  def initialize(node, action_view, state = nil, options = {})
     super(node, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(
-      template_directory: @node.template_directory.join('outcomes'),
+      action_view: action_view,
       template_name: @node.name.to_s,
-      locals: @state.to_hash,
-      helpers: [
-        SmartAnswer::FormattingHelper,
-        SmartAnswer::OverseasPassportsHelper,
-        SmartAnswer::MarriageAbroadHelper
-      ]
+      locals: @state.to_hash
     )
   end
 

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -1,13 +1,11 @@
 class QuestionPresenter < NodePresenter
-  def initialize(node, state = nil, options = {})
+  def initialize(node, action_view, state = nil, options = {})
     super(node, state)
     @renderer = options[:renderer]
-    helpers = options[:helpers] || []
     @renderer ||= SmartAnswer::ErbRenderer.new(
-      template_directory: @node.template_directory.join('questions'),
+      action_view: action_view,
       template_name: @node.filesystem_friendly_name,
-      locals: @state.to_hash,
-      helpers: [SmartAnswer::FormattingHelper] + helpers
+      locals: @state.to_hash
     )
   end
 

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -1,8 +1,8 @@
 class StartNodePresenter < NodePresenter
-  def initialize(node, state = nil, options = {})
+  def initialize(node, action_view, state = nil, options = {})
     super(node, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(
-      template_directory: @node.template_directory,
+      action_view: action_view,
       template_name: @node.name.to_s
     )
   end

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -127,6 +127,11 @@ module SmartAnswer
       process(responses).responses
     end
 
+    def template_directory
+      load_path = FlowRegistry.instance.load_path
+      Pathname.new(load_path).join(String(name))
+    end
+
     class InvalidStatus < StandardError; end
 
     private

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -53,11 +53,6 @@ module SmartAnswer
       false
     end
 
-    def template_directory
-      load_path = FlowRegistry.instance.load_path
-      Pathname.new(load_path).join(String(@flow.name))
-    end
-
     def flow_name
       @flow.name
     end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -46,7 +46,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     context "without a valid artefact" do
       setup do
-        SmartAnswerPresenter.any_instance.stubs(:artefact).returns({})
+        FlowPresenter.any_instance.stubs(:artefact).returns({})
       end
 
       should "still return a success response" do
@@ -90,14 +90,14 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     should "send the artefact to slimmer" do
       artefact = artefact_for_slug('smart-answers-controller-sample')
-      SmartAnswerPresenter.any_instance.stubs(:artefact).returns(artefact)
+      FlowPresenter.any_instance.stubs(:artefact).returns(artefact)
       @controller.expects(:set_slimmer_artefact).with(artefact)
 
       get :show, id: 'smart-answers-controller-sample'
     end
 
     should "503 if content_api times out" do
-      SmartAnswerPresenter.any_instance.stubs(:artefact).raises(GdsApi::TimedOutException)
+      FlowPresenter.any_instance.stubs(:artefact).raises(GdsApi::TimedOutException)
 
       get :show, id: 'smart-answers-controller-sample'
       assert_equal 503, response.status

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -1,0 +1,69 @@
+require_relative "../test_helper"
+
+class FlowPresenterTest < ActiveSupport::TestCase
+  setup do
+    @flow = SmartAnswer::Flow.new { value_question :first_question_key }
+    @request = ActionDispatch::TestRequest.new
+    @flow_presenter = FlowPresenter.new(@request, @flow)
+  end
+
+  test '#presenter_for returns presenter for Date question' do
+    question = @flow.date_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of DateQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for CountrySelect question' do
+    question = @flow.country_select(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of CountrySelectQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for MultipleChoice question' do
+    question = @flow.multiple_choice(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of MultipleChoiceQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for Checkbox question' do
+    question = @flow.checkbox_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of CheckboxQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for Value question' do
+    question = @flow.value_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of ValueQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for Money question' do
+    question = @flow.money_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of MoneyQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for Salary question' do
+    question = @flow.salary_question(:question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of SalaryQuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for other question types' do
+    question = @flow.send(:add_question, SmartAnswer::Question::Base, :question_key).last
+    node_presenter = @flow_presenter.presenter_for(question)
+    assert_instance_of QuestionPresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for outcome' do
+    outcome = @flow.outcome(:outcome_key).last
+    node_presenter = @flow_presenter.presenter_for(outcome)
+    assert_instance_of OutcomePresenter, node_presenter
+  end
+
+  test '#presenter_for returns presenter for other node types' do
+    node = @flow.send(:add_question, SmartAnswer::Node, :node_key).last
+    node_presenter = @flow_presenter.presenter_for(node)
+    assert_instance_of NodePresenter, node_presenter
+  end
+end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -66,4 +66,11 @@ class FlowPresenterTest < ActiveSupport::TestCase
     node_presenter = @flow_presenter.presenter_for(node)
     assert_instance_of NodePresenter, node_presenter
   end
+
+  test '#presenter_for always returns same presenter for a given question' do
+    question = @flow.multiple_choice(:question_key).last
+    node_presenter_1 = @flow_presenter.presenter_for(question)
+    node_presenter_2 = @flow_presenter.presenter_for(question)
+    assert_same node_presenter_1, node_presenter_2
+  end
 end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -81,4 +81,10 @@ class FlowPresenterTest < ActiveSupport::TestCase
     start_node = @flow_presenter.start_node
     assert_instance_of StartNodePresenter, start_node
   end
+
+  test '#start_node always returns same presenter for landing page node' do
+    start_node_1 = @flow_presenter.start_node
+    start_node_2 = @flow_presenter.start_node
+    assert_same start_node_1, start_node_2
+  end
 end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -2,7 +2,10 @@ require_relative "../test_helper"
 
 class FlowPresenterTest < ActiveSupport::TestCase
   setup do
-    @flow = SmartAnswer::Flow.new { value_question :first_question_key }
+    @flow = SmartAnswer::Flow.new do
+      name 'flow-name'
+      value_question :first_question_key
+    end
     @request = ActionDispatch::TestRequest.new
     @flow_presenter = FlowPresenter.new(@request, @flow)
   end
@@ -72,5 +75,10 @@ class FlowPresenterTest < ActiveSupport::TestCase
     node_presenter_1 = @flow_presenter.presenter_for(question)
     node_presenter_2 = @flow_presenter.presenter_for(question)
     assert_same node_presenter_1, node_presenter_2
+  end
+
+  test '#start_node returns presenter for landing page node' do
+    start_node = @flow_presenter.start_node
+    assert_instance_of StartNodePresenter, start_node
   end
 end


### PR DESCRIPTION
This turned out to be quite awkward with the current structure of the code.

With the changes as they stand, all the *regression* tests pass, but I haven't
fixed up any of the other tests. Also there are two other places where we use
node presenters which will also need attention:

* `GraphPresenter`
* `FlowRegistrationPresenter`

The biggest problem I ran into was the content in `content_for` blocks for
different node presenters, but the same key were appended to each other. I got
round this by doing the rendering in the node presenter constructor and using
a different instance of `ActionView::OutputFlow` for each presenter.

This means the node presenters don't need to hang on to a reference to the
(now shared) instance of `ActionView::Base`.

Other downsides of this approach are:

* I had to include all helper modules in the one instance of `ActionView::Base`.
  However, we could still feasibly restrict this to the generic helper modules
  and *one* flow-specific helper module relating to the "current" flow.

* I ended up adding the flow directory and both the `questions` & `outcomes`
  sub-directories to the view path. I assume this might cause problems if we
  had a question and an outcome template with the same name for the same flow.
  Thankfully this doesn't seem to be a problem at the moment, but it would be
  good to understand what would happen if this were the case. There might well
  be a better way of setting up the view paths, but I couldn't find it.

Note: It wouldn't be a big step to use Rails' instance of `ActionView::Base`
instead of our own special instance. However, I decided not to do this, to avoid
running into more problems with sharing helpers and view paths with the main
Rails app.