### PR TITLE
Added new Feb 2016 code of practice docs

### DIFF
--- a/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Does the person have 2 of the following:
+  The 2 documents that the person needs to show you depends on where your property is. 
 <% end %>
 
 <% options(
@@ -8,15 +8,25 @@
 ) %>
 
 <% content_for :body do %>
-  - a full birth or adoption certificate (that shows details of at least one of the birth
-  or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland
+  If it's in any part of England:
+
+  - a full birth or adoption certificate (that shows details of at least one of the birth or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland
   - an official letter or document (dated within the last 3 months) from a government agency or department (with their name and work address), an employer (with their name and company address) or UK passport holder (with their name, address and passport number) that confirms the person’s name and that they’re an employee
   - a letter from a UK police force issued within the last 3 months confirming the person is a victim of crime and their documents have been stolen
   - evidence that the person is currently serving in the UK armed forces or has previously served
-  - HM prison discharge papers or probation service letter (or the same from the Scottish or Northern Ireland Prison Service)
   - a letter from a UK further or higher education institution confirming the person has been accepted for studies
   - a current UK driving licence (either full or provisional)
-  - a current UK firearms or shot gun certificate
   - a Disclosure or Barring Service certificate issued in the last 6 months
-  - benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus within the last 12 months
-<% end %>
+  - benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus within the last 3 months
+
+If it's in Birmingham, Walsall, Sandwell, Dudley or Wolverhampton (but not the rest of England), they can also show you:
+
+- a current UK firearms or shotgun certificate
+- HM prison discharge papers or probation service letter dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
+
+If it's in England (but not including Birmingham, Walsall, Sandwell, Dudley or Wolverhampton), they can also show you:
+
+- a letter from an organisation that operates a scheme to prevent or resolve homelessness
+- a letter showing supervision order dated in the last 3 months from the National Offender Management Service in England and Wales (or the equivalents in Scotland or Northern Ireland) 
+- HM prison discharge papers dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
+- a letter from a British passport holder who does a job listed in annex A of the [code of practice](/government/uploads/system/uploads/attachment_data/file/485837/53041_Draft_unnum_with_watermark_Accessible.pdf) and has known the person for at least 3 months (with their name, address, passport number, job and place of work (or former place of work if retired), and how long they have known the holder and in what capacity)<% end %>


### PR DESCRIPTION
There's a separate code of practice for tenancy checks in the rest of England that start in Feb 2016. There's a slightly different valid document list, so in the absence of a logic change, I've split the docs into areas.

https://www.pivotaltracker.com/story/show/110842668

This outcome appears on /landlord-immigration-check/y/B5%204BU/yes/yes/no/no/no/somewhere_else and /landlord-immigration-check/y/B5%204BU/yes/yes/no/no/no/eu_eea_switzerland/no
