### PR TITLE
Add ability to handle exception raised during render

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,16 @@ protected
     if exception and defined? Airbrake
       env["airbrake.error_id"] = notify_airbrake(exception)
     end
-    render status: status_code, text: "#{status_code} error"
+
+    error_message = "#{status_code} error"
+
+    # handle cases where exception occured during render
+    if performed?
+      response.status = status_code
+      response_body = error_message
+    else
+      render status: status_code, text: error_message
+    end
   end
 
   def set_analytics_headers

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -103,6 +103,13 @@ class SmartAnswersControllerTest < ActionController::TestCase
       assert_equal 503, response.status
     end
 
+    should 'cope with 503 exception during rendering' do
+      @controller.view_context_class.any_instance.stubs(:content_for).raises(GdsApi::TimedOutException)
+
+      get :show, id: 'smart-answers-controller-sample'
+      assert_equal 503, response.status
+    end
+
     should "404 Not Found if request is for an unknown format" do
       @controller.stubs(:respond_to).raises(ActionController::UnknownFormat)
 


### PR DESCRIPTION
Smart answers is making calls to the GDS API during the render process, which can sometimes timeout.

To avoid double rendering errors being raised in the rescue_from, add check to see if rendering has already started, and replace the status code and response_body rather than trying to render twice.