### PR TITLE
Remove debugger gem from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,10 +57,6 @@ else
   gem 'govspeak', '~> 3.3.0'
 end
 
-if ENV['RUBY_DEBUG']
-  gem 'debugger', require: "ruby-debug"
-end
-
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else


### PR DESCRIPTION
This gem doesn't seem to support the Ruby version [2.2.3](https://github.com/alphagov/smart-answers/blob/master/Gemfile#L3) we specify in the Gemfile.

From the debugger gem [README.md](https://github.com/cldwalker/debugger/blob/master/README.md#description):

"A fork of ruby-debug(19) that works on 1.9.2 and 1.9.3 and installs easily for rvm/rbenv rubies.
ruby >= 2.0 are *not* supported"