### PR TITLE
Legalisation document checker amends

### DIFF
--- a/lib/data/legalisation_documents_data.yml
+++ b/lib/data/legalisation_documents_data.yml
@@ -106,7 +106,7 @@ department-of-health-document:
 diploma:
   heading: Diploma
   type: diploma
-  group: education_document
+  group: diploma
 disclosure-scotland-document:
   heading: Disclosure Scotland document
   type: Disclosure Scotland document

--- a/lib/data/legalisation_documents_data.yml
+++ b/lib/data/legalisation_documents_data.yml
@@ -206,7 +206,7 @@ police-disclosure-document:
 power-of-attorney:
   heading: Power of attorney
   type: power of attorney
-  group: solicitors_notaries
+  group: power_of_attorney
 probate:
   heading: Grant of probate
   type: grant of probate

--- a/lib/smart_answer_flows/legalisation-document-checker.rb
+++ b/lib/smart_answer_flows/legalisation-document-checker.rb
@@ -93,7 +93,7 @@ module SmartAnswer
 
         precalculate :no_content do
           # all apart from birth_death, certificate_impediment and vet_health
-          no_content = (groups_selected - ["birth_death" , "certificate_impediment", "vet_health"]).size > 0
+          no_content = (groups_selected - %w(birth_death certificate_impediment vet_health)).size > 0
         end
       end
     end

--- a/lib/smart_answer_flows/legalisation-document-checker.rb
+++ b/lib/smart_answer_flows/legalisation-document-checker.rb
@@ -92,8 +92,8 @@ module SmartAnswer
         end
 
         precalculate :no_content do
-          # all apart from birth_death, certificate_impediment and medical_reports
-          no_content = (groups_selected - ["birth_death" , "certificate_impediment", "medical_reports", "vet_health"]).size > 0
+          # all apart from birth_death, certificate_impediment and vet_health
+          no_content = (groups_selected - ["birth_death" , "certificate_impediment", "vet_health"]).size > 0
         end
       end
     end

--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -116,9 +116,6 @@
       - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
       - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/order-life-event-certificates/order-a-marriage-certificate.htm)
 
-      ^Non-GRO marriage certificates (eg Islamic marriage certificates) can't be legalised unless they are certified.^
-
-
       ^A photocopy of your document won’t be accepted.^
     <% when 'medical_reports' %>
       ##<%= heading %>

--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -104,7 +104,9 @@
 
       - an official certified copy of the certificate issued by the General Register Office (GRO) with the original seal
 
-      - an original certificate (or original certified copy) issued by a church, religious establishment or local register office, with the original signature of the official who issued the certificate
+      - an original GRO certificate (or original certified copy) issued by a church, religious establishment or local register office, with the original signature of the official who issued the certificate
+
+      ^If your certificate wasn't issued by the GRO (eg an Islamic marriage certificate), you must get it certified before it can be legalised.^
 
       It can take longer to legalise a signature on an original certificate, especially if it was issued before 1991.
 

--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -49,6 +49,26 @@
       - been certified
 
       It can take the Legalisation Office longer to legalise a court document that only has a signature. Getting your document certified might make the process quicker.
+    <% when 'diploma' %>
+      ##<%= heading %>
+      Your <%= type %> must be issued by an institution that is accredited by either:
+
+      - UK Border Agency
+      - Scottish Qualifications Authority
+      - OfQual
+      - British Accreditation Council
+      - Open and Distance Learning Quality Council
+      - Association of British Language Schools
+      - Sport England
+
+      It must also be certified, signed and dated by either:
+
+      - a solicitor or notary public in the UK
+      - an official of the British Council (only original certificates)
+
+      You may be able to get your document certified at a British embassy. [Check if this service is offered](/government/organisations/foreign-commonwealth-office/series/notarial-services) in the country you’re in.
+
+      ^A photocopy of your document can be legalised, but it must be certified.^
     <% when 'education_document' %>
       ##<%= heading %>
       Your <%= type %> must be issued by an institution that is accredited by either:

--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -119,9 +119,14 @@
       ^A photocopy of your document won’t be accepted.^
     <% when 'medical_reports' %>
       ##<%= heading %>
