### PR TITLE
Birth abroad Cambodia and PNG amends

### DIFF
--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -273,8 +273,6 @@
     The Overseas Registration Unit will contact you if they need more information or if they need to verify your documents. If this happens then it could take longer for the birth to be registered.
   <% elsif registration_country == 'north-korea' and born_in_lower_risk_country %>
     ^Registration can take up to 3 months - your application will be sent to the Foreign and Commonwealth Office in London where the birth will be registered.^
-  <% elsif registration_country.in?(%w[papua-new-guinea cambodia]) and born_in_lower_risk_country %>
-    Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
   <% else %>
     It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -78,7 +78,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
@@ -76,7 +76,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
@@ -78,7 +78,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
@@ -76,7 +76,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -78,7 +78,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -76,7 +76,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
@@ -73,7 +73,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
@@ -73,7 +73,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
@@ -73,7 +73,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
@@ -73,7 +73,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
@@ -73,7 +73,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
@@ -73,7 +73,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to you by secure courier after the birth has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/st-martin/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -76,7 +76,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
@@ -76,7 +76,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
@@ -76,7 +76,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
@@ -76,7 +76,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -76,7 +76,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -76,7 +76,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,9 @@ $A
 
 ##Return of your documents
 
-Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+It usually takes 5 working days for the birth to be registered, once the Overseas Registration Unit has received your form and the right documents.
+
+They’ll contact you within the 5 working days if they need more information or if they need to verify your documents. If this happens then it could take up to 3 months for the birth to be registered.
 
 Your documents will be returned to the British Embassy in Port Moresby after the birth has been registered.
 

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -8,7 +8,7 @@ lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.gov
 lib/smart_answer_flows/register-a-birth/outcomes/no_embassy_result.govspeak.erb: ed56d500311fbe441649c92193f0e631
 lib/smart_answer_flows/register-a-birth/outcomes/no_registration_result.govspeak.erb: 7b60252b078e6aec6f5759e894ce4ffb
 lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb: 61f902aceeebe0c90fb42a998916e0b7
-lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb: d822693c41b9683f12b43cb83b04e8e6
+lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb: eeed695325359da6001774feaa070704
 lib/smart_answer_flows/register-a-birth/questions/childs_date_of_birth.govspeak.erb: e911daf1dc69ce85db372dc4ea3bdd50
 lib/smart_answer_flows/register-a-birth/questions/country_of_birth.govspeak.erb: 31c306c928e71eee86c60352f51ccf83
 lib/smart_answer_flows/register-a-birth/questions/have_you_adopted_the_child.govspeak.erb: 3a9d66656446a508c7232b26778dfa23


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/109534752

Update outcome section "Return of your documents" so the text for Cambodia and Papua New Guinea becomes the same as the other ORUs.

## Fact check

https://pt-109534752.herokuapp.com/register-a-birth

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/register-a-birth/y/cambodia/mother_and_father/yes/same_country)
  * First sentence under "Return of your documents" starts with "It usually takes 5 working days for the birth to be registered"

### Before
![screen shot 2016-01-11 at 4 45 10 pm](https://cloud.githubusercontent.com/assets/351763/12239900/da242244-b882-11e5-9e4d-bbaf0dfce13d.png)

### After
![screen shot 2016-01-11 at 4 46 08 pm](https://cloud.githubusercontent.com/assets/351763/12239905/dee27b1e-b882-11e5-99bc-b1532abe348a.png)