### PR TITLE
Move logic from country_of_ceremony question to MarriageAbroadCalculator

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -108,5 +108,19 @@ module SmartAnswer::Calculators
     def country_name_uppercase_prefix
       @country_name_formatter.definitive_article(ceremony_country, true)
     end
+
+    def country_name_partner_residence
+      if @data_query.british_overseas_territories?(ceremony_country)
+        'British (overseas territories citizen)'
+      elsif @data_query.french_overseas_territories?(ceremony_country)
+        'French'
+      elsif @data_query.dutch_caribbean_islands?(ceremony_country)
+        'Dutch'
+      elsif %w(hong-kong macao).include?(ceremony_country)
+        'Chinese'
+      else
+        "National of #{country_name_lowercase_prefix}"
+      end
+    end
   end
 end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -6,6 +6,10 @@ module SmartAnswer::Calculators
     attr_writer :sex_of_your_partner
     attr_writer :marriage_or_pacs
 
+    def initialize(data_query: nil)
+      @data_query = data_query || MarriageAbroadDataQuery.new
+    end
+
     def partner_british?
       @partner_nationality == 'partner_british'
     end
@@ -75,6 +79,14 @@ module SmartAnswer::Calculators
         fco_organisation.offices_with_service 'Registrations of Marriage and Civil Partnerships'
       else
         []
+      end
+    end
+
+    def marriage_and_partnership_phrases
+      if @data_query.ss_marriage_countries?(ceremony_country) || @data_query.ss_marriage_countries_when_couple_british?(ceremony_country)
+        'ss_marriage'
+      elsif @data_query.ss_marriage_and_partnership?(ceremony_country)
+        'ss_marriage_and_partnership'
       end
     end
   end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -69,5 +69,13 @@ module SmartAnswer::Calculators
     def fco_organisation
       world_location.fco_organisation
     end
+
+    def overseas_passports_embassies
+      if fco_organisation
+        fco_organisation.offices_with_service 'Registrations of Marriage and Civil Partnerships'
+      else
+        []
+      end
+    end
   end
 end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -65,5 +65,9 @@ module SmartAnswer::Calculators
     def world_location
       WorldLocation.find(ceremony_country) || raise(SmartAnswer::InvalidResponse)
     end
+
+    def fco_organisation
+      world_location.fco_organisation
+    end
   end
 end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -6,9 +6,10 @@ module SmartAnswer::Calculators
     attr_writer :sex_of_your_partner
     attr_writer :marriage_or_pacs
 
-    def initialize(data_query: nil, country_name_formatter: nil)
+    def initialize(data_query: nil, country_name_formatter: nil, registrations_data_query: nil)
       @data_query = data_query || MarriageAbroadDataQuery.new
       @country_name_formatter = country_name_formatter || CountryNameFormatter.new
+      @registrations_data_query = registrations_data_query || RegistrationsDataQuery.new
     end
 
     def partner_british?
@@ -120,6 +121,14 @@ module SmartAnswer::Calculators
         'Chinese'
       else
         "National of #{country_name_lowercase_prefix}"
+      end
+    end
+
+    def embassy_or_consulate_ceremony_country
+      if @registrations_data_query.has_consulate?(ceremony_country) || @registrations_data_query.has_consulate_general?(ceremony_country)
+        'consulate'
+      else
+        'embassy'
       end
     end
   end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -104,5 +104,9 @@ module SmartAnswer::Calculators
         ceremony_country_name
       end
     end
+
+    def country_name_uppercase_prefix
+      @country_name_formatter.definitive_article(ceremony_country, true)
+    end
   end
 end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -6,8 +6,9 @@ module SmartAnswer::Calculators
     attr_writer :sex_of_your_partner
     attr_writer :marriage_or_pacs
 
-    def initialize(data_query: nil)
+    def initialize(data_query: nil, country_name_formatter: nil)
       @data_query = data_query || MarriageAbroadDataQuery.new
+      @country_name_formatter = country_name_formatter || CountryNameFormatter.new
     end
 
     def partner_british?
@@ -91,6 +92,16 @@ module SmartAnswer::Calculators
         'ss_marriage'
       elsif @data_query.ss_marriage_and_partnership?(ceremony_country)
         'ss_marriage_and_partnership'
+      end
+    end
+
+    def country_name_lowercase_prefix
+      if @country_name_formatter.requires_definite_article?(ceremony_country)
+        @country_name_formatter.definitive_article(ceremony_country)
+      elsif @country_name_formatter.has_friendly_name?(ceremony_country)
+        @country_name_formatter.friendly_name(ceremony_country).html_safe
+      else
+        ceremony_country_name
       end
     end
   end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -61,5 +61,9 @@ module SmartAnswer::Calculators
     def want_to_get_married?
       @marriage_or_pacs == 'marriage'
     end
