### PR TITLE
Update link to check british by descent

### DIFF
--- a/lib/smart_answer_flows/register-a-birth/questions/who_has_british_nationality.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/questions/who_has_british_nationality.govspeak.erb
@@ -10,6 +10,6 @@
 ) %>
 
 <% content_for :body do %>
-  If the British parent was born abroad, they may be a British citizen ‘by descent’. This means they may not be allowed to pass on their British nationality to a child also born abroad. [Check if the parent is a British citizen](/check-british-citizen).
+  If the British parent was born abroad, they may be a British citizen ‘by descent’. This means they may not be allowed to pass on their British nationality to a child also born abroad. [Check if the parent is a British citizen by descent](/check-british-citizen).
 
 <% end %>

--- a/test/artefacts/register-a-birth/afghanistan.html
+++ b/test/artefacts/register-a-birth/afghanistan.html
@@ -35,7 +35,7 @@
     Who has British nationality?
   </h2>
   <div class="question-body">
-    <p>If the British parent was born abroad, they may be a British citizen ‘by descent’. This means they may not be allowed to pass on their British nationality to a child also born abroad. <a href="/check-british-citizen">Check if the parent is a British citizen</a>.</p>
+    <p>If the British parent was born abroad, they may be a British citizen ‘by descent’. This means they may not be allowed to pass on their British nationality to a child also born abroad. <a href="/check-british-citizen">Check if the parent is a British citizen by descent</a>.</p>
 
 
 

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -15,7 +15,7 @@ lib/smart_answer_flows/register-a-birth/questions/have_you_adopted_the_child.gov
 lib/smart_answer_flows/register-a-birth/questions/married_couple_or_civil_partnership.govspeak.erb: a2dba2ba31c300f55b1588bfbec4deb9
 lib/smart_answer_flows/register-a-birth/questions/where_are_you_now.govspeak.erb: ad17b2c0caf3785c34b0656af5543309
 lib/smart_answer_flows/register-a-birth/questions/which_country.govspeak.erb: 913b5637a2814cbd529affffc55b1f72
-lib/smart_answer_flows/register-a-birth/questions/who_has_british_nationality.govspeak.erb: 3e482183d55ccc5f7548d5a5d4034375
+lib/smart_answer_flows/register-a-birth/questions/who_has_british_nationality.govspeak.erb: 9a1a1acec4abc5a3f5199ab2eae0cd1c
 lib/smart_answer_flows/register-a-birth/register_a_birth.govspeak.erb: 05cf2d9426fc91f395fc524fdfdac800
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/109537798

Amends link to check British citizenship to be specific to the register a birth question where the parent may be British by descent.

## Fact check

https://serene-lowlands-8033.herokuapp.com/register-a-birth/y/barbados

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/register-a-birth/y/barbados)
  * Link "Check if the parent is a British citizen" becomes "Check if the parent is a British citizen"

### Before
![screen shot 2015-12-21 at 4 53 23 pm](https://cloud.githubusercontent.com/assets/351763/11936178/08a7a6b6-a804-11e5-9b06-9477815e90b8.png)

### After
![screen shot 2015-12-21 at 4 53 29 pm](https://cloud.githubusercontent.com/assets/351763/11936180/0f711572-a804-11e5-8ae1-068988e08a47.png)

