### PR TITLE
Marriage abroad civil partnership amend

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_no_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_no_cni.govspeak.erb
@@ -47,7 +47,7 @@
     <% end %>
   <% end %>
 
-  There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in <%= country_name_lowercase_prefix %>.
+  There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in <%= country_name_lowercase_prefix %>.
 
   <% if partner_nationality != 'partner_british' %>
     <%= render partial: 'partner_naturalisation_in_uk.govspeak.erb' %>

--- a/test/artefacts/marriage-abroad/argentina/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/argentina/ceremony_country/partner_british/same_sex.txt
@@ -11,5 +11,5 @@ Same-sex relationships in Argentina that are recognised as civil partnerships un
 
 Contact the relevant local authorities in Argentina to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Argentina.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Argentina.
 

--- a/test/artefacts/marriage-abroad/argentina/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/argentina/ceremony_country/partner_local/same_sex.txt
@@ -11,7 +11,7 @@ Same-sex relationships in Argentina that are recognised as civil partnerships un
 
 Contact the relevant local authorities in Argentina to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Argentina.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Argentina.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/argentina/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/argentina/ceremony_country/partner_other/same_sex.txt
@@ -11,7 +11,7 @@ Same-sex relationships in Argentina that are recognised as civil partnerships un
 
 Contact the relevant local authorities in Argentina to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Argentina.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Argentina.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/argentina/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/argentina/third_country/partner_british/same_sex.txt
@@ -11,5 +11,5 @@ Same-sex relationships in Argentina that are recognised as civil partnerships un
 
 Contact the relevant local authorities in Argentina to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Argentina.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Argentina.
 

--- a/test/artefacts/marriage-abroad/argentina/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/argentina/third_country/partner_local/same_sex.txt
@@ -11,7 +11,7 @@ Same-sex relationships in Argentina that are recognised as civil partnerships un
 
 Contact the relevant local authorities in Argentina to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Argentina.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Argentina.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/argentina/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/argentina/third_country/partner_other/same_sex.txt
@@ -11,7 +11,7 @@ Same-sex relationships in Argentina that are recognised as civil partnerships un
 
 Contact the relevant local authorities in Argentina to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Argentina.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Argentina.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/argentina/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/argentina/uk/partner_british/same_sex.txt
@@ -11,5 +11,5 @@ Same-sex relationships in Argentina that are recognised as civil partnerships un
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing Argentina before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Argentina.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Argentina.
 

--- a/test/artefacts/marriage-abroad/argentina/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/argentina/uk/partner_local/same_sex.txt
@@ -11,7 +11,7 @@ Same-sex relationships in Argentina that are recognised as civil partnerships un
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing Argentina before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Argentina.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Argentina.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/argentina/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/argentina/uk/partner_other/same_sex.txt
@@ -11,7 +11,7 @@ Same-sex relationships in Argentina that are recognised as civil partnerships un
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing Argentina before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Argentina.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Argentina.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/ceremony_country/partner_british/same_sex.txt
@@ -13,5 +13,5 @@ Bonaire St Eustatius Saba is one of the Dutch Caribbean islands.
 
 Contact the relevant local authorities in Bonaire St Eustatius Saba to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Bonaire St Eustatius Saba.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Bonaire St Eustatius Saba.
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/ceremony_country/partner_local/same_sex.txt
@@ -13,7 +13,7 @@ Bonaire St Eustatius Saba is one of the Dutch Caribbean islands.
 
 Contact the relevant local authorities in Bonaire St Eustatius Saba to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Bonaire St Eustatius Saba.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Bonaire St Eustatius Saba.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/ceremony_country/partner_other/same_sex.txt
@@ -13,7 +13,7 @@ Bonaire St Eustatius Saba is one of the Dutch Caribbean islands.
 
 Contact the relevant local authorities in Bonaire St Eustatius Saba to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Bonaire St Eustatius Saba.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Bonaire St Eustatius Saba.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/third_country/partner_british/same_sex.txt
