### PR TITLE
Remove conditional selection of gem version/path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby '2.2.3'
 gem 'rails', '4.2.5'
 
 gem 'airbrake', '4.1.0'
+gem 'gds-api-adapters', '~> 25.1'
+gem 'govspeak', '~> 3.3.0'
 gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
 gem 'govuk_frontend_toolkit', '3.1.0'
 gem 'htmlentities', '~> 4'
@@ -15,6 +17,7 @@ gem 'plek', '1.7.0'
 gem 'rack_strip_client_ip', '0.0.1'
 gem 'rails-i18n'
 gem 'sass-rails', '~> 4.0.0'
+gem 'slimmer', '9.0.0'
 gem 'tilt', '1.4.1'
 gem 'therubyracer', '~> 0.12.1'
 gem 'uglifier'
@@ -43,22 +46,4 @@ group :test do
   gem 'simplecov-rcov', '~> 0.2.3', require: false
   gem 'timecop'
   gem 'webmock', '1.20.4', require: false
-end
-
-if ENV['API_DEV']
-  gem 'gds-api-adapters', path: '../gds-api-adapters'
-else
-  gem 'gds-api-adapters', '~> 25.1'
-end
-
-if ENV['GOVSPEAK_DEV']
-  gem 'govspeak', path: '../govspeak'
-else
-  gem 'govspeak', '~> 3.3.0'
-end
-
-if ENV['SLIMMER_DEV']
-  gem 'slimmer', path: '../slimmer'
-else
-  gem 'slimmer', '9.0.0'
 end


### PR DESCRIPTION
Developers can easily modify the Gemfile to include a ```path: <path>``` option or ```git: <uri>``` option to a particular version of a gem if they want to work towards, rather than setting ```ENV``` variables which are very easy to forget to unset.
