### PR TITLE
Fix failing date dependent test

### DIFF
--- a/lib/smart_answer/calculators/state_pension_amount_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_amount_calculator.rb
@@ -207,7 +207,7 @@ module SmartAnswer::Calculators
     end
 
     def over_55?
-      dob <= 55.years.ago
+      Date.today >= dob.advance(years: 55)
     end
   end
 end

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -25,7 +25,7 @@ lib/smart_answer_flows/calculate-state-pension/questions/years_of_caring.govspea
 lib/smart_answer_flows/calculate-state-pension/questions/years_of_jsa.govspeak.erb: 3c6b46fd896efe8a31772cc12499fb76
 lib/smart_answer_flows/calculate-state-pension/questions/years_of_work.govspeak.erb: ba4c65820b3797c1cdecd4b06094ba57
 lib/smart_answer_flows/calculate-state-pension/questions/years_paid_ni.govspeak.erb: 7c6dfc7d6bdcba46aefed81a563328d2
-lib/smart_answer/calculators/state_pension_amount_calculator.rb: dc34ccef222287ea14e4c9c7af164a32
+lib/smart_answer/calculators/state_pension_amount_calculator.rb: 6454d70c0f95d7eb3ddfa3e97c6c40a8
 lib/data/rates/state_pension.yml: 7e97e88500fb698038c49332b48b82bf
 lib/data/state_pension_date_query.rb: ddb745e6cfdfc199c5003e66d674b0f0
 lib/data/state_pension_dates.yml: da1bdee8a5b42c489b3966c43b625113


### PR DESCRIPTION
This method seems to have been failing one test since we ticked over to 2016. After the test travels to Jan 1 2015 with Timecop, the call to 55.years.ago incorrectly goes a little too far:
```ruby
[1] pry(#<SmartAnswer::Calculators::StatePensionAmountCalculatorTest>)> 55.years.ago

=> Thu, 31 Dec 1959 13:00:00 UTC +00:00
```