### PR TITLE
Add logging config for when deployed to Heroku

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,5 +71,9 @@ SmartAnswers::Application.configure do
     config.logstasher.enabled = true
     config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
     config.logstasher.suppress_app_logs = true
+  else
+    # enable STDOUT logging for Heroku
+    config.logger = Logger.new(STDOUT)
+    config.logger.level = Logger.const_get(ENV['LOG_LEVEL'] ? ENV['LOG_LEVEL'].upcase : 'INFO')
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ SmartAnswers::Application.configure do
   config.action_mailer.default_url_options = { host: Plek.new.find('smartanswers') }
   config.action_mailer.delivery_method = :ses
 
-  unless ENV['RUNNING_ON_HEROKU'].present?
+  if ENV['RUNNING_ON_HEROKU'].blank?
     # Enable JSON-style logging
     config.logstasher.enabled = true
     config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,6 +72,9 @@ SmartAnswers::Application.configure do
     config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
     config.logstasher.suppress_app_logs = true
   else
+    # flush output to the underlying OS without buffering
+    STDOUT.sync = true
+
     # enable STDOUT logging for Heroku
     config.logger = Logger.new(STDOUT)
     config.logger.level = Logger.const_get(ENV['LOG_LEVEL'] ? ENV['LOG_LEVEL'].upcase : 'INFO')


### PR DESCRIPTION
As we use Heroku for our all out staging servers for fact checking processes, we need to point Rails logging to STDOUT for the application log to be available when on Heroku:

https://devcenter.heroku.com/articles/rails4

@dsingleton @jennyd 

