### PR TITLE
Remove Seychelles from countries recognising same sex marriages

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -34,9 +34,9 @@ module SmartAnswer::Calculators
 
     COUNTRIES_WITHOUT_CONSULAR_FACILITIES = %w(argentina aruba bonaire-st-eustatius-saba burundi cote-d-ivoire curacao czech-republic saint-barthelemy slovakia st-maarten st-martin taiwan)
 
-    SS_MARRIAGE_COUNTRIES = %w(australia azerbaijan bolivia chile china colombia dominican-republic estonia germany hungary kosovo latvia mongolia montenegro nicaragua russia san-marino serbia seychelles)
+    SS_MARRIAGE_COUNTRIES = %w(australia azerbaijan bolivia chile china colombia dominican-republic estonia germany hungary kosovo latvia mongolia montenegro nicaragua russia san-marino serbia)
 
-    NO_SS_MARRIAGE_COUNTRIES = %w(san-marino)
+    NO_SS_MARRIAGE_COUNTRIES = %w(san-marino seychelles)
 
     SS_MARRIAGE_COUNTRIES_WHEN_COUPLE_BRITISH = %w(lithuania)
 

--- a/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_british/opposite_sex.txt
@@ -1,0 +1,11 @@
+Marriage in the Seychelles
+
+
+Contact the relevant local authorities in the Seychelles to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+
+The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+
+*[CNI]:certificate of no impediment
+

--- a/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_british/same_sex.txt
@@ -1,0 +1,4 @@
+Same-sex marriage and civil partnership in the Seychelles
+
+It’s not possible to get legal recognition for your same-sex relationship in the Seychelles.
+

--- a/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_local/opposite_sex.txt
@@ -1,0 +1,15 @@
+Marriage in the Seychelles
+
+
+Contact the relevant local authorities in the Seychelles to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+
+The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+

--- a/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_local/same_sex.txt
@@ -1,0 +1,4 @@
+Same-sex marriage and civil partnership in the Seychelles
+
+It’s not possible to get legal recognition for your same-sex relationship in the Seychelles.
+

--- a/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_other/opposite_sex.txt
@@ -1,0 +1,15 @@
+Marriage in the Seychelles
+
+
+Contact the relevant local authorities in the Seychelles to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+
+The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+

--- a/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/ceremony_country/partner_other/same_sex.txt
@@ -1,0 +1,4 @@
+Same-sex marriage and civil partnership in the Seychelles
+
+It’s not possible to get legal recognition for your same-sex relationship in the Seychelles.
+

--- a/test/artefacts/marriage-abroad/seychelles/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/third_country/partner_british/opposite_sex.txt
@@ -1,0 +1,11 @@
+Marriage in the Seychelles
+
+
+Contact the relevant local authorities in the Seychelles to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Seychelles](/foreign-travel-advice/seychelles) before making any plans.
+
+The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+
+*[CNI]:certificate of no impediment
+

--- a/test/artefacts/marriage-abroad/seychelles/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/third_country/partner_british/same_sex.txt
@@ -1,0 +1,4 @@
+Same-sex marriage and civil partnership in the Seychelles
+
+It’s not possible to get legal recognition for your same-sex relationship in the Seychelles.
+

--- a/test/artefacts/marriage-abroad/seychelles/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/third_country/partner_local/opposite_sex.txt
@@ -1,0 +1,15 @@
+Marriage in the Seychelles
+
+
+Contact the relevant local authorities in the Seychelles to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Seychelles](/foreign-travel-advice/seychelles) before making any plans.
+
+The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+

--- a/test/artefacts/marriage-abroad/seychelles/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/third_country/partner_local/same_sex.txt
@@ -1,0 +1,4 @@
+Same-sex marriage and civil partnership in the Seychelles
+
+It’s not possible to get legal recognition for your same-sex relationship in the Seychelles.
+

--- a/test/artefacts/marriage-abroad/seychelles/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/third_country/partner_other/opposite_sex.txt
@@ -1,0 +1,15 @@
+Marriage in the Seychelles
+
+
+Contact the relevant local authorities in the Seychelles to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Seychelles](/foreign-travel-advice/seychelles) before making any plans.
+
+The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+

