### PR TITLE
Update lead-in line and links in energy grant calculator outcomes

### DIFF
--- a/lib/smart_answer_flows/energy-grants-calculator/outcomes/_help_and_advice_body.govspeak.erb
+++ b/lib/smart_answer_flows/energy-grants-calculator/outcomes/_help_and_advice_body.govspeak.erb
@@ -1,8 +1,8 @@
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -24,12 +24,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -40,12 +40,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,12 +22,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -38,12 +38,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,12 +20,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/top_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/house/none.txt
@@ -36,12 +36,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
@@ -28,12 +28,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/house/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/top_floor/none.txt
@@ -28,12 +28,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/house/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,12 +10,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,12 +10,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/top_floor/none.txt
@@ -28,12 +28,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/house/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
@@ -28,12 +28,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/house/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/top_floor/none.txt
@@ -28,12 +28,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/house/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,12 +18,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,12 +34,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,12 +12,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,12 +16,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -32,12 +32,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,12 +10,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,12 +10,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,12 +14,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/ground_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/top_floor/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/top_floor/none.txt
@@ -28,12 +28,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house/mains_gas,electric_heating,loft_attic_conversion,draught_proofing.txt
@@ -1,11 +1,11 @@
 You don't qualify for the Green Deal or for any help with energy efficient measures for your home.
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house/none.txt
@@ -30,12 +30,12 @@ If your home is well insulated you could also qualify for money towards a [renew
 
 ###Help and advice
 
-You can find more help on saving money on your energy bills from the Citizens Advice Bureau:
+You can get more help saving money on your energy bills, eg:
 
-- how to [save money on your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_saving_money_on_energy_bills_e/saving_money_on_energy_bills.htm)
-- understand [your energy bill](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_energy_bills_e/consumer_understanding_your_energy_bill_e.htm)
-- find out how to [switch energy suppliers](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_choosing_and_switching_supplier_e/switching_gas_or_electricity_supplier.htm)
-- make a complaint about [your energy company](http://www.adviceguide.org.uk/england/consumer_e/consumer_energy_and_water_supply_e/consumer_energy_supply_e/consumer_complaining_about_energy_companies_e.htm)
+- find out what to do if [your energy bill seems too high](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/energy-bill-seems-too-high-or-low/)
+- understand [your energy bill](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/problems-with-your-energy-bill/understand-your-energy-bill/)
+- find out how to [switch energy suppliers](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/get-a-better-energy-deal/switching-energy-supplier/)
+- make a complaint about [your energy company](https://www.citizensadvice.org.uk/consumer/energy/energy-supply/complain-about-an-energy-company/complain-to-your-energy-supplier/)
 - find out about [energy efficient appliances](http://www.energysavingtrust.org.uk/Electricity/Products-and-appliances)
 - visit an [energy-efficient home near you](http://www.greenopenhomes.net/search)
 

--- a/test/data/energy-grants-calculator-files.yml
+++ b/test/data/energy-grants-calculator-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/energy-grants-calculator/outcomes/_header_boilers_and_ins
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_header_heating.govspeak.erb: 88074867368be04f0cf2b73ed48555d1
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_header_windows_and_doors.govspeak.erb: bc19c54dae7edcefa68af714f51c076c
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_help_and_advice.govspeak.erb: c1ab52acfca58c09c7aae5631d30f440
-lib/smart_answer_flows/energy-grants-calculator/outcomes/_help_and_advice_body.govspeak.erb: 99323433a2534be87284b2688883b618
+lib/smart_answer_flows/energy-grants-calculator/outcomes/_help_and_advice_body.govspeak.erb: 8968e82b9200fda21ac007cc32c0607a
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_may_qualify_for_affordable_warmth_obligation.govspeak.erb: 6aa8f277addf6cf6762c04f87ce394f3
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_better_heating_controls.govspeak.erb: 452fb619021106cba35e02932aa95182
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_biomass_boilers_heaters.govspeak.erb: 5e0f0fd9ae6f7a85861b47076d5f03a5


### PR DESCRIPTION
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/1253498

Updates the lead-in line and links to external sites in the Help and Advice section of the energy grant calculator, removing the wording Citizens Advice Bureau as not all links lead to their site.

## Fact check

https://zd-1253498.herokuapp.com/energy-grants-calculator

## Expected changes
 [URL on gov.uk](https://www.gov.uk/energy-grants-calculator/y/help_energy_efficiency/benefits/working_tax_credit/child_under_5/1940s-1984/house/electric_heating)
 * removes the wording "Citizens Advice Bureau" in the lead-in line under the Help and Advice section
 * updates the links in the Help and Advice section

### Before

![screen shot 2016-02-11 at 4 07 32 pm](https://cloud.githubusercontent.com/assets/351763/12981717/c4a4c4cc-d0d9-11e5-8760-407d393c1c6e.png)

### After

![screen shot 2016-02-11 at 4 07 50 pm](https://cloud.githubusercontent.com/assets/351763/12981722/c92c977c-d0d9-11e5-92eb-f3e6656edd77.png)

Note: this PR supersedes #2267 