+
+    def world_location
+      WorldLocation.find(ceremony_country) || raise(SmartAnswer::InvalidResponse)
+    end
   end
 end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -70,6 +70,10 @@ module SmartAnswer::Calculators
       WorldLocation.find(ceremony_country) || raise(SmartAnswer::InvalidResponse)
     end
 
+    def ceremony_country_name
+      world_location.name
+    end
+
     def fco_organisation
       world_location.fco_organisation
     end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -37,11 +37,7 @@ module SmartAnswer
           calculator.fco_organisation
         end
         calculate :overseas_passports_embassies do
-          if organisation
-            organisation.offices_with_service 'Registrations of Marriage and Civil Partnerships'
-          else
-            []
-          end
+          calculator.overseas_passports_embassies
         end
 
         calculate :marriage_and_partnership_phrases do

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -49,13 +49,7 @@ module SmartAnswer
         end
 
         calculate :country_name_lowercase_prefix do
-          if country_name_query.requires_definite_article?(calculator.ceremony_country)
-            country_name_query.definitive_article(calculator.ceremony_country)
-          elsif country_name_query.has_friendly_name?(calculator.ceremony_country)
-            country_name_query.friendly_name(calculator.ceremony_country).html_safe
-          else
-            ceremony_country_name
-          end
+          calculator.country_name_lowercase_prefix
         end
 
         calculate :country_name_uppercase_prefix do

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -34,7 +34,7 @@ module SmartAnswer
           calculator.world_location
         end
         calculate :organisation do
-          location.fco_organisation
+          calculator.fco_organisation
         end
         calculate :overseas_passports_embassies do
           if organisation

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -31,9 +31,7 @@ module SmartAnswer
         end
 
         calculate :location do
-          loc = WorldLocation.find(calculator.ceremony_country)
-          raise InvalidResponse unless loc
-          loc
+          calculator.world_location
         end
         calculate :organisation do
           location.fco_organisation

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -61,11 +61,7 @@ module SmartAnswer
         end
 
         calculate :embassy_or_consulate_ceremony_country do
