### PR TITLE
Update student finance style

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb
@@ -6,7 +6,7 @@
 
   To apply for Disabled Students’ Allowance for a part-time, Open University or postgraduate course, complete the full DSA1.
  
-  Academic Year | Form
+  Academic year | Form
   - | -
   2015 to 2016 | [DSA1 - full form (PDF, 653KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_form_1516_d.pdf)
   2015 to 2016 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-dsa/year-1516.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-dsa/year-1516.txt
@@ -3,7 +3,7 @@ Disabled Students’Allowances
 
 To apply for Disabled Students’ Allowance for a part-time, Open University or postgraduate course, complete the full DSA1.
 
-Academic Year | Form
+Academic year | Form
 - | -
 2015 to 2016 | [DSA1 - full form (PDF, 653KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_form_1516_d.pdf)
 2015 to 2016 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -11,7 +11,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govsp
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1415.govspeak.erb: 28be62b617f9d16efe440ac51bca8b06
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1415_pt.govspeak.erb: 7198976bdc668c05a71973041eb9107d
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb: cc283294a806d4a5000838a2c3af50d4
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb: 85bbcaa668f9e3312a3d434acc060461
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb: 44075f617f6d6d6a041111c75f42c059
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_expenses.govspeak.erb: 83e8b32ee7412461815f6feccf6cba96
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1415_continuing.govspeak.erb: c3cdebfa03aad871951e947e191d7503
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1415_new.govspeak.erb: e123572009840efbfac1eef937878d0d


### PR DESCRIPTION
This PR supersedes #2195 

Change case of 'year' in 'academic year' because style.

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/student-finance-forms/y/uk-part-time/apply-dsa/year-1516)
  * Change table header from 'Academic Year' to 'Academic year'

### Before
![screen shot 2015-12-16 at 8 41 29 am](https://cloud.githubusercontent.com/assets/351763/11836255/5648da52-a3d1-11e5-81b3-6da6e778e770.png)

### After
![screen shot 2015-12-16 at 8 41 33 am](https://cloud.githubusercontent.com/assets/351763/11836257/5ac40eb2-a3d1-11e5-9e72-8f16f26e4c3d.png)

