### PR TITLE
Style correction to outcome.

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb
@@ -6,7 +6,7 @@
 
   To apply for Disabled Students’ Allowance for a part-time, Open University or postgraduate course, complete the full DSA1.
  
-  Academic Year | Form
+  Academic year | Form
   - | -
   2015 to 2016 | [DSA1 - full form (PDF, 653KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_form_1516_d.pdf)
   2015 to 2016 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)


### PR DESCRIPTION
Corrected 'Academic Year' to 'Academic year' in the table header.