--- a/test/artefacts/marriage-abroad/seychelles/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/third_country/partner_other/same_sex.txt
@@ -1,0 +1,4 @@
+Same-sex marriage and civil partnership in the Seychelles
+
+It’s not possible to get legal recognition for your same-sex relationship in the Seychelles.
+

--- a/test/artefacts/marriage-abroad/seychelles/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/uk/partner_british/opposite_sex.txt
@@ -1,0 +1,11 @@
+Marriage in the Seychelles
+
+
+Contact the [High Commission of the Seychelles](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Seychelles](/foreign-travel-advice/seychelles) before making any plans.
+
+The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+
+*[CNI]:certificate of no impediment
+

--- a/test/artefacts/marriage-abroad/seychelles/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/uk/partner_british/same_sex.txt
@@ -1,0 +1,4 @@
+Same-sex marriage and civil partnership in the Seychelles
+
+It’s not possible to get legal recognition for your same-sex relationship in the Seychelles.
+

--- a/test/artefacts/marriage-abroad/seychelles/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/uk/partner_local/opposite_sex.txt
@@ -1,0 +1,15 @@
+Marriage in the Seychelles
+
+
+Contact the [High Commission of the Seychelles](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Seychelles](/foreign-travel-advice/seychelles) before making any plans.
+
+The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+

--- a/test/artefacts/marriage-abroad/seychelles/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/uk/partner_local/same_sex.txt
@@ -1,0 +1,4 @@
+Same-sex marriage and civil partnership in the Seychelles
+
+It’s not possible to get legal recognition for your same-sex relationship in the Seychelles.
+

--- a/test/artefacts/marriage-abroad/seychelles/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/uk/partner_other/opposite_sex.txt
@@ -1,0 +1,15 @@
+Marriage in the Seychelles
+
+
+Contact the [High Commission of the Seychelles](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
+
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Seychelles](/foreign-travel-advice/seychelles) before making any plans.
+
+The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+*[CNI]:certificate of no impediment
+

--- a/test/artefacts/marriage-abroad/seychelles/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/seychelles/uk/partner_other/same_sex.txt
@@ -1,0 +1,4 @@
+Same-sex marriage and civil partnership in the Seychelles
+
+It’s not possible to get legal recognition for your same-sex relationship in the Seychelles.
+

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/marriage-abroad.rb: 8801e5af39d848d3d11b6fced5ca273e
-test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
-test/data/marriage-abroad-responses-and-expected-results.yml: 2fc866ca2a51d7322ece623f1b7a6f54
+test/data/marriage-abroad-questions-and-responses.yml: 85feca37588fbe9da8d56b382e6cdc23
+test/data/marriage-abroad-responses-and-expected-results.yml: 3e963b5c4d120c5012dede8491a187ad
 lib/smart_answer_flows/marriage-abroad/marriage_abroad.govspeak.erb: b4d0cfc1c7c4776d968c9b5b6df85027
 lib/smart_answer_flows/marriage-abroad/outcomes/_affirmation_os_translation_in_local_language_text.govspeak.erb: 4ac964ce5e41e3efaf0f43d11c71b2b7
 lib/smart_answer_flows/marriage-abroad/outcomes/_appointment_documents_in_vietnam.govspeak.erb: 6390e13560110a71b8a3c0dc018ff4cf
@@ -142,6 +142,6 @@ lib/smart_answer_flows/marriage-abroad/questions/partner_opposite_or_same_sex.go
 lib/smart_answer_flows/marriage-abroad/questions/what_is_your_partners_nationality.govspeak.erb: f8569c0fef74864a92536e8181fa23e6
 lib/smart_answer/calculators/marriage_abroad_calculator.rb: bfd71d32cd19091b44165fe50fdaa892
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 2f521bae99c2f48b49d07bcb283a8063
-lib/smart_answer/calculators/marriage_abroad_data_query.rb: edfb4439ecb62235306dbd317497993d
+lib/smart_answer/calculators/marriage_abroad_data_query.rb: 80043ce123ab86befc4def86361abb81
 lib/smart_answer/calculators/country_name_formatter.rb: 69a0726640385f42de50b80fdb144ff8
 lib/smart_answer/calculators/registrations_data_query.rb: 563c5db7d7272bc07bd636a92b40f3ce

