### PR TITLE
Removed link to DSA1 guidance

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb
@@ -19,7 +19,6 @@
   Academic Year | Form
   - | -
   2015 to 2016 | [DSA - slim form (PDF, 122KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa_slim_form_1516_d.pdf)
-  2015 to 2016 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
 
 
 

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-dsa/year-1516.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-dsa/year-1516.txt
@@ -15,7 +15,6 @@ If you've already applied for other student finance (like a Tuition Fee Loan) co
 Academic Year | Form
 - | -
 2015 to 2016 | [DSA - slim form (PDF, 122KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa_slim_form_1516_d.pdf)
-2015 to 2016 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
 
 ##Where to send your form(s)
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -10,7 +10,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1516.govspeak.
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 6d17c37622196bdd568ee6bf3ca12351
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1415.govspeak.erb: 28be62b617f9d16efe440ac51bca8b06
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1415_pt.govspeak.erb: 7198976bdc668c05a71973041eb9107d
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb: 80c62a3bcc6ed3979b1d6b12b6cf6f5c
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb: cc283294a806d4a5000838a2c3af50d4
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb: 85bbcaa668f9e3312a3d434acc060461
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_expenses.govspeak.erb: 83e8b32ee7412461815f6feccf6cba96
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1415_continuing.govspeak.erb: c3cdebfa03aad871951e947e191d7503


### PR DESCRIPTION
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/1208951
 
The DSA slim form doesn't require guidance notes, so delete that line.

## Expected changes

* [URL on gov.uk](https://www.gov.uk/student-finance-forms/y/uk-full-time/apply-dsa/year-1516)
 * Only one download link should be visible below the sentence "If you’ve already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form."

### Before
![screen shot 2015-12-14 at 12 04 20](https://cloud.githubusercontent.com/assets/351763/11780583/e2764398-a25a-11e5-92c3-37d05667857c.png)

### After
![screen shot 2015-12-14 at 12 04 34](https://cloud.githubusercontent.com/assets/351763/11780586/e6c8b6ba-a25a-11e5-94eb-c47538370b4f.png)

This PR supersede #2187 