### PR TITLE
Remove unnecessary dependency on extlib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby '2.2.3'
 gem 'rails', '4.2.5'
 
 gem 'airbrake', '4.1.0'
-gem 'extlib', '0.9.16'
 gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
 gem 'govuk_frontend_toolkit', '3.1.0'
 gem 'htmlentities', '~> 4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,6 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.4.0)
-    extlib (0.9.16)
     gds-api-adapters (25.1.0)
       link_header
       lrucache (~> 0.1.1)
@@ -264,7 +263,6 @@ DEPENDENCIES
   binding_of_caller
   capybara (= 2.1.0)
   ci_reporter
-  extlib (= 0.9.16)
   gds-api-adapters (~> 25.1)
   govspeak (~> 3.3.0)
   govuk-content-schema-test-helpers (~> 1.3.0)

--- a/test/unit/smart_answer_files_test.rb
+++ b/test/unit/smart_answer_files_test.rb
@@ -46,7 +46,8 @@ class SmartAnswerFilesTest < ActiveSupport::TestCase
       smart_answer_with_erb_templates(flow_name) do |erb_template_files|
         smart_answer_files = SmartAnswerFiles.new(flow_name)
         erb_template_files.each do |file|
-          expected_path = file.path.relative_path_from(Rails.root)
+          absolute_path = File.expand_path(file)
+          expected_path = Pathname.new(absolute_path).relative_path_from(Rails.root).to_s
           assert_equal true, smart_answer_files.paths.include?(expected_path)
         end
       end


### PR DESCRIPTION
The dependency on `extlib` was originally just an implicit dependency via
`google-api-client`, but in [this commit][1] it was converted into an explicit
dependency in order to fix a [security vulnerability][2].

The dependency on `google-api-client` was removed in [this commit][3]
and so now, as far as I can see, we no longer need `extlib` at all.

[1]: https://github.com/alphagov/smart-answers/commit/d0709ebaf107286ac35229829a08feb741d002cf
[2]: http://osvdb.org/show/osvdb/90740
[3]: https://github.com/alphagov/smart-answers/commit/ac0c081d09553d3ac12d9e608044fb591fb5b3ef
