### PR TITLE
Update homeoffice outcome

### DIFF
--- a/lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb
@@ -1,10 +1,14 @@
 <% content_for :body do %>
   $!You must register the birth according to the regulations in <%= registration_country_name_lowercase_prefix %>.$!
 
-  You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+  You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
   You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-  You may also be able to register the birth if you’ve married the other parent since the child was born.
+  You may however be able to register the birth if either:
+
+  - you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+  - the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
   Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 <% end %>

--- a/test/artefacts/register-a-birth/afghanistan/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in Afghanistan.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in Algeria.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/libya/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in Libya.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in Morocco.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in North Korea.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in Papua New Guinea.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in the Philippines.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in Sierra Leone.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in St Martin.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in Indonesia.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in Usa.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2006-06-30.txt
@@ -2,10 +2,14 @@
 
 $!You must register the birth according to the regulations in Venezuela.$!
 
-You can’t register your child’s birth with the UK authorities abroad. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
+You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit. This is because unmarried fathers can’t pass on British nationality to a child born before 1 July 2006.
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born.
+You may however be able to register the birth if either:
+
+- you’ve married the other parent since the child was born (depending on where the father was considered to be permanently living at the time of the birth)
+- the country where the father was considered to be permanently living at the time of the birth did not distinguish between married and unmarried parents
+
 Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/register-a-birth.rb: 730dba55e2cc3353cf3982277702d68c
 test/data/register-a-birth-questions-and-responses.yml: c59cb1d0c11f3ad29f905b632f7c58bb
 test/data/register-a-birth-responses-and-expected-results.yml: 3ac4372034c86d8cc87665db59ff11d5
 lib/smart_answer_flows/register-a-birth/outcomes/commonwealth_result.govspeak.erb: a7c70e3191f23f7e747cb45587e4825f
-lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb: 680f670245380ebb3b9e95cb3b45a164
+lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb: 546c5ccac2d088c6209a75da0a7d5425
 lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.govspeak.erb: 174d68aa0d7cf3922a9e6a1867676359
 lib/smart_answer_flows/register-a-birth/outcomes/no_embassy_result.govspeak.erb: ed56d500311fbe441649c92193f0e631
 lib/smart_answer_flows/register-a-birth/outcomes/no_registration_result.govspeak.erb: 7b60252b078e6aec6f5759e894ce4ffb


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/109541280

Amend the outcome for unmarried fathers who's child was born before July 1, 2006 with additional details for cases where the child may be registrable with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit.

## Fact check

https://intense-ridge-1024.herokuapp.com/register-a-birth

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/register-a-birth/y/barbados/father/no/2005-04-16)
  * Replaces "You can’t register your child’s birth with the UK authorities abroad" with "You can’t usually register your child’s birth with the Foreign and Commonwealth Office (FCO) Overseas Registration Unit."
  * Adds two bullet points outline those cases where you can register a birth to an unmarried father

### Before
![screen shot 2015-12-21 at 4 34 03 pm](https://cloud.githubusercontent.com/assets/351763/11935643/da654be4-a800-11e5-8cbf-faf9157e3294.png)

### After
![screen shot 2016-01-11 at 9 49 21 am](https://cloud.githubusercontent.com/assets/351763/12230454/a3730894-b848-11e5-8d93-0998b13b8e11.png)

