### PR TITLE
Update start page content for state pension

### DIFF
--- a/lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb
@@ -7,26 +7,37 @@
 <% end %>
 
 <% content_for :body do %>
-  Calculate when you’ll reach State Pension age, Pension Credit qualifying age or find out when you’ll be eligible for free bus travel.
+  Use the calculator to:
 
-  If you're under 55 you can also find out how much you may get in today's money for your basic State Pension.
+  * work out when you’ll reach State Pension age
+  * work out your Pension Credit qualifying age
+  * find out when you’ll be eligible for free bus travel
 
-  Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if:
+  ##If you’re under 55
 
-  - you’re 55 or over
-  - you’re making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/)
+  The calculator also gives an estimate of your basic State Pension under the current rules - not the [new State Pension](/new-state-pension) rules.  
+
+  It doesn’t estimate any [Additional State Pension](/additional-state-pension).
+
+  ##If you’re 55 or over
+
+  Don’t use the calculator to work out your State Pension. Get a [State Pension Statement](/state-pension-statement) instead.
+
 <% end %>
 
 <% content_for :post_body do %>
-  ##If you're under 55:
+  ##What you need
 
-  This calculator gives an estimate of your basic State Pension and information about the [new State Pension](/new-state-pension).
+  You need to enter the number of years you:
 
-  It doesn’t estimate any [Additional State Pension.](/additional-state-pension)
+  * worked and paid National Insurance
+  * got unemployment, sickness or disability benefits
+  * claimed Child Benefit or were a carer or foster carer
 
-  You’ll be asked for the number of years you worked and paid National Insurance or got certain benefits. These are the years of your [National Insurance contributions](/national-insurance) that count towards your State Pension.
+  Don’t count the current tax year. Count tax years from 6 April to 5 April and don’t count any years twice, eg when you were working and getting benefits.
 
-  Count tax years from 6 April to 5 April and don’t count any years twice (eg when you were working and getting benefits). Don’t count the current tax year.
+  This calculator uses a simplified calculation based on the current law. It can’t take into account every circumstance that might affect you.
 
-  This calculator uses a simplified calculation based on the current law. It can’t take into account every circumstance that might affect you. Don't make future financial decisions based on its results.
+  ^Don’t use the calculator to make future financial decisions.^
+
 <% end %>

--- a/test/artefacts/calculate-state-pension/calculate-state-pension.txt
+++ b/test/artefacts/calculate-state-pension/calculate-state-pension.txt
@@ -1,22 +1,31 @@
 State Pension calculator
 
-Calculate when you’ll reach State Pension age, Pension Credit qualifying age or find out when you’ll be eligible for free bus travel.
+Use the calculator to:
 
-If you're under 55 you can also find out how much you may get in today's money for your basic State Pension.
+* work out when you’ll reach State Pension age
+* work out your Pension Credit qualifying age
+* find out when you’ll be eligible for free bus travel
 
-Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if:
+##If you’re under 55
 
-- you’re 55 or over
-- you’re making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/)
+The calculator also gives an estimate of your basic State Pension under the current rules - not the [new State Pension](/new-state-pension) rules.  
 
-##If you're under 55:
+It doesn’t estimate any [Additional State Pension](/additional-state-pension).
 
-This calculator gives an estimate of your basic State Pension and information about the [new State Pension](/new-state-pension).
+##If you’re 55 or over
 
-It doesn’t estimate any [Additional State Pension.](/additional-state-pension)
+Don’t use the calculator to work out your State Pension. Get a [State Pension Statement](/state-pension-statement) instead.
 
-You’ll be asked for the number of years you worked and paid National Insurance or got certain benefits. These are the years of your [National Insurance contributions](/national-insurance) that count towards your State Pension.
+##What you need
 
-Count tax years from 6 April to 5 April and don’t count any years twice (eg when you were working and getting benefits). Don’t count the current tax year.
+You need to enter the number of years you:
 
-This calculator uses a simplified calculation based on the current law. It can’t take into account every circumstance that might affect you. Don't make future financial decisions based on its results.
+* worked and paid National Insurance
+* got unemployment, sickness or disability benefits
+* claimed Child Benefit or were a carer or foster carer
+
+Don’t count the current tax year. Count tax years from 6 April to 5 April and don’t count any years twice, eg when you were working and getting benefits.
+
+This calculator uses a simplified calculation based on the current law. It can’t take into account every circumstance that might affect you.
+
+^Don’t use the calculator to make future financial decisions.^

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/calculate-state-pension.rb: decb4f660f830f305d9ff577d981a16d
 test/data/calculate-state-pension-questions-and-responses.yml: 7637baad3326dc8e39f445684e615da3
 test/data/calculate-state-pension-responses-and-expected-results.yml: 61e8ccba31841f6616cf8b26f3da6ff9
-lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb: 44e4a3aeaf295ddc7e987e987afd23fc
+lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb: e5824723fbca9ea894189d34f87488a3
 lib/smart_answer_flows/calculate-state-pension/outcomes/_bus_pass_age.govspeak.erb: 5f1f77ef0e25bd24b4b8c6b4e30d4e92
 lib/smart_answer_flows/calculate-state-pension/outcomes/age_result.govspeak.erb: 8b5d360fd6ef72d4f53a2592d8d7671f
 lib/smart_answer_flows/calculate-state-pension/outcomes/amount_result.govspeak.erb: b46187c00300132102d7e5c214385b0d


### PR DESCRIPTION
This PR supersedes #2182 

Updates content on the start page based on fact check review to clarify who the the state pension calculator is intended for.

## Expected changes

* [Calculate State Pension](https://www.gov.uk/calculate-state-pension)
 * Should now start with "Use the calculator to:" followed by three bullet points

![screen shot 2015-12-08 at 16 41 46](https://cloud.githubusercontent.com/assets/351763/11661891/03bfbb6c-9dcc-11e5-990e-831a78b53485.png)
 