### PR TITLE
Update outcomes for countries in Electronic Visa Waiver program

### DIFF
--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -120,6 +120,6 @@ module SmartAnswer::Calculators
 
     COUNTRY_GROUP_YOUTH_MOBILITY_SCHEME = %w(australia canada japan monaco new-zealand hong-kong south-korea taiwan)
 
-    COUNTRY_GROUP_ELECTRONIC_VISA_WAIVER = %w(oman qatar united-arab-emirates)
+    COUNTRY_GROUP_ELECTRONIC_VISA_WAIVER = %w(kuwait oman qatar united-arab-emirates)
   end
 end

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -69,6 +69,7 @@ module SmartAnswer
           :outcome_medical_y,
           :outcome_no_visa_needed,
           :outcome_school_n,
+          :outcome_school_waiver,
           :outcome_school_y,
           :outcome_standard_visit,
           :outcome_taiwan_exception,
@@ -83,7 +84,17 @@ module SmartAnswer
             next :staying_for_how_long?
           elsif calculator.diplomatic_visit?
             next :outcome_diplomatic_business
-          elsif calculator.medical_visit? || calculator.tourism_visit? || calculator.school_visit?
+          elsif calculator.school_visit?
+            if calculator.passport_country_in_electronic_visa_waiver_list?
+              next :outcome_school_waiver
+            elsif calculator.passport_country_is_taiwan?
+              next :outcome_taiwan_exception
+            elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list?
+              next :outcome_school_n
+            else
+              next :outcome_school_y
+            end
+          elsif calculator.medical_visit? || calculator.tourism_visit?
             if calculator.passport_country_in_electronic_visa_waiver_list?
               next :outcome_visit_waiver
             elsif calculator.passport_country_is_taiwan?
@@ -92,16 +103,14 @@ module SmartAnswer
           end
 
           if calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list?
-            if calculator.school_visit? || calculator.tourism_visit?
+            if calculator.tourism_visit?
               next :outcome_school_n
             elsif calculator.medical_visit?
               next :outcome_medical_n
             end
           end
 
-          if calculator.school_visit?
-            :outcome_school_y
-          elsif calculator.tourism_visit?
+          if calculator.tourism_visit?
             :outcome_standard_visit
           elsif calculator.marriage_visit?
             :outcome_marriage
@@ -237,6 +246,7 @@ module SmartAnswer
       outcome :outcome_medical_y
       outcome :outcome_no_visa_needed
       outcome :outcome_school_n
+      outcome :outcome_school_waiver
       outcome :outcome_school_y
       outcome :outcome_standard_visit
       outcome :outcome_study_m

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -190,6 +190,7 @@ module SmartAnswer
           :outcome_visit_waiver,
           :outcome_work_m,
           :outcome_work_n,
+          :outcome_work_waiver,
           :outcome_work_y
         ]
         next_node(permitted: permitted_next_nodes) do |response|
@@ -212,7 +213,9 @@ module SmartAnswer
                 :outcome_no_visa_needed #outcome 1 no visa needed
               end
             elsif calculator.work_visit?
-              if calculator.passport_country_in_ukot_list? ||
+              if calculator.passport_country_in_electronic_visa_waiver_list?
+                :outcome_work_waiver
+              elsif calculator.passport_country_in_ukot_list? ||
                   calculator.passport_country_is_taiwan? || calculator.passport_country_in_non_visa_national_list?
                 #outcome 5.5 work N no visa needed
                 :outcome_work_n
@@ -249,6 +252,7 @@ module SmartAnswer
       outcome :outcome_visit_waiver
       outcome :outcome_work_m
       outcome :outcome_work_n