--- a/test/data/marriage-abroad-questions-and-responses.yml
+++ b/test/data/marriage-abroad-questions-and-responses.yml
@@ -81,6 +81,7 @@
 - saint-barthelemy
 - san-marino
 - saudi-arabia
+- seychelles
 - serbia
 - singapore
 - slovakia

--- a/test/data/marriage-abroad-responses-and-expected-results.yml
+++ b/test/data/marriage-abroad-responses-and-expected-results.yml
@@ -17537,6 +17537,236 @@
   :outcome_node: true
 - :current_node: :country_of_ceremony?
   :responses:
+  - seychelles
+  :next_node: :legal_residency?
+  :outcome_node: false
+- :current_node: :legal_residency?
+  :responses:
+  - seychelles
+  - uk
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses:
+  - seychelles
+  - uk
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - uk
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - uk
+  - partner_british
+  - same_sex
+  :next_node: :outcome_ss_marriage_not_possible
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses:
+  - seychelles
+  - uk
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - uk
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - uk
+  - partner_local
+  - same_sex
+  :next_node: :outcome_ss_marriage_not_possible
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses:
+  - seychelles
+  - uk
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - uk
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - uk
+  - partner_other
+  - same_sex
+  :next_node: :outcome_ss_marriage_not_possible
+  :outcome_node: true
+- :current_node: :legal_residency?
+  :responses:
+  - seychelles
+  - ceremony_country
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses:
+  - seychelles
+  - ceremony_country
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - ceremony_country
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_no_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - ceremony_country
+  - partner_british
+  - same_sex
+  :next_node: :outcome_ss_marriage_not_possible
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses:
+  - seychelles
+  - ceremony_country
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - ceremony_country
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_no_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - ceremony_country
+  - partner_local
+  - same_sex
+  :next_node: :outcome_ss_marriage_not_possible
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses:
+  - seychelles
+  - ceremony_country
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - ceremony_country
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_no_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - ceremony_country
+  - partner_other
+  - same_sex
+  :next_node: :outcome_ss_marriage_not_possible
+  :outcome_node: true
+- :current_node: :legal_residency?
+  :responses:
+  - seychelles
+  - third_country
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses:
+  - seychelles
+  - third_country
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - third_country
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_no_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - third_country
+  - partner_british
+  - same_sex
+  :next_node: :outcome_ss_marriage_not_possible
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses:
+  - seychelles
+  - third_country
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - third_country
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_no_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - third_country
+  - partner_local
+  - same_sex
+  :next_node: :outcome_ss_marriage_not_possible
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses:
+  - seychelles
+  - third_country
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - third_country
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_no_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses:
+  - seychelles
+  - third_country
+  - partner_other
+  - same_sex
+  :next_node: :outcome_ss_marriage_not_possible
+  :outcome_node: true
+- :current_node: :country_of_ceremony?
+  :responses:
   - saudi-arabia
   :next_node: :legal_residency?
   :outcome_node: false

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -2373,7 +2373,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'ceremony_country'
       add_response 'partner_local'
       add_response 'same_sex'
-      assert_current_node :outcome_ss_marriage
+      assert_current_node :outcome_ss_marriage_not_possible
     end
   end
 


### PR DESCRIPTION
Pivotal ticket: https://www.pivotaltracker.com/story/show/114088901

The authorities in Seychelles have revoked the agreement allowing the British High Commission (BHC) to conduct same sex marriage at the BHC, with immediate effect.

## Fact check

https://pt-114088901.herokuapp.com/marriage-abroad/y/seychelles/uk/partner_british/same_sex

## Expected changes
 [URL on gov.uk](https://www.gov.uk/marriage-abroad/y/seychelles/uk/partner_british/same_sex)
  * Removes sentence "You may be able to get married at the British embassy or consulate in the Seychelles."
  * Removes contact information for British High Commission in Victoria

### Before
![screen shot 2016-02-19 at 4 20 50 pm](https://cloud.githubusercontent.com/assets/351763/13181451/27c3fe14-d725-11e5-9d3e-66a678427966.png)

### After
![screen shot 2016-02-19 at 4 20 59 pm](https://cloud.githubusercontent.com/assets/351763/13181455/2d0b4292-d725-11e5-9a50-4c2b8148fc65.png)
