### PR TITLE
Added link to 'report a tenant'

### DIFF
--- a/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
@@ -7,11 +7,12 @@
 <% end %>
 
 <% content_for :body do %>
-  Find out if someone can rent private residential property in England.
+  Find out if someone can rent your private residential property in England.
 
   You must check anyone aged 18 or over who pays to use your property as their main home, eg tenants, sub-tenants and paying house guests.
 
-  If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](/check-tenant-right-to-rent-documents).
+  If you've bought a property that already has tenants, you need proof that their last landlord did the check. You’ll still be responsible for carrying out [further checks on your tenants](/check-tenant-right-to-rent-documents/further-checks) in future.
 
-  ^You can read more about the [right to rent documents](/government/publications/right-to-rent-document-checks-a-user-guide) you can accept as proof.^
+  ^Read more about the [right to rent documents](/government/publications/right-to-rent-document-checks-a-user-guide) you can accept.^  
+  
 <% end %>

--- a/lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb
@@ -1,7 +1,10 @@
 <% content_for :body do %>
   The person can’t rent your property.
 
-  You may get a [civil penalty](/penalties-illegal-renting) if you still rent your property to someone who isn’t allowed to rent property in the UK.
+  You might [get a fine (civil penalty)](/penalties-illegal-renting) if you rent your property to them.
+  
+  If the person is already renting your property, you need to [report them to the Home Office.](https://eforms.homeoffice.gov.uk/outreach/lcs-reporting.ofml)
 
   You can read the landlord’s [code of practice](/government/publications/right-to-rent-landlords-code-of-practice) on making checks for more information.
+  
 <% end %>

--- a/lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb
@@ -2,8 +2,8 @@
   The person can’t rent your property.
 
   You might [get a fine (civil penalty)](/penalties-illegal-renting) if you rent your property to them.
-  
-  If the person is already renting your property, you need to [report them to the Home Office.](https://eforms.homeoffice.gov.uk/outreach/lcs-reporting.ofml)
+
+  If the person is already renting your property, you must [report them to the Home Office.](https://eforms.homeoffice.gov.uk/outreach/lcs-reporting.ofml)
 
   You can read the landlord’s [code of practice](/government/publications/right-to-rent-landlords-code-of-practice) on making checks for more information.
   

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no/no/no.txt
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no/no/no.txt
@@ -2,7 +2,9 @@
 
 The person can’t rent your property.
 
-You may get a [civil penalty](/penalties-illegal-renting) if you still rent your property to someone who isn’t allowed to rent property in the UK.
+You might [get a fine (civil penalty)](/penalties-illegal-renting) if you rent your property to them.
+
+If the person is already renting your property, you must [report them to the Home Office.](https://eforms.homeoffice.gov.uk/outreach/lcs-reporting.ofml)
 
 You can read the landlord’s [code of practice](/government/publications/right-to-rent-landlords-code-of-practice) on making checks for more information.
 

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/non_eea_but_with_eu_eea_switzerland_family_member/no/no/no.txt
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/non_eea_but_with_eu_eea_switzerland_family_member/no/no/no.txt
@@ -2,7 +2,9 @@
 
 The person can’t rent your property.
 
-You may get a [civil penalty](/penalties-illegal-renting) if you still rent your property to someone who isn’t allowed to rent property in the UK.
+You might [get a fine (civil penalty)](/penalties-illegal-renting) if you rent your property to them.
+
+If the person is already renting your property, you must [report them to the Home Office.](https://eforms.homeoffice.gov.uk/outreach/lcs-reporting.ofml)
 
 You can read the landlord’s [code of practice](/government/publications/right-to-rent-landlords-code-of-practice) on making checks for more information.
 

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/somewhere_else/no/no/no/no/no.txt
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/somewhere_else/no/no/no/no/no.txt
@@ -2,7 +2,9 @@
 
 The person can’t rent your property.
 
-You may get a [civil penalty](/penalties-illegal-renting) if you still rent your property to someone who isn’t allowed to rent property in the UK.
+You might [get a fine (civil penalty)](/penalties-illegal-renting) if you rent your property to them.
+
+If the person is already renting your property, you must [report them to the Home Office.](https://eforms.homeoffice.gov.uk/outreach/lcs-reporting.ofml)
 
 You can read the landlord’s [code of practice](/government/publications/right-to-rent-landlords-code-of-practice) on making checks for more information.
 

--- a/test/artefacts/landlord-immigration-check/landlord-immigration-check.txt
+++ b/test/artefacts/landlord-immigration-check/landlord-immigration-check.txt
@@ -1,10 +1,10 @@
 Check if someone can rent your residential property
 
-Find out if someone can rent private residential property in England.
+Find out if someone can rent your private residential property in England.
 
 You must check anyone aged 18 or over who pays to use your property as their main home, eg tenants, sub-tenants and paying house guests.
 
-If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](/check-tenant-right-to-rent-documents).
+If you've bought a property that already has tenants, you need proof that their last landlord did the check. You’ll still be responsible for carrying out [further checks on your tenants](/check-tenant-right-to-rent-documents/further-checks) in future.
 
-^You can read more about the [right to rent documents](/government/publications/right-to-rent-document-checks-a-user-guide) you can accept as proof.^
+^Read more about the [right to rent documents](/government/publications/right-to-rent-document-checks-a-user-guide) you can accept.^  
 

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -2,9 +2,9 @@
 lib/smart_answer_flows/landlord-immigration-check.rb: c254f6b85c1b958ac2993665801690e7
 test/data/landlord-immigration-check-questions-and-responses.yml: d4b485131540c40211b26a50e071032d
 test/data/landlord-immigration-check-responses-and-expected-results.yml: 7982d80c9851bfa7e55dbee4661e70bc
-lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: 2588f9941fcf6b35e472a843da7cc9e5
+lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: 60507bfc657cf13a750b258017453743
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_landlord_code_of_practice.govspeak.erb: cfb1261ac17c7aa40445173406459290
-lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb: b83670d3f12e65c9f343dfef98293f00
+lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_rent.govspeak.erb: e9854adbcd8bfc03d8751eeb6791a464
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_rent.govspeak.erb: f94250541ec614c4e22e2eda9a322237
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_rent_but_check_will_be_needed_again.govspeak.erb: b21dd02e88d391fb815869ea8c5cfc18
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_rent_for_12_months.govspeak.erb: adc44f085dc1778beaf0b6aa57f838af


### PR DESCRIPTION
Zenddesk Story: https://govuk.zendesk.com/agent/tickets/1247752

* Added a link to a Home Office form so that landlords don't get fined.

## Factcheck
https://smart-answers-pr-2284.herokuapp.com/landlord-immigration-check

### Expected changes
*  Changed [URL](//gov.uk//landlord-immigration-check) from /check-tenant-right-to-rent-documents to /check-tenant-right-to-rent-documents/further-checks

### Before
<img width="1154" alt="before" src="https://cloud.githubusercontent.com/assets/84896/13117338/6c631148-d597-11e5-9cd6-246e8a65903b.png">


### After
 
<img width="1158" alt="after" src="https://cloud.githubusercontent.com/assets/84896/13117351/77536e9a-d597-11e5-8693-ecd27a3dc601.png">
