### PR TITLE
Remove unused SmartAnswerPresenter#page_title method

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -127,7 +127,4 @@ class FlowPresenter
       responses << params[:response] if params[:next]
     end
   end
-
-  def page_title
-  end
 end

--- a/app/views/smart_answers/_content.html.erb
+++ b/app/views/smart_answers/_content.html.erb
@@ -17,9 +17,6 @@
   <% if @presenter.finished? %>
     <%= render partial: "result", locals: { outcome: @presenter.current_node } %>
   <% else %>
-    <% if @presenter.page_title %>
-      <h2 class="page-title"><%= @presenter.page_title %></h2>
-    <% end %>
     <div class="step current">
       <%= form_tag calculate_current_question_path(@presenter), :method => :get %>
         <div class="current-question" id="current-question">


### PR DESCRIPTION
This hasn't been used since this commit [1].

[1]: c8f4e22ca8ca94d38c30a17feaf4e8874c42502c