### PR TITLE
Update whitespace in smart answer artefacts

### DIFF
--- a/test/artefacts/am-i-getting-minimum-wage/current_payment_april_2016.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment_april_2016.html
@@ -30,7 +30,7 @@
     <div class="step current">
       <form action="/am-i-getting-minimum-wage/y/current_payment_april_2016" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
         <div class="current-question" id="current-question">
-            <div class="question">
+          <div class="question">
   <h2>
     Will you be in the first year of an apprenticeship on 1 April 2016?
   </h2>
@@ -43,16 +43,16 @@
 
       <ul class="options inline">
     <li>
-        <label for="response_0" class="selectable">
-          <input type="radio" name="response" id="response_0" value="yes" />
-          Yes
-        </label>
+      <label for="response_0" class="selectable">
+        <input type="radio" name="response" id="response_0" value="yes" />
+        Yes
+      </label>
     </li>
     <li>
-        <label for="response_1" class="selectable">
-          <input type="radio" name="response" id="response_1" value="no" />
-          No
-        </label>
+      <label for="response_1" class="selectable">
+        <input type="radio" name="response" id="response_1" value="no" />
+        No
+      </label>
     </li>
 </ul>
 
@@ -70,33 +70,31 @@
         </div>
       </form>
     </div>
-    <div class="previous-answers ">
+    <div class="previous-answers">
     <div class="done-questions">
       <article>
-            <h3 class="previous-answers-title">
-              Previous answers
-            </h3>
+          <h3 class="previous-answers-title">
+            Previous answers
+          </h3>
           <a class="start-right" href="/am-i-getting-minimum-wage">Start again</a>
         <table>
           <tbody>
-              
-    <tr class="section">
-    <td class="previous-question-title">What would you like to check?</td>
-      <td class="previous-question-body">
-      If you'll get the national living wage (from 1 April 2016)</td>
+              <tr class="section">
+  <td class="previous-question-title">What would you like to check?</td>
+    <td class="previous-question-body">
+    If you'll get the national living wage (from 1 April 2016)</td>
 
-      <td class="link-right">
-          <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment_april_2016">
-            Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
-</a>      </td>
-  </tr>
+  <td class="link-right">
+    <a href="/am-i-getting-minimum-wage/y?previous_response=current_payment_april_2016">
+      Change<span class="visuallyhidden"> answer to "What would you like to check?"</span>
+</a>  </td>
+</tr>
 
           </tbody>
         </table>
       </article>
     </div>
   </div>
-
 
 
   </div>

--- a/test/artefacts/am-i-getting-minimum-wage/y.html
+++ b/test/artefacts/am-i-getting-minimum-wage/y.html
@@ -55,10 +55,10 @@
       </label>
     </li>
     <li>
-        <label for="response_2" class="selectable">
-          <input type="radio" name="response" id="response_2" value="current_payment_april_2016" />
-          If you'll get the national living wage (from 1 April 2016)
-        </label>
+      <label for="response_2" class="selectable">
+        <input type="radio" name="response" id="response_2" value="current_payment_april_2016" />
+        If you'll get the national living wage (from 1 April 2016)
+      </label>
     </li>
 </ul>
 


### PR DESCRIPTION
A recent merge has altered the whitespace in the smart answer template and generated artefacts with slightly different spacing, causing the master branch build to fail. These new artefacts should have the correct spacing.

Execute:

 RUN_REGRESSION_TESTS=am-i-getting-minimum-wage ruby test/regression/smart_answers_regression_test.rb