### PR TITLE
Update student allowance outcome

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb
@@ -4,11 +4,11 @@
 
 <% content_for :body do %>
 
-  There are two different forms.  You only need to complete one.
+  There are 2 different forms.  You only need to complete one.
 
   If you’re only applying for DSA and no other student finance, complete the DSA1 full.
 
-  Academic Year | Form
+  Academic year | Form
   - | -
   2015 to 2016 | [DSA1 - full form (PDF, 282KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_form_1516_d.pdf)
   2015 to 2016 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
@@ -16,7 +16,7 @@
   If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
 
 
-  Academic Year | Form
+  Academic year | Form
   - | -
   2015 to 2016 | [DSA - slim form (PDF, 122KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa_slim_form_1516_d.pdf)
 

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-dsa/year-1516.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-dsa/year-1516.txt
@@ -1,18 +1,18 @@
 Disabled Students' Allowances
 
 
-There are two different forms.  You only need to complete one.
+There are 2 different forms.  You only need to complete one.
 
 If you’re only applying for DSA and no other student finance, complete the DSA1 full.
 
-Academic Year | Form
+Academic year | Form
 - | -
 2015 to 2016 | [DSA1 - full form (PDF, 282KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_form_1516_d.pdf)
 2015 to 2016 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
 
 If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
 
-Academic Year | Form
+Academic year | Form
 - | -
 2015 to 2016 | [DSA - slim form (PDF, 122KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa_slim_form_1516_d.pdf)
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -10,7 +10,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1516.govspeak.
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 6d17c37622196bdd568ee6bf3ca12351
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1415.govspeak.erb: 28be62b617f9d16efe440ac51bca8b06
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1415_pt.govspeak.erb: 7198976bdc668c05a71973041eb9107d
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb: cc283294a806d4a5000838a2c3af50d4
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516.govspeak.erb: 5dadef6e9f2457405f19272b32f1f398
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.govspeak.erb: 85bbcaa668f9e3312a3d434acc060461
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_expenses.govspeak.erb: 83e8b32ee7412461815f6feccf6cba96
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1415_continuing.govspeak.erb: c3cdebfa03aad871951e947e191d7503


### PR DESCRIPTION
This PR supersedes #2190 

Change 'two' to '2', and change case of 'year' in 'academic year' because style.

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/student-finance-forms/y/uk-full-time/apply-dsa/year-1516)
  * The first sentance should replace the word two with the number 2
  * Both instances of table header Academic Year should appear as Academic year

### Before
![screen shot 2015-12-15 at 07 07 33](https://cloud.githubusercontent.com/assets/351763/11804392/5bdb3d56-a2fb-11e5-921b-3c5ee3615206.png)

### After
![screen shot 2015-12-15 at 07 07 38](https://cloud.githubusercontent.com/assets/351763/11804397/617acc86-a2fb-11e5-8fa1-f749fb9fbd5d.png)

Note: this PR supersedes #2191 which was merged to the master branch, but reverted after the merge to the release branch by Jenkins failed.