### PR TITLE
Marriage abroad spain replace download links

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
@@ -35,7 +35,7 @@
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
       locals: { calculator: calculator } %>
 
-  You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+  You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
   <% if calculator.resident_of_third_country? %>
     Check with the civil registry  where you’re getting married to find out what certificate you’ll need.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
@@ -35,7 +35,7 @@
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
       locals: { calculator: calculator } %>
 
-  You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+  You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
   <% if calculator.resident_of_third_country? %>
     Check with the civil registry  where you’re getting married to find out what certificate you’ll need.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
@@ -35,7 +35,7 @@
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
       locals: { calculator: calculator } %>
 
-  You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+  You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
   <% if calculator.resident_of_third_country? %>
     Check with the civil registry  where you’re getting married to find out what certificate you’ll need.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
@@ -35,7 +35,7 @@
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
       locals: { calculator: calculator } %>
 
-  You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+  You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
   <% if calculator.resident_of_third_country? %>
     Check with the civil registry  where you’re getting married to find out what certificate you’ll need.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
@@ -35,15 +35,7 @@
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
       locals: { calculator: calculator } %>
 
-  You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-  $D
-  [Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-  $D
-
-  $D
-  [Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-  $D
+  You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
   <% if calculator.resident_of_third_country? %>
     Check with the civil registry  where you’re getting married to find out what certificate you’ll need.

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -8,15 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -8,15 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -8,15 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -8,15 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -8,15 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -8,7 +8,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -8,15 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -8,7 +8,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
@@ -8,15 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
@@ -10,15 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
@@ -8,15 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
@@ -10,15 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
@@ -8,15 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Spain to find out about local marriage
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
@@ -10,15 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
@@ -9,15 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
@@ -10,15 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
@@ -9,15 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
@@ -10,15 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
@@ -9,15 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
@@ -9,7 +9,7 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), a [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
@@ -10,15 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-$D
-[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
-$D
-
-$D
-[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/publications/marital-status-example)
-$D
+You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](//www.gov.uk/government/publications/example-certificate-of-no-impediment-cni), [marital status](//www.gov.uk/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
@@ -10,7 +10,7 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 ##What you need to do
 
-You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status](/government/publications/marital-status-example) certificate or both to prove you’re allowed to marry.
+You'll be asked to provide a [certificate of no impediment (CNI)](/government/publications/example-certificate-of-no-impediment-cni), [marital status certificate](/government/publications/marital-status-example) or both to prove you’re allowed to marry.
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -127,7 +127,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_other_countries.govsp
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_poland.govspeak.erb: c58d79b7eab27b73359d060352cf9747
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_slovenia.govspeak.erb: 3cc85d2b3adc3049b9adf439486cbd0e
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_portugal.govspeak.erb: 7928e930761d5d6d2f32491194004c15
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb: c3e53d39df81bb7b87d7f70b3d6dfd06
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb: c0679dfee2c3e04b8773fa6117e9df14
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ss_affirmation.govspeak.erb: 27cf6dd1f2f8602d40f46cb32970d308
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ss_marriage.govspeak.erb: 7e97841c8401304f56620f849d60c5f9
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ss_marriage_malta.govspeak.erb: b7450b569fc6fb92e671ca0dac196ce4


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/projects/1270592/stories/110175582

I have replaced the PDF download links on all Spanish marriage outcome pages with links to certificate of no impediment and marital status respectively.

* https://www.gov.uk/government/publications/example-certificate-of-no-impediment-cni (Certificate of no Impediment)
* https://www.gov.uk/government/publications/marital-status-example (Marital Status)

## FactCheck
[Marriage abroad spain replace download links](https://smart-answers-pr-110175582.herokuapp.com/marriage-abroad/y/spain/uk/partner_british/opposite_sex)

## Expected Changes
* [URL on gov.uk](https://www.gov.uk/marriage-abroad/y/spain/uk/partner_british/opposite_sex)
     * Remove PDF download links on Spanish outcome pages.
     * Change links to point to the certificate of no impediment and marital status on Spanish outcome pages respectively.

### Before
![screen shot 2016-02-22 at 15 29 03](https://cloud.githubusercontent.com/assets/84896/13222698/0a69dc16-d979-11e5-9fe6-f0dccb1c7e2c.png)


### After

![screen shot 2016-02-25 at 16 12 13](https://cloud.githubusercontent.com/assets/84896/13325632/9436ebec-dbda-11e5-82d2-6bf7616b987f.png)
