### PR TITLE
Update landlord immigration check startpage

### DIFF
--- a/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
@@ -15,7 +15,7 @@
 
   In Birmingham, Walsall, Sandwell, Dudley or Wolverhampton, check tenancies that started on or after 1 December 2014.
 
-  If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](/government/publications/right-to-rent-landlords-code-of-practice).
-
+  If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](/check-tenant-right-to-rent-documents).
+  
   ^You can read more about the [right to rent documents](/government/publications/rules-and-acceptable-documents-right-to-rent-checks) you can accept as proof.^
 <% end %>

--- a/test/artefacts/landlord-immigration-check/landlord-immigration-check.txt
+++ b/test/artefacts/landlord-immigration-check/landlord-immigration-check.txt
@@ -8,7 +8,7 @@ You must check tenancies which start on or after 1 February 2016.
 
 In Birmingham, Walsall, Sandwell, Dudley or Wolverhampton, check tenancies that started on or after 1 December 2014.
 
-If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](/government/publications/right-to-rent-landlords-code-of-practice).
+If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](/check-tenant-right-to-rent-documents).
 
 ^You can read more about the [right to rent documents](/government/publications/rules-and-acceptable-documents-right-to-rent-checks) you can accept as proof.^
 

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/landlord-immigration-check.rb: b52cd9e27d5d11193dace24525e1be4d
 test/data/landlord-immigration-check-questions-and-responses.yml: d4b485131540c40211b26a50e071032d
 test/data/landlord-immigration-check-responses-and-expected-results.yml: 0b6c53667749fb35ecff3eed3b62e703
-lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: 8c2f83f3ec2b1ad64f49b04d848e292a
+lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: c15fc79c88211c8156332663ea796ad2
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_england_outcome.govspeak.erb: 869599657e71a21cee71ecf8e4bb0c75
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_included_area.govspeak.erb: a36312f9c071ba570332ca25fc3ae4b7
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_landlord_code_of_practice.govspeak.erb: cfb1261ac17c7aa40445173406459290


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/n/projects/503131/stories/110973118

Updates the start page for landlord immigration check smart answer, correcting the link source for further checks on your tenants.

## Fact check

https://mighty-beach-3538.herokuapp.com/landlord-immigration-check

## Expected changes
 * [URL on gov.uk](https://www.gov.uk/landlord-immigration-check/y)
  * The link to "further checks on your tenants" now points at the relative path of /check-tenant-right-to-rent-documents