+      outcome :outcome_work_waiver
       outcome :outcome_work_y
     end
   end

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -185,9 +185,9 @@ module SmartAnswer
         permitted_next_nodes = [
           :outcome_no_visa_needed,
           :outcome_study_m,
+          :outcome_study_waiver,
           :outcome_study_y,
           :outcome_taiwan_exception,
-          :outcome_visit_waiver,
           :outcome_work_m,
           :outcome_work_n,
           :outcome_work_waiver,
@@ -204,7 +204,7 @@ module SmartAnswer
           when 'six_months_or_less'
             if calculator.study_visit?
               if calculator.passport_country_in_electronic_visa_waiver_list?
-                :outcome_visit_waiver #outcome 12 visit outcome_visit_waiver
+                :outcome_study_waiver
               elsif calculator.passport_country_is_taiwan?
                 :outcome_taiwan_exception
               elsif calculator.passport_country_in_datv_list? || calculator.passport_country_in_visa_national_list?
@@ -240,6 +240,7 @@ module SmartAnswer
       outcome :outcome_school_y
       outcome :outcome_standard_visit
       outcome :outcome_study_m
+      outcome :outcome_study_waiver
       outcome :outcome_study_y
       outcome :outcome_taiwan_exception
       outcome :outcome_transit_leaving_airport

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_waiver.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_waiver.govspeak.erb
@@ -1,0 +1,12 @@
+<% content_for :title do %>
+  You’ll need an electronic visa waiver (EVW) or a visa
+<% end %>
+
+<% content_for :body do %>
+  You must either apply for:
+
+  + an [EVW](/get-electronic-visa-waiver) to stay for up to 6 months
+  + a [Parent of Tier 4 child visa](/parent-of-a-child-at-school-visa)
+  
+  *[EVW]: electronic visa waiver
+<% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_waiver.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_waiver.govspeak.erb
@@ -1,0 +1,12 @@
+<% content_for :title do %>
+  You’ll need an electronic visa waiver (EVW) or a visa
+<% end %>
+
+<% content_for :body do %>
+  You must either apply for:
+
+  + an [EVW](/get-electronic-visa-waiver)
+  + a [Short-term study visa](/study-visit-visa)
+  
+  *[EVW]: electronic visa waiver
+<% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver.govspeak.erb
@@ -1,15 +1,12 @@
 <% content_for :title do %>
-  You’ll need an electronic visa waiver (EVW)  or a visitor visa
+  You’ll need an electronic visa waiver (EVW) or a visitor visa
 <% end %>
 
 <% content_for :body do %>
-  You can enter the UK with either an electronic visa waiver (EVW) or a visitor visa
+  You must either apply for:
 
-  ###EVW
-
-  You must [apply for an EVW](https://www.visa4uk.fco.gov.uk/) online at least 48 hours before you travel.
-
-  ###Visitor visa
-
-  Apply for a [Standard Visitor visa](/standard-visitor-visa).
+  + an [EVW](/get-electronic-visa-waiver)
+  + a [Standard Visitor visa](/standard-visitor-visa)
+  
+  *[EVW]: electronic visa waiver
 <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_waiver.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_waiver.govspeak.erb
@@ -1,0 +1,33 @@
+<% content_for :title do %>
+  You'll need to apply to do business, academic research or work in the UK
+
+<% end %>
+
+<% content_for :body do %>
+  What you need to apply for depends on your circumstances.
+
+  ##Business and academic visits
+
+  You can apply:
+
+  - for a [Standard Visitor visa](/standard-visitor-visa) or an [electronic visa waiver](/get-electronic-visa-waiver) (EVW) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
+  - as a visitor doing a [‘permitted paid engagement’](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
+
+  ##Temporary workers
+
+  A temporary worker visa may be suitable if you want work in the UK for a short time:
+
+  - in [sports](/tier-5-temporary-worker-creative-and-sporting-visa)
+  - in [arts or entertainment](/tier-5-temporary-worker-creative-and-sporting-visa)
+  - as a [volunteer](/tier-5-temporary-worker-charity-worker-visa)
+  - in a [work experience role](/tier-5-government-authorised-exchange)
+  - for a [charity](/tier-5-temporary-worker-charity-worker-visa)
+  - for a [religious organisation](/tier-5-religious)
+  - as a [domestic worker in a private household](/domestic-workers-in-a-private-household-visa)
+  - in a [role in your overseas employer’s UK branch](/tier-2-intracompany-transfer-worker-visa)
+  - in a [skilled job](/tier-2-general)
+
+  You can also apply for an [international agreement](/tier-5-international-agreement) visa if you’ll be doing work covered by international law while in the UK (eg working for a foreign government or as a private servant in a diplomatic household).
+  
+  *[EVW]: electronic visa waiver
+<% end %>

--- a/test/artefacts/check-uk-visa/oman/medical.txt
+++ b/test/artefacts/check-uk-visa/oman/medical.txt
@@ -1,12 +1,9 @@
-You’ll need an electronic visa waiver (EVW)  or a visitor visa
+You’ll need an electronic visa waiver (EVW) or a visitor visa
 
-You can enter the UK with either an electronic visa waiver (EVW) or a visitor visa
+You must either apply for:
 
-###EVW
++ an [EVW](/get-electronic-visa-waiver)
++ a [Standard Visitor visa](/standard-visitor-visa)
 
-You must [apply for an EVW](https://www.visa4uk.fco.gov.uk/) online at least 48 hours before you travel.
-
-###Visitor visa
-
-Apply for a [Standard Visitor visa](/standard-visitor-visa).
+*[EVW]: electronic visa waiver
 

--- a/test/artefacts/check-uk-visa/oman/school.txt
+++ b/test/artefacts/check-uk-visa/oman/school.txt
@@ -1,12 +1,9 @@
-You’ll need an electronic visa waiver (EVW)  or a visitor visa
+You’ll need an electronic visa waiver (EVW) or a visa
 
-You can enter the UK with either an electronic visa waiver (EVW) or a visitor visa
+You must either apply for:
 
-###EVW
++ an [EVW](/get-electronic-visa-waiver) to stay for up to 6 months
++ a [Parent of Tier 4 child visa](/parent-of-a-child-at-school-visa)
 
-You must [apply for an EVW](https://www.visa4uk.fco.gov.uk/) online at least 48 hours before you travel.
-
-###Visitor visa
-
-Apply for a [Standard Visitor visa](/standard-visitor-visa).
+*[EVW]: electronic visa waiver
 

--- a/test/artefacts/check-uk-visa/oman/study/six_months_or_less.txt
+++ b/test/artefacts/check-uk-visa/oman/study/six_months_or_less.txt
@@ -1,12 +1,9 @@
-You’ll need an electronic visa waiver (EVW)  or a visitor visa
+You’ll need an electronic visa waiver (EVW) or a visa
 
-You can enter the UK with either an electronic visa waiver (EVW) or a visitor visa
+You must either apply for:
 
-###EVW
++ an [EVW](/get-electronic-visa-waiver)
++ a [Short-term study visa](/study-visit-visa)
 
-You must [apply for an EVW](https://www.visa4uk.fco.gov.uk/) online at least 48 hours before you travel.
-
-###Visitor visa
-
-Apply for a [Standard Visitor visa](/standard-visitor-visa).
+*[EVW]: electronic visa waiver
 

--- a/test/artefacts/check-uk-visa/oman/tourism.txt
+++ b/test/artefacts/check-uk-visa/oman/tourism.txt
@@ -1,12 +1,9 @@
-You’ll need an electronic visa waiver (EVW)  or a visitor visa
+You’ll need an electronic visa waiver (EVW) or a visitor visa
 
-You can enter the UK with either an electronic visa waiver (EVW) or a visitor visa
+You must either apply for:
 
-###EVW
++ an [EVW](/get-electronic-visa-waiver)
++ a [Standard Visitor visa](/standard-visitor-visa)
 
-You must [apply for an EVW](https://www.visa4uk.fco.gov.uk/) online at least 48 hours before you travel.
-
-###Visitor visa
-
-Apply for a [Standard Visitor visa](/standard-visitor-visa).
+*[EVW]: electronic visa waiver
 

--- a/test/artefacts/check-uk-visa/oman/work/six_months_or_less.txt
+++ b/test/artefacts/check-uk-visa/oman/work/six_months_or_less.txt
@@ -1,12 +1,12 @@
-You'll need a visa to work, do business or academic research in the UK
+You'll need to apply to do business, academic research or work in the UK
 
-The visa you need to apply for depends on your circumstances.
+What you need to apply for depends on your circumstances.
 
-##Business visits
+##Business and academic visits
 
 You can apply:
 
-- for a [Standard Visitor visa](/standard-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
+- for a [Standard Visitor visa](/standard-visitor-visa) or an [electronic visa waiver](/get-electronic-visa-waiver) (EVW) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
 - as a visitor doing a [‘permitted paid engagement’](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
 
 ##Temporary workers
@@ -24,4 +24,6 @@ A temporary worker visa may be suitable if you want work in the UK for a short t
 - in a [skilled job](/tier-2-general)
 
 You can also apply for an [international agreement](/tier-5-international-agreement) visa if you’ll be doing work covered by international law while in the UK (eg working for a foreign government or as a private servant in a diplomatic household).
+
+*[EVW]: electronic visa waiver
 

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,7 +1,7 @@
 ---
-lib/smart_answer_flows/check-uk-visa.rb: 39209fe763decf718a50df08cd353003
+lib/smart_answer_flows/check-uk-visa.rb: 3c8842514ba5d6ab7f0110d3005d9008
 test/data/check-uk-visa-questions-and-responses.yml: 1c812e8d00a9dc8525848e643f1ae0e0
-test/data/check-uk-visa-responses-and-expected-results.yml: e4ece324545e65d70a904c58b811a14f
+test/data/check-uk-visa-responses-and-expected-results.yml: b8a10942fca47f5fbebc7a6161f0e7d2
 lib/smart_answer_flows/check-uk-visa/check_uk_visa.govspeak.erb: a442b4ddd169b26a401c70d145e5b44e
 lib/smart_answer_flows/check-uk-visa/outcomes/_b1_b2_visa_exception.govspeak.erb: 410e39d565d0a5caed2d1b8c20c1ca77
 lib/smart_answer_flows/check-uk-visa/outcomes/_stateless_or_refugee.govspeak.erb: a14d7807087e4f05e9fada8ac755ee2e
@@ -14,9 +14,11 @@ lib/smart_answer_flows/check-uk-visa/outcomes/outcome_medical_n.govspeak.erb: 16
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_medical_y.govspeak.erb: 595b99b77d444bd812b413cb29363931
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed.govspeak.erb: b146c4ebacd5a06aea53b1d11ca45aab
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_n.govspeak.erb: e9a82b3c28270a075ca24250db9b868b
+lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_waiver.govspeak.erb: 74ffd01d62f3520f37bdc4562ebae9bc
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_y.govspeak.erb: 3416c2c984b9dcfbf3679de322e922d2
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_standard_visit.govspeak.erb: 3ffbc8285db58fa65b3bf5713ab8fdfe
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_m.govspeak.erb: 3fc2c54633e28cac546673d1a7d605c2
+lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_waiver.govspeak.erb: dd0351a3dcde033fd5e66a791fa13a7b
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_y.govspeak.erb: b268016aaa0e7c6c50149b24fed15557
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_taiwan_exception.govspeak.erb: a571306467b1bfac12fb4088fae8f3c8
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_leaving_airport.govspeak.erb: 5ab6a0a0e197780eee24c4259a9a247c
@@ -26,9 +28,10 @@ lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_refugee_not_leavin
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan.govspeak.erb: 72a43a01e16942fd7ffce864e5b1bdee
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.govspeak.erb: ee519450526cc90ead79ee29021f04a6
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_venezuela.govspeak.erb: bae2c1566964317ca3d92b5b1d8a21f3
-lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver.govspeak.erb: 7a56f0a6b714bb114cb3f966497d9b4e
+lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver.govspeak.erb: 02d5c593f767fe5201de2afe81e65963
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_m.govspeak.erb: 2a2021fec2f3a63d873bb1f48206349d
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_n.govspeak.erb: da229fbf8796faffab862bee3ed2b9a0
+lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_waiver.govspeak.erb: 916d5d06e4f6958d2dc287f128fd0bc9
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_y.govspeak.erb: a1caae0e095e58717119356bf52e2a2a
 lib/smart_answer_flows/check-uk-visa/questions/israeli_document_type.govspeak.erb: 6e6ea79788922c6e4a76f87cac040193
 lib/smart_answer_flows/check-uk-visa/questions/passing_through_uk_border_control.govspeak.erb: 06c6cc3553ff2ce5b62364f3430e9394

--- a/test/data/check-uk-visa-responses-and-expected-results.yml
+++ b/test/data/check-uk-visa-responses-and-expected-results.yml
@@ -650,7 +650,7 @@
   - oman
   - study
   - six_months_or_less
-  :next_node: :outcome_visit_waiver
+  :next_node: :outcome_study_waiver
   :outcome_node: true
 - :current_node: :staying_for_how_long?
   :responses:

--- a/test/data/check-uk-visa-responses-and-expected-results.yml
+++ b/test/data/check-uk-visa-responses-and-expected-results.yml
@@ -630,7 +630,7 @@
   - oman
   - work
   - six_months_or_less
-  :next_node: :outcome_work_m
+  :next_node: :outcome_work_waiver
   :outcome_node: true
 - :current_node: :staying_for_how_long?
   :responses:

--- a/test/data/check-uk-visa-responses-and-expected-results.yml
+++ b/test/data/check-uk-visa-responses-and-expected-results.yml
@@ -695,7 +695,7 @@
   :responses:
   - oman
   - school
-  :next_node: :outcome_visit_waiver
+  :next_node: :outcome_school_waiver
   :outcome_node: true
 - :current_node: :purpose_of_visit?
   :responses:

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -347,6 +347,16 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context 'coming to the UK to visit a child in school' do
+      setup do
+        add_response 'school'
+      end
+
+      should 'take you to the outcome work_waiver' do
+        assert_current_node :outcome_school_waiver
+      end
+    end
   end
 
   context "choose a DATV country" do
@@ -398,16 +408,6 @@ class CheckUkVisaTest < ActiveSupport::TestCase
       end
       should "take you to school_y outcome" do
         assert_current_node :outcome_school_y
-      end
-      context "Oman passport" do
-        setup do
-          reset_responses
-          add_response "oman"
-          add_response "school"
-        end
-        should "take you to outcome_visit_waiver outcome" do
-          assert_current_node :outcome_visit_waiver
-        end
       end
     end
     context "getting married" do

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -279,6 +279,46 @@ class CheckUkVisaTest < ActiveSupport::TestCase
     end
   end
 
+  context 'choose an EVW country' do
+    setup do
+      add_response 'oman'
+    end
+
+    should 'ask what are you comming to the UK to do' do
+      assert_current_node :purpose_of_visit?
+    end
+
+    context 'coming to the UK to work' do
+      setup do
+        add_response 'work'
+      end
+
+      should 'ask how long you intend to stay' do
+        assert_current_node :staying_for_how_long?
+      end
+
+      context '6 months or less' do
+        setup do
+          add_response 'six_months_or_less'
+        end
+
+        should 'take you to the outcome work_waiver' do
+          assert_current_node :outcome_work_waiver
+        end
+      end
+
+      context 'longer than 6 months' do
+        setup do
+          add_response 'longer_than_six_months'
+        end
+
+        should 'take you to the outcome work_y' do
+          assert_current_node :outcome_work_y
+        end
+      end
+    end
+  end
+
   context "choose a DATV country" do
     setup do
       add_response 'yemen'

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -317,6 +317,36 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context 'coming to the UK to study' do
+      setup do
+        add_response 'study'
+      end
+
+      should 'ask how long you intend to stay' do
+        assert_current_node :staying_for_how_long?
+      end
+
+      context '6 months or less' do
+        setup do
+          add_response 'six_months_or_less'
+        end
+
+        should 'take you to the outcome work_waiver' do
+          assert_current_node :outcome_study_waiver
+        end
+      end
+
+      context 'longer than 6 months' do
+        setup do
+          add_response 'longer_than_six_months'
+        end
+
+        should 'take you to the outcome study_y' do
+          assert_current_node :outcome_study_y
+        end
+      end
+    end
   end
 
   context "choose a DATV country" do
@@ -586,18 +616,6 @@ class CheckUkVisaTest < ActiveSupport::TestCase
       end
     end
   end #end armenia -  visa country
-
-  #testing venezuela - oman - qatar - UAE
-  context "testing venezuela special outcome - study - less or six months" do
-    setup do
-      add_response "oman"
-      add_response "study"
-      add_response "six_months_or_less"
-    end
-    should "take you to outcome_visit_waiver" do
-      assert_current_node :outcome_visit_waiver
-    end
-  end
 
   context "choose a Non-visa country and check for outcome_work_n" do
     setup do


### PR DESCRIPTION
Pivotal ticket: https://www.pivotaltracker.com/story/show/113366241

Updates an existing outcome with corrections for countries included EVW program and adds three new outcomes specific to the purpose of visit in cases of work (for less than 6 months), study or to visit a child in school.

## Fact check

https://pt-113366241.herokuapp.com/check-uk-visa

## Expected changes
 [URL on gov.uk](https://www.gov.uk/check-uk-visa/y/kuwait/work/six_months_or_less)
  * H2 heading Business visits becomes Business and academic visits
  * adds the option of applying for an Electronic Visa Waiver (EVW) in the first option under business and academic visits

### Before
![screen shot 2016-02-17 at 2 09 56 pm](https://cloud.githubusercontent.com/assets/351763/13111880/3dd58d0e-d580-11e5-97fc-6e92eae97dc5.png)

### After
![screen shot 2016-02-17 at 2 10 16 pm](https://cloud.githubusercontent.com/assets/351763/13111883/4379f10a-d580-11e5-88bb-f1c0ab9cd879.png)

Note: this PR supersedes #2274, #2275, #2276 and #2277