@@ -13,5 +13,5 @@ Bonaire St Eustatius Saba is one of the Dutch Caribbean islands.
 
 Contact the relevant local authorities in Bonaire St Eustatius Saba to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Bonaire St Eustatius Saba.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Bonaire St Eustatius Saba.
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/third_country/partner_local/same_sex.txt
@@ -13,7 +13,7 @@ Bonaire St Eustatius Saba is one of the Dutch Caribbean islands.
 
 Contact the relevant local authorities in Bonaire St Eustatius Saba to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Bonaire St Eustatius Saba.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Bonaire St Eustatius Saba.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/third_country/partner_other/same_sex.txt
@@ -13,7 +13,7 @@ Bonaire St Eustatius Saba is one of the Dutch Caribbean islands.
 
 Contact the relevant local authorities in Bonaire St Eustatius Saba to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Bonaire St Eustatius Saba.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Bonaire St Eustatius Saba.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_british/same_sex.txt
@@ -13,5 +13,5 @@ Bonaire St Eustatius Saba is one of the Dutch Caribbean islands.
 
 Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Bonaire St Eustatius Saba.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Bonaire St Eustatius Saba.
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_local/same_sex.txt
@@ -13,7 +13,7 @@ Bonaire St Eustatius Saba is one of the Dutch Caribbean islands.
 
 Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Bonaire St Eustatius Saba.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Bonaire St Eustatius Saba.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_other/same_sex.txt
@@ -13,7 +13,7 @@ Bonaire St Eustatius Saba is one of the Dutch Caribbean islands.
 
 Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Bonaire St Eustatius Saba.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Bonaire St Eustatius Saba.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/burundi/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/ceremony_country/partner_british/same_sex.txt
@@ -8,5 +8,5 @@ Civil partnership in Burundi
 
 Contact the relevant local authorities in Burundi to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Burundi.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Burundi.
 

--- a/test/artefacts/marriage-abroad/burundi/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/ceremony_country/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ Civil partnership in Burundi
 
 Contact the relevant local authorities in Burundi to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Burundi.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Burundi.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/burundi/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/ceremony_country/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ Civil partnership in Burundi
 
 Contact the relevant local authorities in Burundi to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Burundi.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Burundi.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/burundi/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/third_country/partner_british/same_sex.txt
@@ -8,5 +8,5 @@ Civil partnership in Burundi
 
 Contact the relevant local authorities in Burundi to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Burundi.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Burundi.
 

--- a/test/artefacts/marriage-abroad/burundi/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/third_country/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ Civil partnership in Burundi
 
 Contact the relevant local authorities in Burundi to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Burundi.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Burundi.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/burundi/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/third_country/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ Civil partnership in Burundi
 
 Contact the relevant local authorities in Burundi to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Burundi.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Burundi.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/burundi/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/uk/partner_british/same_sex.txt
@@ -8,5 +8,5 @@ Civil partnership in Burundi
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing Burundi before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Burundi.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Burundi.
 

--- a/test/artefacts/marriage-abroad/burundi/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/uk/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ Civil partnership in Burundi
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing Burundi before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Burundi.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Burundi.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/burundi/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/uk/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ Civil partnership in Burundi
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing Burundi before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Burundi.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Burundi.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_british/same_sex.txt
@@ -12,5 +12,5 @@ Same-sex relationships in Mexico that are recognised as civil partnerships under
 
 Contact the relevant local authorities in Mexico to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Mexico.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Mexico.
 

--- a/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_local/same_sex.txt
@@ -12,7 +12,7 @@ Same-sex relationships in Mexico that are recognised as civil partnerships under
 
 Contact the relevant local authorities in Mexico to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Mexico.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Mexico.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_other/same_sex.txt
@@ -12,7 +12,7 @@ Same-sex relationships in Mexico that are recognised as civil partnerships under
 
 Contact the relevant local authorities in Mexico to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Mexico.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Mexico.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/mexico/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/third_country/partner_british/same_sex.txt