-      Your <%= type %> must be signed by a [doctor registered with the General Medical Council.](http://www.gmc-uk.org/doctors/register/LRMP.asp)
 
-      ^Your document can’t be legalised if it has been signed on behalf of your doctor by another doctor or member of staff.^
+      Your <%= type %> can only be legalised if it’s either:
+
+      - signed by a [doctor registered with the General Medical Council](http://www.gmc-uk.org/doctors/register/LRMP.asp) (your document can’t be legalised if it’s been signed on behalf of your doctor by another doctor or member of staff)
+      - a certified copy
+
+      ^A photocopy of your document can be legalised, but it must be certified first.^
+
     <% when 'police_disclosure' %>
       ##<%= heading %>
       Your <%= type %> can only be legalised if it has been either:

--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -130,6 +130,14 @@
       - certified
 
       ^A photocopy of your document won’t be accepted.^
+    <% when 'power_of_attorney' %>
+      ##<%= heading %>
+
+      Your <%= type %> can only be legalised if it’s either:
+
+      - an original document issued by the Office of the Public Guardian (OPG) that’s marked with the embossed seal or the ink signature of an official of the OPG
+      - an original or photocopy that’s been certified
+
     <% when 'solicitors_notaries' %>
       ##<%= heading %>
       Your <%= type %> can only be legalised if it has been certified.

--- a/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb
@@ -136,7 +136,7 @@
       - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
       - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/order-life-event-certificates/order-a-marriage-certificate.htm)
 
-      ^A photocopy of your document won’t be accepted.^
+      ^A photocopy of your GRO document won’t be accepted.^
     <% when 'medical_reports' %>
       ##<%= heading %>
 

--- a/test/artefacts/legalisation-document-checker/diploma.txt
+++ b/test/artefacts/legalisation-document-checker/diploma.txt
@@ -9,6 +9,7 @@ Your diploma must be issued by an institution that is accredited by either:
 - British Accreditation Council
 - Open and Distance Learning Quality Council
 - Association of British Language Schools
+- Sport England
 
 It must also be certified, signed and dated by either:
 

--- a/test/artefacts/legalisation-document-checker/doctor-letter-medical.txt
+++ b/test/artefacts/legalisation-document-checker/doctor-letter-medical.txt
@@ -1,9 +1,38 @@
 
 
 ##Doctor’s letter (medical)
-Your doctor’s letter must be signed by a [doctor registered with the General Medical Council.](http://www.gmc-uk.org/doctors/register/LRMP.asp)
 
-^Your document can’t be legalised if it has been signed on behalf of your doctor by another doctor or member of staff.^
+Your doctor’s letter can only be legalised if it’s either:
+
+- signed by a [doctor registered with the General Medical Council](http://www.gmc-uk.org/doctors/register/LRMP.asp) (your document can’t be legalised if it’s been signed on behalf of your doctor by another doctor or member of staff)
+- a certified copy
+
+^A photocopy of your document can be legalised, but it must be certified first.^
+
+##Certifying documents
+
+If you provide a certified document, it must be certified in the UK by a solicitor or ‘notary public’.
+
+When the solicitor or notary public signs the document, they must:
+
+- note the type of certification they have done (eg the document is a true copy of the original)
+- use their personal signature, not a company signature
+- include the date of certification
+- include their company address
+
+If they add a notarial certificate, it must be attached to the document. The certificate must also  contain a specific reference to the document they have certified.
+
+If a notary public from England, Wales or Northern Ireland signs a document for legalisation, they must also stamp or emboss the document with their notarial seal.
+
+You can find:
+
+- [solicitors in England and Wales](http://www.lawsociety.org.uk/home.law)
+
+- [notaries public in England and Wales](http://www.facultyoffice.org.uk/notary/find-a-notary/)
+
+- [solicitors and notaries public in Scotland](http://www.lawscot.org.uk/)
+
+- [solicitors and notaries public in Northern Ireland](http://www.lawsoc-ni.org/)
 
 ##Get your documents legalised
 

--- a/test/artefacts/legalisation-document-checker/marriage-certificate.txt
+++ b/test/artefacts/legalisation-document-checker/marriage-certificate.txt
@@ -6,7 +6,9 @@ Your marriage certificate can be legalised if it’s either:
 
 - an official certified copy of the certificate issued by the General Register Office (GRO) with the original seal
 
-- an original certificate (or original certified copy) issued by a church, religious establishment or local register office, with the original signature of the official who issued the certificate
+- an original GRO certificate (or original certified copy) issued by a church, religious establishment or local register office, with the original signature of the official who issued the certificate
+
+^If your certificate wasn't issued by the GRO (eg an Islamic marriage certificate), you must get it certified before it can be legalised.^
 
 It can take longer to legalise a signature on an original certificate, especially if it was issued before 1991.
 
@@ -16,9 +18,7 @@ It might be quicker to order a certified copy of your certificate from the:
 - [GRO for Scotland](http://www.gro-scotland.gov.uk/contacts/opentime/index.html/)
 - [General Register Office for Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/order-life-event-certificates/order-a-marriage-certificate.htm)
 
-^Non-GRO marriage certificates (eg Islamic marriage certificates) can't be legalised unless they are certified.^
-
-^A photocopy of your document won’t be accepted.^
+^A photocopy of your GRO document won’t be accepted.^
 
 ##Certifying documents
 

--- a/test/data/legalisation-document-checker-files.yml
+++ b/test/data/legalisation-document-checker-files.yml
@@ -1,9 +1,9 @@
 ---
-lib/smart_answer_flows/legalisation-document-checker.rb: b467124147814649224b01c1e6bbf757
+lib/smart_answer_flows/legalisation-document-checker.rb: 302adadd2c5f6ff33c396db7ad254399
 test/data/legalisation-document-checker-questions-and-responses.yml: 37c99c68ba04e459447622b01938ce0b
 test/data/legalisation-document-checker-responses-and-expected-results.yml: d55ccccc64cc1f58b648e810e5fa07e5
 lib/smart_answer_flows/legalisation-document-checker/legalisation_document_checker.govspeak.erb: 4be67b8e3aeebe4f3b99a5153b92ccdf
-lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb: 2a5010d551c4862e4a9af98bb2bb6a79
+lib/smart_answer_flows/legalisation-document-checker/outcomes/outcome_results.govspeak.erb: 43b1eb3528a773e49eda3f2a3940a9a6
 lib/smart_answer_flows/legalisation-document-checker/questions/which_documents_do_you_want_legalised.govspeak.erb: 807d6bee48fd47731d066aab6ad50544
 lib/smart_answer/calculators/legalisation_documents_data_query.rb: 31d5eec29a4cf4e27a4204e8f08132f9
-lib/data/legalisation_documents_data.yml: 788f0f6cbd9b35be712f9aca7c871591
+lib/data/legalisation_documents_data.yml: c9e9ce969845f657824904ad03a63793


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/110398716

## Fact check

https://whispering-beyond-3079.herokuapp.com/legalisation-document-checker

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/legalisation-document-checker/y/marriage-certificate)
  * Re-orders the statements for having marriage certificates legalised

### Before
![screen shot 2016-01-11 at 2 30 48 pm](https://cloud.githubusercontent.com/assets/351763/12236173/2ce7c124-b870-11e5-8653-3dd43241ab42.png)

### After
![screen shot 2016-01-11 at 2 31 07 pm](https://cloud.githubusercontent.com/assets/351763/12236177/30f86976-b870-11e5-9892-1f4c46842804.png)

 * [URL on gov.uk](https://www.gov.uk/legalisation-document-checker/y/diploma)
  * Adds 'Sport England' as an accrediting body for organisations who issue Watersports Diplomas.

### Before
![screen shot 2016-01-11 at 2 29 02 pm](https://cloud.githubusercontent.com/assets/351763/12236095/bf969212-b86f-11e5-9d45-d9177c8871dc.png)

### After
![screen shot 2016-01-11 at 2 29 20 pm](https://cloud.githubusercontent.com/assets/351763/12236097/c3c2a8e4-b86f-11e5-886a-9ebb5b4f805f.png)

