### PR TITLE
Increase the location cache max_size from 100 (default) to 250

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -4,7 +4,7 @@ class WorldLocation
   extend Forwardable
 
   def self.cache
-    @cache ||= LRUCache.new(soft_ttl: 24.hours, ttl: 1.week)
+    @cache ||= LRUCache.new(max_size: 250, soft_ttl: 24.hours, ttl: 1.week)
   end
 
   def self.reset_cache

--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -260,4 +260,10 @@ class WorldLocationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "cache configuration" do
+    should "have capacity for 250 cache entries" do
+      assert_equal WorldLocation.cache.max_size, 250
+    end
+  end
 end


### PR DESCRIPTION
Smart Answers uses an LRU cache for storing world locations returned from Whitehall, but the [default max_size of 100](https://github.com/kindkid/lrucache/blob/0f6193e9bce0b88d571ad23ed7b1c330a72dedde/lib/lrucache.rb#L10) kicks out 116 of the 226 countries we currently offer in our dropdown:

For example:

 https://www.gov.uk/overseas-passports/y

 ```javascript
   $('#response > option').length;
   226
 ```

@dsingleton @alexmuller @jennyd 