### PR TITLE
Update the `govuk-lint` gem to version 0.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       sanitize (~> 2.1.0)
     govuk-content-schema-test-helpers (1.3.0)
       json-schema (~> 2.5.1)
-    govuk-lint (0.6.2)
+    govuk-lint (0.7.0)
       rubocop (~> 0.35.0)
       scss_lint (~> 0.44.0)
     govuk_frontend_toolkit (4.8.0)


### PR DESCRIPTION
Version 0.7.0 was released to disabled the `IfUnlessModifier` cop dis-allowing single line blocks inside `if` and `unless` statements.

For smart answers, the change will allow us to write sequences of `if` statements in a consistent form, regardless of how many lines are inside the block.

If accepted, we can remove the second commit adding Rubocop `enable` and `disable` directives to the `check-uk-visa` smart answer in PR #2306