@@ -12,5 +12,5 @@ Same-sex relationships in Mexico that are recognised as civil partnerships under
 
 Contact the relevant local authorities in Mexico to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Mexico.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Mexico.
 

--- a/test/artefacts/marriage-abroad/mexico/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/third_country/partner_local/same_sex.txt
@@ -12,7 +12,7 @@ Same-sex relationships in Mexico that are recognised as civil partnerships under
 
 Contact the relevant local authorities in Mexico to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Mexico.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Mexico.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/mexico/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/third_country/partner_other/same_sex.txt
@@ -12,7 +12,7 @@ Same-sex relationships in Mexico that are recognised as civil partnerships under
 
 Contact the relevant local authorities in Mexico to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Mexico.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Mexico.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/mexico/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/uk/partner_british/same_sex.txt
@@ -12,5 +12,5 @@ Same-sex relationships in Mexico that are recognised as civil partnerships under
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing Mexico before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Mexico.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Mexico.
 

--- a/test/artefacts/marriage-abroad/mexico/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/uk/partner_local/same_sex.txt
@@ -12,7 +12,7 @@ Same-sex relationships in Mexico that are recognised as civil partnerships under
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing Mexico before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Mexico.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Mexico.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/mexico/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/uk/partner_other/same_sex.txt
@@ -12,7 +12,7 @@ Same-sex relationships in Mexico that are recognised as civil partnerships under
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing Mexico before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in Mexico.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in Mexico.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/new-zealand/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/new-zealand/ceremony_country/partner_british/same_sex.txt
@@ -8,5 +8,5 @@ You may be able to get married or enter into a ‘civil union’ at the British 
 
 Contact the relevant local authorities in New Zealand to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in New Zealand.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in New Zealand.
 

--- a/test/artefacts/marriage-abroad/new-zealand/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/new-zealand/ceremony_country/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ You may be able to get married or enter into a ‘civil union’ at the British 
 
 Contact the relevant local authorities in New Zealand to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in New Zealand.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in New Zealand.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/new-zealand/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/new-zealand/ceremony_country/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ You may be able to get married or enter into a ‘civil union’ at the British 
 
 Contact the relevant local authorities in New Zealand to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in New Zealand.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in New Zealand.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/new-zealand/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/new-zealand/third_country/partner_british/same_sex.txt
@@ -8,5 +8,5 @@ You may be able to get married or enter into a ‘civil union’ at the British 
 
 Contact the relevant local authorities in New Zealand to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in New Zealand.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in New Zealand.
 

--- a/test/artefacts/marriage-abroad/new-zealand/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/new-zealand/third_country/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ You may be able to get married or enter into a ‘civil union’ at the British 
 
 Contact the relevant local authorities in New Zealand to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in New Zealand.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in New Zealand.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/new-zealand/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/new-zealand/third_country/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ You may be able to get married or enter into a ‘civil union’ at the British 
 
 Contact the relevant local authorities in New Zealand to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in New Zealand.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in New Zealand.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/new-zealand/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/new-zealand/uk/partner_british/same_sex.txt
@@ -8,5 +8,5 @@ You may be able to get married or enter into a ‘civil union’ at the British 
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing New Zealand before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in New Zealand.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in New Zealand.
 

--- a/test/artefacts/marriage-abroad/new-zealand/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/new-zealand/uk/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ You may be able to get married or enter into a ‘civil union’ at the British 
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing New Zealand before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in New Zealand.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in New Zealand.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/new-zealand/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/new-zealand/uk/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ You may be able to get married or enter into a ‘civil union’ at the British 
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing New Zealand before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in New Zealand.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in New Zealand.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/usa/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/ceremony_country/partner_british/same_sex.txt
@@ -30,5 +30,5 @@ Same-sex relationships in US states that are recognised as civil partnerships un
 
 Contact the relevant local authorities in the USA to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in the USA.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 

