### PR TITLE
Update landlord immigration outcome

### DIFF
--- a/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Does the person have 2 of the following:
+  The 2 documents that the person needs to show you depends on where your property is. 
 <% end %>
 
 <% options(
@@ -8,15 +8,25 @@
 ) %>
 
 <% content_for :body do %>
-  - a full birth or adoption certificate (that shows details of at least one of the birth
-  or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland
+  If it's in any part of England:
+
+  - a full birth or adoption certificate (that shows details of at least one of the birth or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland
   - an official letter or document (dated within the last 3 months) from a government agency or department (with their name and work address), an employer (with their name and company address) or UK passport holder (with their name, address and passport number) that confirms the person’s name and that they’re an employee
   - a letter from a UK police force issued within the last 3 months confirming the person is a victim of crime and their documents have been stolen
   - evidence that the person is currently serving in the UK armed forces or has previously served
-  - HM prison discharge papers or probation service letter (or the same from the Scottish or Northern Ireland Prison Service)
   - a letter from a UK further or higher education institution confirming the person has been accepted for studies
   - a current UK driving licence (either full or provisional)
-  - a current UK firearms or shot gun certificate
   - a Disclosure or Barring Service certificate issued in the last 6 months
-  - benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus within the last 12 months
-<% end %>
+  - benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus within the last 3 months
+
+If it's in Birmingham, Walsall, Sandwell, Dudley or Wolverhampton (but not the rest of England), they can also show you:
+
+- a current UK firearms or shotgun certificate
+- HM prison discharge papers or probation service letter dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
+
+If it's in England (but not including Birmingham, Walsall, Sandwell, Dudley or Wolverhampton), they can also show you:
+
+- a letter from an organisation that operates a scheme to prevent or resolve homelessness
+- a letter showing supervision order dated in the last 3 months from the National Offender Management Service in England and Wales (or the equivalents in Scotland or Northern Ireland) 
+- HM prison discharge papers dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
+- a letter from a British passport holder who does a job listed in annex A of the [code of practice](/government/uploads/system/uploads/attachment_data/file/485837/53041_Draft_unnum_with_watermark_Accessible.pdf) and has known the person for at least 3 months (with their name, address, passport number, job and place of work (or former place of work if retired), and how long they have known the holder and in what capacity)<% end %>

--- a/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  The 2 documents that the person needs to show you depends on where your property is. 
+  The 2 documents that the person needs to show you depends on where your property is.
 <% end %>
 
 <% options(
@@ -19,14 +19,15 @@
   - a Disclosure or Barring Service certificate issued in the last 6 months
   - benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus within the last 3 months
 
-If it's in Birmingham, Walsall, Sandwell, Dudley or Wolverhampton (but not the rest of England), they can also show you:
+  If it's in Birmingham, Walsall, Sandwell, Dudley or Wolverhampton (but not the rest of England), they can also show you:
 
-- a current UK firearms or shotgun certificate
-- HM prison discharge papers or probation service letter dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
+  - a current UK firearms or shotgun certificate
+  - HM prison discharge papers or probation service letter dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
 
-If it's in England (but not including Birmingham, Walsall, Sandwell, Dudley or Wolverhampton), they can also show you:
+  If it's in England (but not including Birmingham, Walsall, Sandwell, Dudley or Wolverhampton), they can also show you:
 
-- a letter from an organisation that operates a scheme to prevent or resolve homelessness
-- a letter showing supervision order dated in the last 3 months from the National Offender Management Service in England and Wales (or the equivalents in Scotland or Northern Ireland) 
-- HM prison discharge papers dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
-- a letter from a British passport holder who does a job listed in annex A of the [code of practice](/government/uploads/system/uploads/attachment_data/file/485837/53041_Draft_unnum_with_watermark_Accessible.pdf) and has known the person for at least 3 months (with their name, address, passport number, job and place of work (or former place of work if retired), and how long they have known the holder and in what capacity)<% end %>
+  - a letter from an organisation that operates a scheme to prevent or resolve homelessness
+  - a letter showing supervision order dated in the last 3 months from the National Offender Management Service in England and Wales (or the equivalents in Scotland or Northern Ireland)
+  - HM prison discharge papers dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
+  - a letter from a British passport holder who does a job listed in annex A of the [code of practice](/government/uploads/system/uploads/attachment_data/file/485837/53041_Draft_unnum_with_watermark_Accessible.pdf) and has known the person for at least 3 months (with their name, address, passport number, job and place of work (or former place of work if retired), and how long they have known the holder and in what capacity)
+<% end %>

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no.html
@@ -32,21 +32,36 @@
         <div class="current-question" id="current-question">
           <div class="question">
   <h2>
-    Does the person have 2 of the following:
+    The 2 documents that the person needs to show you depends on where your property is.
   </h2>
   <div class="question-body">
-    <ul>
-  <li>a full birth or adoption certificate (that shows details of at least one of the birth
-or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland</li>
+    <p>If it&rsquo;s in any part of England:</p>
+
+<ul>
+  <li>a full birth or adoption certificate (that shows details of at least one of the birth or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland</li>
   <li>an official letter or document (dated within the last 3 months) from a government agency or department (with their name and work address), an employer (with their name and company address) or UK passport holder (with their name, address and passport number) that confirms the person’s name and that they’re an employee</li>
   <li>a letter from a UK police force issued within the last 3 months confirming the person is a victim of crime and their documents have been stolen</li>
   <li>evidence that the person is currently serving in the UK armed forces or has previously served</li>
-  <li>HM prison discharge papers or probation service letter (or the same from the Scottish or Northern Ireland Prison Service)</li>
   <li>a letter from a UK further or higher education institution confirming the person has been accepted for studies</li>
   <li>a current UK driving licence (either full or provisional)</li>
-  <li>a current UK firearms or shot gun certificate</li>
   <li>a Disclosure or Barring Service certificate issued in the last 6 months</li>
-  <li>benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus within the last 12 months</li>
+  <li>benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus within the last 3 months</li>
+</ul>
+
+<p>If it&rsquo;s in Birmingham, Walsall, Sandwell, Dudley or Wolverhampton (but not the rest of England), they can also show you:</p>
+
+<ul>
+  <li>a current UK firearms or shotgun certificate</li>
+  <li>HM prison discharge papers or probation service letter dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)</li>
+</ul>
+
+<p>If it&rsquo;s in England (but not including Birmingham, Walsall, Sandwell, Dudley or Wolverhampton), they can also show you:</p>
+
+<ul>
+  <li>a letter from an organisation that operates a scheme to prevent or resolve homelessness</li>
+  <li>a letter showing supervision order dated in the last 3 months from the National Offender Management Service in England and Wales (or the equivalents in Scotland or Northern Ireland)</li>
+  <li>HM prison discharge papers dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)</li>
+  <li>a letter from a British passport holder who does a job listed in annex A of the <a href="/government/uploads/system/uploads/attachment_data/file/485837/53041_Draft_unnum_with_watermark_Accessible.pdf">code of practice</a> and has known the person for at least 3 months (with their name, address, passport number, job and place of work (or former place of work if retired), and how long they have known the holder and in what capacity)</li>
 </ul>
 
 

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no.html
@@ -172,13 +172,13 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Does the person have 2 of the following:</td>
+  <td class="previous-question-title">The 2 documents that the person needs to show you depends on where your property is.</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Does the person have 2 of the following:"</span>
+      Change<span class="visuallyhidden"> answer to "The 2 documents that the person needs to show you depends on where your property is."</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no.html
@@ -168,13 +168,13 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Does the person have 2 of the following:</td>
+  <td class="previous-question-title">The 2 documents that the person needs to show you depends on where your property is.</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Does the person have 2 of the following:"</span>
+      Change<span class="visuallyhidden"> answer to "The 2 documents that the person needs to show you depends on where your property is."</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no.html
@@ -168,13 +168,13 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Does the person have 2 of the following:</td>
+  <td class="previous-question-title">The 2 documents that the person needs to show you depends on where your property is.</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Does the person have 2 of the following:"</span>
+      Change<span class="visuallyhidden"> answer to "The 2 documents that the person needs to show you depends on where your property is."</span>
 </a>  </td>
 </tr>
 

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no/no.html
@@ -168,13 +168,13 @@
 </tr>
 
               <tr class="section">
-  <td class="previous-question-title">Does the person have 2 of the following:</td>
+  <td class="previous-question-title">The 2 documents that the person needs to show you depends on where your property is.</td>
     <td class="previous-question-body">
     No</td>
 
   <td class="link-right">
     <a href="/landlord-immigration-check/y/B1%201PW/yes/yes/no/no/no/eu_eea_switzerland/no?previous_response=no">
-      Change<span class="visuallyhidden"> answer to "Does the person have 2 of the following:"</span>
+      Change<span class="visuallyhidden"> answer to "The 2 documents that the person needs to show you depends on where your property is."</span>
 </a>  </td>
 </tr>
 

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -20,7 +20,7 @@ lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_check_not_nee
 lib/smart_answer_flows/landlord-immigration-check/questions/has_asylum_card.govspeak.erb: da15f9bb156eed4ff866cfba4072620b
 lib/smart_answer_flows/landlord-immigration-check/questions/has_certificate.govspeak.erb: c670d7bc733232a394b4caa93a6aefb9
 lib/smart_answer_flows/landlord-immigration-check/questions/has_documents.govspeak.erb: ea1250a0013c28b4a7cbcb0337219e16
-lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb: 2157c66688127c990cc2964dd0e09f86
+lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb: c206964ad0a4be9c80d8d85cb7e44540
 lib/smart_answer_flows/landlord-immigration-check/questions/has_residence_card_or_eu_eea_swiss_family_member.govspeak.erb: 566627594105a24069451ab40f540846
 lib/smart_answer_flows/landlord-immigration-check/questions/has_uk_passport.govspeak.erb: 294e10196ecf02efcc75eea4fd8c966c
 lib/smart_answer_flows/landlord-immigration-check/questions/immigration_application.govspeak.erb: c03287c66e6560432c56f1dea2e3dcba


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/110842668

There's a separate code of practice for tenancy checks in the rest of England that start in Feb 2016. There's a slightly different valid document list, so in the absence of a logic change, I've split the docs into areas.

## Fact check
https://mighty-beach-3538.herokuapp.com/landlord-immigration-check

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/landlord-immigration-check/y/B5%204BU/yes/yes/no/no/no/somewhere_else)
  * Splits the list of required documents per region

### Before
![screen shot 2016-01-01 at 10 51 54 am](https://cloud.githubusercontent.com/assets/351763/12069156/b8112612-b075-11e5-852d-b8470b280f9f.png)

### After
![screen shot 2016-01-04 at 9 10 00 pm](https://cloud.githubusercontent.com/assets/351763/12087491/913156f2-b327-11e5-998b-67ffc635a135.png)


This PR supercedes #2226 