### PR TITLE
Update legalisation document checker headings

### DIFF
--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -145,6 +145,7 @@
       ##Pet export document from DEFRA
       Your pet export document can only be legalised if it has been signed and stamped by a veterinary surgeon registered with the Department of Food and Rural Affairs.
     <% end %>
+
   <% end %>
 
   <% if no_content %>

--- a/test/data/legalisation-document-checker-files.yml
+++ b/test/data/legalisation-document-checker-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/legalisation-document-checker.rb: b467124147814649224b01c
 test/data/legalisation-document-checker-questions-and-responses.yml: 37c99c68ba04e459447622b01938ce0b
 test/data/legalisation-document-checker-responses-and-expected-results.yml: d55ccccc64cc1f58b648e810e5fa07e5
 lib/smart_answer_flows/legalisation-document-checker/legalisation_document_checker.govspeak.erb: 4be67b8e3aeebe4f3b99a5153b92ccdf
-lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb: 00c464b05564abf1824e3da37bca1d24
+lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb: 2a5010d551c4862e4a9af98bb2bb6a79
 lib/smart_answer_flows/legalisation-document-checker/questions/which_documents_do_you_want_legalised.govspeak.erb: 807d6bee48fd47731d066aab6ad50544
 lib/smart_answer/calculators/legalisation_documents_data_query.rb: 31d5eec29a4cf4e27a4204e8f08132f9
 lib/data/legalisation_documents_data.yml: 788f0f6cbd9b35be712f9aca7c871591


### PR DESCRIPTION
Adds missing line break to put each heading on it's own newline when rendered inside a loop, ensuring markdown renders headings correctly.

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/legalisation-document-checker/y/affidavit,articles-of-association,bank-statement)
  * Each heading - Affidavit, Articles of association and Bank statement should be rendered on its own line with the correct font weight and size.

### Before
![screen shot 2015-12-21 at 12 25 52 pm](https://cloud.githubusercontent.com/assets/351763/11930798/7fef2508-a7de-11e5-801b-38a67ecc0cbf.png)

### After
![screen shot 2015-12-21 at 12 26 02 pm](https://cloud.githubusercontent.com/assets/351763/11930802/8584119a-a7de-11e5-8fc9-336e24f28d89.png)

Note: This PR was previously merged as part of PR #2206 but then reverted to rebase it with the master branch, so Jenkins can merge it onto the release branch as part of the build.