### PR TITLE
Split list of acceptable docs by user's location

### DIFF
--- a/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
@@ -15,7 +15,7 @@
 
   In Birmingham, Walsall, Sandwell, Dudley or Wolverhampton, check tenancies that started on or after 1 December 2014.
 
-  If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](/government/publications/right-to-rent-landlords-code-of-practice).
+  If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](check-tenant-right-to-rent-documents).
 
   ^You can read more about the [right to rent documents](/government/publications/rules-and-acceptable-documents-right-to-rent-checks) you can accept as proof.^
 <% end %>

--- a/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
@@ -15,7 +15,7 @@
 
   In Birmingham, Walsall, Sandwell, Dudley or Wolverhampton, check tenancies that started on or after 1 December 2014.
 
-  If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](check-tenant-right-to-rent-documents).
+  If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](/check-tenant-right-to-rent-documents).
 
   ^You can read more about the [right to rent documents](/government/publications/rules-and-acceptable-documents-right-to-rent-checks) you can accept as proof.^
 <% end %>

--- a/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  The 2 documents that the person needs to show you depends on where your property is.
+  Does the person have 2 of the following:
 <% end %>
 
 <% options(
@@ -8,26 +8,17 @@
 ) %>
 
 <% content_for :body do %>
-  If it's in any part of England:
-
-  - a full birth or adoption certificate (that shows details of at least one of the birth or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland
-  - an official letter or document (dated within the last 3 months) from a government agency or department (with their name and work address), an employer (with their name and company address) or UK passport holder (with their name, address and passport number) that confirms the person’s name and that they’re an employee
+   - a full birth or adoption certificate (that shows details of at least one of the birth or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland
   - a letter from a UK police force issued within the last 3 months confirming the person is a victim of crime and their documents have been stolen
   - evidence that the person is currently serving in the UK armed forces or has previously served
-  - a letter from a UK further or higher education institution confirming the person has been accepted for studies
   - a current UK driving licence (either full or provisional)
-  - a Disclosure or Barring Service certificate issued in the last 6 months
+  - a Disclosure or Barring Service certificate issued in the last 3 months 
   - benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus within the last 3 months
 
-  If it's in Birmingham, Walsall, Sandwell, Dudley or Wolverhampton (but not the rest of England), they can also show you:
-
-  - a current UK firearms or shotgun certificate
-  - HM prison discharge papers or probation service letter dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
-
-  If it's in England (but not including Birmingham, Walsall, Sandwell, Dudley or Wolverhampton), they can also show you:
-
-  - a letter from an organisation that operates a scheme to prevent or resolve homelessness
-  - a letter showing supervision order dated in the last 3 months from the National Offender Management Service in England and Wales (or the equivalents in Scotland or Northern Ireland)
-  - HM prison discharge papers dated in the last 6 months (or the same from the Scottish or Northern Ireland Prison Service)
-  - a letter from a British passport holder who does a job listed in annex A of the [code of practice](/government/uploads/system/uploads/attachment_data/file/485837/53041_Draft_unnum_with_watermark_Accessible.pdf) and has known the person for at least 3 months (with their name, address, passport number, job and place of work (or former place of work if retired), and how long they have known the holder and in what capacity)
+	<% if calculator.included_borough? %>
+  		<%= render partial: '_pilot_documents.govspeak.erb' %>
+	<% elsif calculator.included_country? %>
+  		<%= render partial: '_england_documents.govspeak.erb' %>
+	<% end %>
+  
 <% end %>


### PR DESCRIPTION
Trying to simplify the view of documents that a prospective tenant has to show a landlord. 
I'm not sure if I've done the conditional renders correctly, but I'm hoping it will show the user a slightly different bullet list of documents depending on the location of their property. 
If they're in included_borough, they should see _pilot_documents.govspeak.erb.
If they're in included_country, they should see _england_documents.govspeak.erb.

Currently appears at: /landlord-immigration-check/y/B5%204RU/yes/yes/no/no/no/somewhere_else

This will need to go to the department for fact check.

From: https://www.pivotaltracker.com/story/show/110973118