### PR TITLE
Update DWP contact details

### DIFF
--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/_dwp_contact_details.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/_dwp_contact_details.govspeak.erb
@@ -1,7 +1,7 @@
 $C
-**Department for Work and Pensions**
-Telephone: 0345 605 7064
-Telephone (Welsh): 0345 605 7066
-Textphone: 0345 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/_dwp_contact_details.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/_dwp_contact_details.govspeak.erb
@@ -1,7 +1,7 @@
 $C
 **Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+Telephone: 0345 605 7064
+Telephone (Welsh): 0345 605 7066
+Textphone: 0345 608 8551
 [Find out about call charges](/call-charges)
 $C

--- a/test/artefacts/benefit-cap-calculator/no.txt
+++ b/test/artefacts/benefit-cap-calculator/no.txt
@@ -5,10 +5,10 @@ You aren’t affected by the benefit cap if you’re not claiming Housing Benefi
 Contact the Department for Work and Pensions if you need further help:
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/350.0/couple.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/350.0/couple.txt
@@ -27,10 +27,10 @@ Your Housing Benefit won’t be reduced to 0. You need to be getting some Housin
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/350.0/parent.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/350.0/parent.txt
@@ -27,10 +27,10 @@ Your Housing Benefit won’t be reduced to 0. You need to be getting some Housin
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/350.0/single.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/350.0/single.txt
@@ -27,10 +27,10 @@ Your Housing Benefit won’t be reduced to 0. You need to be getting some Housin
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/couple.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/couple.txt
@@ -27,10 +27,10 @@ Your Housing Benefit won’t be reduced to 0. You need to be getting some Housin
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/parent.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/parent.txt
@@ -27,10 +27,10 @@ Your Housing Benefit won’t be reduced to 0. You need to be getting some Housin
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/single.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/single.txt
@@ -27,10 +27,10 @@ Your Housing Benefit won’t be reduced to 0. You need to be getting some Housin
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/350.0/couple.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/350.0/couple.txt
@@ -11,10 +11,10 @@ As this amount is lower than your benefit cap of £500.00, your benefits won’t
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/350.0/parent.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/350.0/parent.txt
@@ -11,10 +11,10 @@ As this amount is lower than your benefit cap of £500.00, your benefits won’t
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/350.0/single.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/350.0/single.txt
@@ -25,10 +25,10 @@ New Housing Benefit amount: £300.00
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.0/couple.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.0/couple.txt
@@ -11,10 +11,10 @@ As this amount is lower than your benefit cap of £500.00, your benefits won’t
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.0/parent.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.0/parent.txt
@@ -11,10 +11,10 @@ As this amount is lower than your benefit cap of £500.00, your benefits won’t
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.0/single.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.0/single.txt
@@ -11,10 +11,10 @@ As this amount is lower than your benefit cap of £350.00, your benefits won’t
 This is an estimate only. Contact the Department for Work and Pensions if you need further help.
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/none.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/none.txt
@@ -5,10 +5,10 @@ There are only certain benefits that are affected by the benefit cap.  You may s
 You should contact the Department for Work and Pensions if you need further help or your circumstances change:
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/yes.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/no/yes.txt
@@ -17,10 +17,10 @@ You may be affected by the cap if your circumstances change.
 Contact the Department for Work and Pensions if you need further help:
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/artefacts/benefit-cap-calculator/yes/yes.txt
+++ b/test/artefacts/benefit-cap-calculator/yes/yes.txt
@@ -17,10 +17,10 @@ You may be affected by the cap if your circumstances change.
 Contact the Department for Work and Pensions if you need further help:
 
 $C
-**Department for Work and Pensions**
-Telephone: 0845 605 7064
-Telephone (Welsh): 0845 605 7066
-Textphone: 0845 608 8551
+**Department for Work and Pensions**\\
+Telephone: 0345 605 7064\\
+Telephone (Welsh): 0345 605 7066\\
+Textphone: 0345 608 8551\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/benefit-cap-calculator.rb: 3272eb6344567f88ec75694fc1d4b7
 test/data/benefit-cap-calculator-questions-and-responses.yml: b608788e9eb18ad20a066de99259aa84
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 497ab9a2846c8821e61ac28c5b0d6cc1
 lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: ce5203f11989c0b35bd9c53ade1f3f82
-lib/smart_answer_flows/benefit-cap-calculator/outcomes/_dwp_contact_details.govspeak.erb: e562518b1b0289ec3e21c3174e9dab9c
+lib/smart_answer_flows/benefit-cap-calculator/outcomes/_dwp_contact_details.govspeak.erb: 3bab6f0d1df0457dbf0ff7548150ba4f
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap.govspeak.erb: c17ada7b1500ee964d16ce03b985fb53
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected.govspeak.erb: dba8dbd0632617bf73cb7838709d44b7
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions.govspeak.erb: c87ec73df23e7fc42f501604311dc6c4


### PR DESCRIPTION
PR supersedes #2202 

This PR updates the contact numbers for DWP, and updates their formatting to be presented as a line separated list.

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/benefit-cap-calculator/y/yes/yes)
  * Each telephone number changes from starting with 0845 to 0345
  * Each telephone number is rendered on a line of it's own

### Before
![screen shot 2015-12-21 at 10 59 22 am](https://cloud.githubusercontent.com/assets/351763/11929439/de27e94a-a7d2-11e5-9f98-6f8439468d0c.png)

### After
![screen shot 2015-12-21 at 10 59 27 am](https://cloud.githubusercontent.com/assets/351763/11929441/e34d8b6e-a7d2-11e5-988d-c410a991c094.png)
