### PR TITLE
Rename SmartAnswerPresenter to FlowPresenter

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -69,7 +69,7 @@ private
   def find_smart_answer
     @name = params[:id].to_sym
     @smart_answer = flow_registry.find(@name.to_s)
-    @presenter = SmartAnswerPresenter.new(request, @smart_answer)
+    @presenter = FlowPresenter.new(request, @smart_answer)
   end
 
   def flow_registry

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -1,7 +1,7 @@
 require 'node_presenter'
 require 'gds_api/helpers'
 
-class SmartAnswerPresenter
+class FlowPresenter
   include GdsApi::Helpers
   extend Forwardable
   include Rails.application.routes.url_helpers

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -122,9 +122,7 @@ class FlowPresenter
 
   def all_responses
     normalize_responses_param.dup.tap do |responses|
-      if params[:next]
-        responses << params[:response]
-      end
+      responses << params[:response] if params[:next]
     end
   end
 

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -46,7 +46,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     context "without a valid artefact" do
       setup do
-        SmartAnswerPresenter.any_instance.stubs(:artefact).returns({})
+        FlowPresenter.any_instance.stubs(:artefact).returns({})
       end
 
       should "still return a success response" do
@@ -90,14 +90,14 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     should "send the artefact to slimmer" do
       artefact = artefact_for_slug('smart-answers-controller-sample')
-      SmartAnswerPresenter.any_instance.stubs(:artefact).returns(artefact)
+      FlowPresenter.any_instance.stubs(:artefact).returns(artefact)
       @controller.expects(:set_slimmer_artefact).with(artefact)
 
       get :show, id: 'smart-answers-controller-sample'
     end
 
     should "503 if content_api times out" do
-      SmartAnswerPresenter.any_instance.stubs(:artefact).raises(GdsApi::TimedOutException)
+      FlowPresenter.any_instance.stubs(:artefact).raises(GdsApi::TimedOutException)
 
       get :show, id: 'smart-answers-controller-sample'
       assert_equal 503, response.status


### PR DESCRIPTION
Since we have a Flow with many Nodes, it makes more sense to me that we have
a FlowPresenter with many NodePresenters.

This is also part of #2172, but I reckon it's much less controversial, so thought it was worth a separate PR.