--- a/test/artefacts/marriage-abroad/usa/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/ceremony_country/partner_local/same_sex.txt
@@ -30,7 +30,7 @@ Same-sex relationships in US states that are recognised as civil partnerships un
 
 Contact the relevant local authorities in the USA to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in the USA.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/usa/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/ceremony_country/partner_other/same_sex.txt
@@ -30,7 +30,7 @@ Same-sex relationships in US states that are recognised as civil partnerships un
 
 Contact the relevant local authorities in the USA to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in the USA.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/usa/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/third_country/partner_british/same_sex.txt
@@ -30,5 +30,5 @@ Same-sex relationships in US states that are recognised as civil partnerships un
 
 Contact the relevant local authorities in the USA to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in the USA.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 

--- a/test/artefacts/marriage-abroad/usa/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/third_country/partner_local/same_sex.txt
@@ -30,7 +30,7 @@ Same-sex relationships in US states that are recognised as civil partnerships un
 
 Contact the relevant local authorities in the USA to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in the USA.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/usa/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/third_country/partner_other/same_sex.txt
@@ -30,7 +30,7 @@ Same-sex relationships in US states that are recognised as civil partnerships un
 
 Contact the relevant local authorities in the USA to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in the USA.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/usa/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/uk/partner_british/same_sex.txt
@@ -30,5 +30,5 @@ Same-sex relationships in US states that are recognised as civil partnerships un
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing the USA before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in the USA.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 

--- a/test/artefacts/marriage-abroad/usa/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/uk/partner_local/same_sex.txt
@@ -30,7 +30,7 @@ Same-sex relationships in US states that are recognised as civil partnerships un
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing the USA before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in the USA.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/artefacts/marriage-abroad/usa/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/uk/partner_other/same_sex.txt
@@ -30,7 +30,7 @@ Same-sex relationships in US states that are recognised as civil partnerships un
 
 Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing the USA before making any plans to find out about local laws, including what documents you’ll need.
 
-There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in the USA.
+There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -91,7 +91,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_all_other_countries.g
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_commonwealth_countries.govspeak.erb: 3a47e4e91c7d14eb3b7977caacd25b2a
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_consular.govspeak.erb: 2a32ffdc9655b2268bfb322a84bb7d8c
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_france_pacs.govspeak.erb: 1eef5da75250dff504b7667777f0a08e
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_no_cni.govspeak.erb: ac6c3addf16df4946edf742c78698a56
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_no_cni.govspeak.erb: 84bba7c2c8eba5ddc97fa66e1b82a196
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_or_equivalent.govspeak.erb: 6a1fcab7388db4800ad613cd367762ea
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ireland.govspeak.erb: d1cd076fbc8c1c5304e35be6b8041d95
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_marriage_via_local_authorities.govspeak.erb: 6fbc4c0fa89a7bcb3f1a0b33ab8eec43


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/n/projects/1270592/stories/109439008

This PR adds a missing word in civil partnerships outcome for non-CNI countries. It was originally included as part of PR #2194 but was moved out into its own PR as it changes more than just USA outcomes.

## Expected change
 * [URL on gov.uk](https://www.gov.uk/marriage-abroad/y/usa/uk/partner_british/same_sex)
  * Updates second sentence from "eligible enter" to "eligible to enter"

### Before
![screen shot 2015-12-17 at 10 33 58 am](https://cloud.githubusercontent.com/assets/351763/11867583/f887f5d6-a4a9-11e5-9553-8a2da4335b9c.png)

### After
![screen shot 2015-12-17 at 10 35 07 am](https://cloud.githubusercontent.com/assets/351763/11867591/fcf63376-a4a9-11e5-9523-7a6990576633.png)

Note: This PR was previously merged as part of PR #2198 but then reverted to rebase it, so Jenkins can merge it onto the release branch as part of the build.