### PR TITLE
Update next node for check UK visa

### DIFF
--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -82,9 +82,13 @@ module SmartAnswer
 
           if calculator.study_visit? || calculator.work_visit?
             next :staying_for_how_long?
-          elsif calculator.diplomatic_visit?
+          end
+
+          if calculator.diplomatic_visit?
             next :outcome_diplomatic_business
-          elsif calculator.school_visit?
+          end
+
+          if calculator.school_visit?
             if calculator.passport_country_in_electronic_visa_waiver_list?
               next :outcome_school_waiver
             elsif calculator.passport_country_is_taiwan?
@@ -94,42 +98,52 @@ module SmartAnswer
             else
               next :outcome_school_y
             end
-          elsif calculator.medical_visit? || calculator.tourism_visit?
+          end
+
+          if calculator.medical_visit?
             if calculator.passport_country_in_electronic_visa_waiver_list?
               next :outcome_visit_waiver
             elsif calculator.passport_country_is_taiwan?
               next :outcome_taiwan_exception
-            end
-          end
-
-          if calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list?
-            if calculator.tourism_visit?
-              next :outcome_school_n
-            elsif calculator.medical_visit?
+            elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list?
               next :outcome_medical_n
+            else
+              next :outcome_medical_y
             end
           end
 
           if calculator.tourism_visit?
-            :outcome_standard_visit
-          elsif calculator.marriage_visit?
-            :outcome_marriage
-          elsif calculator.medical_visit?
-            :outcome_medical_y
-          elsif calculator.transit_visit?
+            if calculator.passport_country_in_electronic_visa_waiver_list?
+              next :outcome_visit_waiver
+            elsif calculator.passport_country_is_taiwan?
+              next :outcome_taiwan_exception
+            elsif calculator.passport_country_in_non_visa_national_list? || calculator.passport_country_in_ukot_list?
+              next :outcome_school_n # outcome does not contain school specific content
+            else
+              next :outcome_standard_visit
+            end
+          end
+
+          if calculator.marriage_visit?
+            next :outcome_marriage
+          end
+
+          if calculator.transit_visit?
             if calculator.passport_country_in_datv_list? ||
                 calculator.passport_country_in_visa_national_list? || calculator.passport_country_is_taiwan? || calculator.passport_country_is_venezuela?
-              :passing_through_uk_border_control?
+              next :passing_through_uk_border_control?
             else
-              :outcome_no_visa_needed
+              next :outcome_no_visa_needed
             end
-          elsif calculator.family_visit?
+          end
+
+          if calculator.family_visit?
             if calculator.passport_country_in_ukot_list?
-              :outcome_joining_family_m
+              next :outcome_joining_family_m
             elsif calculator.passport_country_in_non_visa_national_list?
-              :outcome_joining_family_nvn
+              next :outcome_joining_family_nvn
             else
-              :outcome_joining_family_y
+              next :outcome_joining_family_y
             end
           end
         end

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/check-uk-visa.rb: 3c8842514ba5d6ab7f0110d3005d9008
+lib/smart_answer_flows/check-uk-visa.rb: 53e5e3dfa257186c7ccd020df65ac6fd
 test/data/check-uk-visa-questions-and-responses.yml: 64bada47571ee751ee5df84fa7a64c7a
 test/data/check-uk-visa-responses-and-expected-results.yml: e096cbc2b6ebfc1615cc5799430ac199
 lib/smart_answer_flows/check-uk-visa/check_uk_visa.govspeak.erb: a442b4ddd169b26a401c70d145e5b44e


### PR DESCRIPTION
This PR reorganises the conditional logic in a `next_node` block for the check UK visa flow, moving the branching logic related to the question `purpose_of_visit` to the top level within the block, and nesting any sub-branching within each if statement for the particular purpose of visit.

Related to #2281, #2289, #2292 and #2306 