### PR TITLE
Use `instance_eval` instead of `eval` for `use_shared_logic`

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -23,7 +23,8 @@ module SmartAnswer
     end
 
     def use_shared_logic(filename)
-      eval File.read(Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")), binding
+      path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")
+      instance_eval File.read(path), path.to_s, 0
     end
 
     def name(name = nil)


### PR DESCRIPTION
This change reduces the scope of the context in which the code in the shared
logic files is executed which feels like a good thing to do.

This change also supplies a file path and a line number to the call to
`instance_eval` which means we get much better error messages when there is a
`SyntaxError` in a shared logic file.