### PR TITLE
Amend USA marriage abroad outcome

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_no_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_no_cni.govspeak.erb
@@ -60,10 +60,6 @@
     <% end %>
   <% end %>
 
-  <% if ceremony_country == 'usa' %>
-    ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-  <% end %>
-
   There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in <%= country_name_lowercase_prefix %>.
 
   <% if partner_nationality != 'partner_british' %>

--- a/test/artefacts/marriage-abroad/usa/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/ceremony_country/partner_british/same_sex.txt
@@ -8,7 +8,5 @@ Contact the local authorities in the state you want to get married in the USA to
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-
 There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 

--- a/test/artefacts/marriage-abroad/usa/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/ceremony_country/partner_local/same_sex.txt
@@ -8,8 +8,6 @@ Contact the local authorities in the state you want to get married in the USA to
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-
 There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK

--- a/test/artefacts/marriage-abroad/usa/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/ceremony_country/partner_other/same_sex.txt
@@ -8,8 +8,6 @@ Contact the local authorities in the state you want to get married in the USA to
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-
 There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK

--- a/test/artefacts/marriage-abroad/usa/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/third_country/partner_british/same_sex.txt
@@ -8,7 +8,5 @@ Contact the local authorities in the state you want to get married in the USA to
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-
 There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 

--- a/test/artefacts/marriage-abroad/usa/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/third_country/partner_local/same_sex.txt
@@ -8,8 +8,6 @@ Contact the local authorities in the state you want to get married in the USA to
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-
 There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK

--- a/test/artefacts/marriage-abroad/usa/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/third_country/partner_other/same_sex.txt
@@ -8,8 +8,6 @@ Contact the local authorities in the state you want to get married in the USA to
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-
 There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK

--- a/test/artefacts/marriage-abroad/usa/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/uk/partner_british/same_sex.txt
@@ -8,7 +8,5 @@ Contact the local authorities in the state you want to get married in the USA to
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-
 There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 

--- a/test/artefacts/marriage-abroad/usa/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/uk/partner_local/same_sex.txt
@@ -8,8 +8,6 @@ Contact the local authorities in the state you want to get married in the USA to
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-
 There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK

--- a/test/artefacts/marriage-abroad/usa/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/usa/uk/partner_other/same_sex.txt
@@ -8,8 +8,6 @@ Contact the local authorities in the state you want to get married in the USA to
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
-
 There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible to enter into a same-sex relationship, in the USA.
 
 ##Naturalisation of your partner if they move to the UK

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -91,7 +91,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_all_other_countries.g
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_commonwealth_countries.govspeak.erb: 207c201f9c1c941bb6775122724527d8
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_consular.govspeak.erb: 2a32ffdc9655b2268bfb322a84bb7d8c
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_france_pacs.govspeak.erb: 1eef5da75250dff504b7667777f0a08e
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_no_cni.govspeak.erb: f51838dba2c2b6dcbaf1142bffb41478
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_no_cni.govspeak.erb: 7846411334ef8709886312a503516a9a
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_or_equivalent.govspeak.erb: e20fe7b9def33ad2a452345123ba0a1b
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ireland.govspeak.erb: d1cd076fbc8c1c5304e35be6b8041d95
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_marriage_via_local_authorities.govspeak.erb: 9bdf727343008a2430484b78e26d5b11


### PR DESCRIPTION
PR #2223 introduced a duplicated piece of content on several of the outcome pages.

This PR removes this change.

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/marriage-abroad/y/usa/uk/partner_british/same_sex?abc=xyz)
  * Removes duplicated callout ^You should get legal advice before making any plans.^

### Before
![screen shot 2015-12-23 at 4 10 35 pm](https://cloud.githubusercontent.com/assets/351763/11980160/bee126a4-a990-11e5-998b-2bab17bba65a.png)

### After
![screen shot 2015-12-23 at 4 10 48 pm](https://cloud.githubusercontent.com/assets/351763/11980163/c439c516-a990-11e5-96f6-06efbd6fcf5b.png)