-          if reg_data_query.has_consulate?(calculator.ceremony_country) || reg_data_query.has_consulate_general?(calculator.ceremony_country)
-            "consulate"
-          else
-            "embassy"
-          end
+          calculator.embassy_or_consulate_ceremony_country
         end
 
         permitted_next_nodes = [

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -45,7 +45,7 @@ module SmartAnswer
         end
 
         calculate :ceremony_country_name do
-          location.name
+          calculator.ceremony_country_name
         end
 
         calculate :country_name_lowercase_prefix do

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -57,17 +57,7 @@ module SmartAnswer
         end
 
         calculate :country_name_partner_residence do
-          if data_query.british_overseas_territories?(calculator.ceremony_country)
-            "British (overseas territories citizen)"
-          elsif data_query.french_overseas_territories?(calculator.ceremony_country)
-            "French"
-          elsif data_query.dutch_caribbean_islands?(calculator.ceremony_country)
-            "Dutch"
-          elsif %w(hong-kong macao).include?(calculator.ceremony_country)
-            "Chinese"
-          else
-            "National of #{country_name_lowercase_prefix}"
-          end
+          calculator.country_name_partner_residence
         end
 
         calculate :embassy_or_consulate_ceremony_country do

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -53,7 +53,7 @@ module SmartAnswer
         end
 
         calculate :country_name_uppercase_prefix do
-          country_name_query.definitive_article(calculator.ceremony_country, true)
+          calculator.country_name_uppercase_prefix
         end
 
         calculate :country_name_partner_residence do

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -41,11 +41,7 @@ module SmartAnswer
         end
 
         calculate :marriage_and_partnership_phrases do
-          if data_query.ss_marriage_countries?(calculator.ceremony_country) || data_query.ss_marriage_countries_when_couple_british?(calculator.ceremony_country)
-            "ss_marriage"
-          elsif data_query.ss_marriage_and_partnership?(calculator.ceremony_country)
-            "ss_marriage_and_partnership"
-          end
+          calculator.marriage_and_partnership_phrases
         end
 
         calculate :ceremony_country_name do

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: 8801e5af39d848d3d11b6fced5ca273e
+lib/smart_answer_flows/marriage-abroad.rb: 7f9fa3470f1c59bc2bf25463f64dbea0
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: 2fc866ca2a51d7322ece623f1b7a6f54
 lib/smart_answer_flows/marriage-abroad/marriage_abroad.govspeak.erb: b4d0cfc1c7c4776d968c9b5b6df85027
@@ -140,7 +140,7 @@ lib/smart_answer_flows/marriage-abroad/questions/legal_residency.govspeak.erb: d
 lib/smart_answer_flows/marriage-abroad/questions/marriage_or_pacs.govspeak.erb: a51aecfac697188f90ca9efefcb2e0ea
 lib/smart_answer_flows/marriage-abroad/questions/partner_opposite_or_same_sex.govspeak.erb: 40d0c99a5be50f0625c6562f06fe4afd
 lib/smart_answer_flows/marriage-abroad/questions/what_is_your_partners_nationality.govspeak.erb: f8569c0fef74864a92536e8181fa23e6
-lib/smart_answer/calculators/marriage_abroad_calculator.rb: bfd71d32cd19091b44165fe50fdaa892
+lib/smart_answer/calculators/marriage_abroad_calculator.rb: d5542e5dc4c6455f58919c7fc180428f
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: edfb4439ecb62235306dbd317497993d
 lib/smart_answer/calculators/country_name_formatter.rb: 69a0726640385f42de50b80fdb144ff8

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -272,6 +272,27 @@ module SmartAnswer
           assert_nil @calculator.fco_organisation
         end
       end
+
+      context '#overseas_passports_embassies' do
+        setup do
+          @calculator = MarriageAbroadCalculator.new
+        end
+
+        should 'return the offices that offer registrations of marriage and civil partnerships' do
+          world_office = stub('World Office')
+          organisation = stub.quacks_like(WorldwideOrganisation.new({}))
+          organisation.stubs(:offices_with_service).with('Registrations of Marriage and Civil Partnerships').returns([world_office])
+          @calculator.stubs(:fco_organisation).returns(organisation)
+
+          assert_equal [world_office], @calculator.overseas_passports_embassies
+        end
+
+        should 'return an empty array when there is no fco organisation' do
+          @calculator.stubs(:fco_organisation).returns(nil)
+
+          assert_equal [], @calculator.overseas_passports_embassies
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -293,6 +293,37 @@ module SmartAnswer
           assert_equal [], @calculator.overseas_passports_embassies
         end
       end
+
+      context '#marriage_and_partnership_phrases' do
+        setup do
+          @data_query = stub.quacks_like(MarriageAbroadDataQuery.new)
+          @data_query.stubs(:ss_marriage_countries?).returns(false)
+          @data_query.stubs(:ss_marriage_countries_when_couple_british?).returns(false)
+          @data_query.stubs(:ss_marriage_and_partnership?).returns(false)
+          @calculator = MarriageAbroadCalculator.new(data_query: @data_query)
+        end
+
+        should 'return ss_marriage when the ceremony country is in the list of same sex marriage countries' do
+          @calculator.ceremony_country = 'same-sex-marriage-country'
+          @data_query.stubs(:ss_marriage_countries?).with('same-sex-marriage-country').returns(true)
+
+          assert_equal 'ss_marriage', @calculator.marriage_and_partnership_phrases
+        end
+
+        should 'return ss_marriage when the ceremony country is in the list of same sex marriage countries for british couples' do
+          @calculator.ceremony_country = 'same-sex-marriage-country-for-british-couple'
+          @data_query.stubs(:ss_marriage_countries_when_couple_british?).with('same-sex-marriage-country-for-british-couple').returns(true)
+
+          assert_equal 'ss_marriage', @calculator.marriage_and_partnership_phrases
+        end
+
+        should 'return ss_marriage_and_partnership when the ceremony country is in the list of same sex marriage and partnership countries' do
+          @calculator.ceremony_country = 'same-sex-marriage-and-partnership-country'
+          @data_query.stubs(:ss_marriage_and_partnership?).with('same-sex-marriage-and-partnership-country').returns(true)
+
+          assert_equal 'ss_marriage_and_partnership', @calculator.marriage_and_partnership_phrases
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -247,6 +247,31 @@ module SmartAnswer
           end
         end
       end
+
+      context '#fco_organisation' do
+        setup do
+          @calculator = MarriageAbroadCalculator.new
+        end
+
+        should 'return the fco organisation for the world location' do
+          fco_organisation = stub.quacks_like(WorldwideOrganisation.new({}))
+          world_location = stub.quacks_like(WorldLocation.new({}))
+          world_location.stubs(:fco_organisation).returns(fco_organisation)
+          WorldLocation.stubs(:find).with('ceremony-country-with-fco-organisation').returns(world_location)
+          @calculator.ceremony_country = 'ceremony-country-with-fco-organisation'
+
+          assert_equal fco_organisation, @calculator.fco_organisation
+        end
+
+        should "return nil if the world location doesn't have an fco organisation" do
+          world_location = stub.quacks_like(WorldLocation.new({}))
+          world_location.stubs(:fco_organisation).returns(nil)
+          WorldLocation.stubs(:find).with('ceremony-country-without-fco-organisation').returns(world_location)
+          @calculator.ceremony_country = 'ceremony-country-without-fco-organisation'
+
+          assert_nil @calculator.fco_organisation
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -436,6 +436,36 @@ module SmartAnswer
           assert_equal 'National of country-name-lowercase-prefix', @calculator.country_name_partner_residence
         end
       end
+
+      context '#embassy_or_consulate_ceremony_country' do
+        setup do
+          @registrations_data_query = stub.quacks_like(RegistrationsDataQuery.new)
+          @registrations_data_query.stubs(:has_consulate?)
+          @registrations_data_query.stubs(:has_consulate_general?)
+
+          @calculator = MarriageAbroadCalculator.new(registrations_data_query: @registrations_data_query)
+          @calculator.ceremony_country = 'country-slug'
+        end
+
+        should 'return "consulate" if ceremony country has consulate' do
+          @registrations_data_query.stubs(:has_consulate?).with('country-slug').returns(true)
+
+          assert_equal 'consulate', @calculator.embassy_or_consulate_ceremony_country
+        end
+
+        should 'return "consulate" if ceremony country has consulate general' do
+          @registrations_data_query.stubs(:has_consulate_general?).with('country-slug').returns(true)
+
+          assert_equal 'consulate', @calculator.embassy_or_consulate_ceremony_country
+        end
+
+        should 'return "embassy" if ceremony country has neither consulate nor consulate general' do
+          @registrations_data_query.stubs(:has_consulate?).returns(false)
+          @registrations_data_query.stubs(:has_consulate_general?).returns(false)
+
+          assert_equal 'embassy', @calculator.embassy_or_consulate_ceremony_country
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -226,6 +226,27 @@ module SmartAnswer
           refute @calculator.want_to_get_married?
         end
       end
+
+      context '#world_location' do
+        setup do
+          @calculator = MarriageAbroadCalculator.new
+          @calculator.ceremony_country = 'ceremony-country'
+        end
+
+        should 'return the world location for the given ceremony country' do
+          WorldLocation.stubs(:find).with('ceremony-country').returns('world-location')
+
+          assert_equal 'world-location', @calculator.world_location
+        end
+
+        should 'raise an InvalidResponse exception if the world location cannot be found for the ceremony country' do
+          WorldLocation.stubs(:find).with('ceremony-country').returns(nil)
+
+          assert_raise(InvalidResponse) do
+            @calculator.world_location
+          end
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -374,6 +374,20 @@ module SmartAnswer
           assert_equal 'country-name', @calculator.country_name_lowercase_prefix
         end
       end
+
+      context '#country_name_uppercase_prefix' do
+        setup do
+          @country_name_formatter = stub.quacks_like(CountryNameFormatter.new)
+          @calculator = MarriageAbroadCalculator.new(country_name_formatter: @country_name_formatter)
+          @calculator.ceremony_country = 'country-slug'
+        end
+
+        should 'return the ceremony country with upper case definite article' do
+          @country_name_formatter.stubs(:definitive_article).with('country-slug', true).returns('The-country-name')
+
+          assert_equal 'The-country-name', @calculator.country_name_uppercase_prefix
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -335,6 +335,45 @@ module SmartAnswer
           assert_equal 'world-location-name', calculator.ceremony_country_name
         end
       end
+
+      context '#country_name_lowercase_prefix' do
+        setup do
+          @country_name_formatter = stub.quacks_like(CountryNameFormatter.new)
+          @calculator = MarriageAbroadCalculator.new(country_name_formatter: @country_name_formatter)
+          @calculator.ceremony_country = 'country-slug'
+        end
+
+        should 'return the definitive article if ceremony country is in the list of countries with definitive article' do
+          @country_name_formatter.stubs(:requires_definite_article?).with('country-slug').returns(true)
+          @country_name_formatter.stubs(:definitive_article).with('country-slug').returns('the-country-name')
+
+          assert_equal 'the-country-name', @calculator.country_name_lowercase_prefix
+        end
+
+        should 'return the friendly country name if definitive article not required and friendly country name found' do
+          @country_name_formatter.stubs(:requires_definite_article?).with('country-slug').returns(false)
+          @country_name_formatter.stubs(:has_friendly_name?).with('country-slug').returns(true)
+          @country_name_formatter.stubs(:friendly_name).with('country-slug').returns('friendly-country-name')
+
+          assert_equal 'friendly-country-name', @calculator.country_name_lowercase_prefix
+        end
+
+        should 'return an html safe version of the friendly country name' do
+          @country_name_formatter.stubs(:requires_definite_article?).with('country-slug').returns(false)
+          @country_name_formatter.stubs(:has_friendly_name?).with('country-slug').returns(true)
+          @country_name_formatter.stubs(:friendly_name).with('country-slug').returns('friendly-country-name')
+
+          assert @calculator.country_name_lowercase_prefix.html_safe?
+        end
+
+        should 'return the ceremony country name if not in the list of definitive articles or friendly country names' do
+          @country_name_formatter.stubs(:requires_definite_article?).with('country-slug').returns(false)
+          @country_name_formatter.stubs(:has_friendly_name?).with('country-slug').returns(false)
+          @calculator.stubs(:ceremony_country_name).returns('country-name')
+
+          assert_equal 'country-name', @calculator.country_name_lowercase_prefix
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -324,6 +324,17 @@ module SmartAnswer
           assert_equal 'ss_marriage_and_partnership', @calculator.marriage_and_partnership_phrases
         end
       end
+
+      context '#ceremony_country_name' do
+        should 'return the name of the world location associated with the ceremony country' do
+          world_location = stub.quacks_like(WorldLocation.new({}))
+          world_location.stubs(:name).returns('world-location-name')
+          calculator = MarriageAbroadCalculator.new
+          calculator.stubs(:world_location).returns(world_location)
+
+          assert_equal 'world-location-name', calculator.ceremony_country_name
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -388,6 +388,54 @@ module SmartAnswer
           assert_equal 'The-country-name', @calculator.country_name_uppercase_prefix
         end
       end
+
+      context '#country_name_partner_residence' do
+        setup do
+          @data_query = stub.quacks_like(MarriageAbroadDataQuery.new)
+          @data_query.stubs(:british_overseas_territories?)
+          @data_query.stubs(:french_overseas_territories?)
+          @data_query.stubs(:dutch_caribbean_islands?)
+
+          @calculator = MarriageAbroadCalculator.new(data_query: @data_query)
+          @calculator.ceremony_country = 'country-slug'
+        end
+
+        should 'return "British (overseas territories citizen)" when ceremony country is British overseas territory' do
+          @data_query.stubs(:british_overseas_territories?).with('country-slug').returns(true)
+
+          assert_equal 'British (overseas territories citizen)', @calculator.country_name_partner_residence
+        end
+
+        should 'return "French" when ceremony country is French overseas territory' do
+          @data_query.stubs(:french_overseas_territories?).with('country-slug').returns(true)
+
+          assert_equal 'French', @calculator.country_name_partner_residence
+        end
+
+        should 'return "Dutch" when ceremony country is in the Dutch Caribbean islands' do
+          @data_query.stubs(:dutch_caribbean_islands?).with('country-slug').returns(true)
+
+          assert_equal 'Dutch', @calculator.country_name_partner_residence
+        end
+
+        should 'return "Chinese" when ceremony country is Hong Kong' do
+          @calculator.ceremony_country = 'hong-kong'
+
+          assert_equal 'Chinese', @calculator.country_name_partner_residence
+        end
+
+        should 'return "Chinese" when ceremony country is Macao' do
+          @calculator.ceremony_country = 'macao'
+
+          assert_equal 'Chinese', @calculator.country_name_partner_residence
+        end
+
+        should 'return "National of <country_name_lowercase_prefix>" in all other cases' do
+          @calculator.stubs(:country_name_lowercase_prefix).returns('country-name-lowercase-prefix')
+
+          assert_equal 'National of country-name-lowercase-prefix', @calculator.country_name_partner_residence
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I've moved the logic from the `calculate` blocks in the `:country_of_ceremony?` question to methods on the `MarriageAbroadCalculator`. I've added unit tests for these methods to describe the existing behaviour.

The next step will be to remove these `calculate` blocks and access the methods on the calculator directly in the flow, questions and outcomes.

I've used `stub.quacks_like(<instance-of-object>)` in a number of tests. This is instead of using a real instance of the object, or of using a plain stub. It gives me confidence that I'm not accidentally relying on behaviour in the real object, and that I'm not stubbing/calling a method that doesn't exist on the real object.