### PR TITLE
Add tags to allow for govspeak rendering for questions.

### DIFF
--- a/app/views/smart_answers/_current_question.html.erb
+++ b/app/views/smart_answers/_current_question.html.erb
@@ -3,7 +3,9 @@
     <%= question.title %>
   </h2>
   <div class="question-body">
-    <%= question.body %>
+    <article role="article">
+      <%= question.body %>
+    </article>
 
     <% if question.hint.present? %>
       <p class="hint"><%= question.hint %></p>

--- a/test/artefacts/additional-commodity-code/0.html
+++ b/test/artefacts/additional-commodity-code/0.html
@@ -35,8 +35,10 @@
     How much sucrose, invert sugar or isoglucose does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/0/0.html
+++ b/test/artefacts/additional-commodity-code/0/0.html
@@ -35,8 +35,10 @@
     How much milk fat does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/0/0/0.html
+++ b/test/artefacts/additional-commodity-code/0/0/0.html
@@ -35,8 +35,10 @@
     How much milk proteins does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/0/0/18.html
+++ b/test/artefacts/additional-commodity-code/0/0/18.html
@@ -35,8 +35,10 @@
     How much milk proteins does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/0/0/3.html
+++ b/test/artefacts/additional-commodity-code/0/0/3.html
@@ -35,8 +35,10 @@
     How much milk proteins does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/0/0/6.html
+++ b/test/artefacts/additional-commodity-code/0/0/6.html
@@ -35,8 +35,10 @@
     How much milk proteins does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/0/0/9.html
+++ b/test/artefacts/additional-commodity-code/0/0/9.html
@@ -35,8 +35,10 @@
     How much milk proteins does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/25.html
+++ b/test/artefacts/additional-commodity-code/25.html
@@ -35,8 +35,10 @@
     How much sucrose, invert sugar or isoglucose does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/50.html
+++ b/test/artefacts/additional-commodity-code/50.html
@@ -35,8 +35,10 @@
     How much sucrose, invert sugar or isoglucose does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/75.html
+++ b/test/artefacts/additional-commodity-code/75.html
@@ -35,8 +35,10 @@
     How much sucrose, invert sugar or isoglucose does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/additional-commodity-code/y.html
+++ b/test/artefacts/additional-commodity-code/y.html
@@ -35,8 +35,10 @@
     How much starch or glucose does the product contain?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The values represent % by weight</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment.html
@@ -35,8 +35,10 @@
     Are you an apprentice?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you’re 19 or over and past your first year you don’t count as an apprentice for minimum wage purposes.</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice.html
@@ -35,8 +35,10 @@
     How old are you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25.html
@@ -35,9 +35,11 @@
     How often do you get paid?
   </h2>
   <div class="question-body">
-    <p>This is your pay period.</p>
+    <article role="article">
+      <p>This is your pay period.</p>
 
 
+    </article>
 
       <p class="hint">You get paid every</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1.html
@@ -35,8 +35,10 @@
     How many hours do you work during the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Don’t include any overtime or other extra hours you might work.</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
@@ -35,8 +35,10 @@
     How much does your employer charge for accommodation per day?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free.html
@@ -35,8 +35,10 @@
     How many days per week do you live in the accommodation?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/0.html
@@ -35,8 +35,10 @@
     Does your employer provide you with accommodation?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
@@ -35,8 +35,10 @@
     How much do you get paid for overtime per hour?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.0/100.html
@@ -35,8 +35,10 @@
     How many hours of overtime do you work during the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you don’t work overtime enter 0</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment/not_an_apprentice/25/1/16.html
@@ -35,8 +35,10 @@
     How much do you get paid before tax in the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Don’t include payments for overtime or anything extra to your pay, eg money for clothes or goods.</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/current_payment_april_2016.html
+++ b/test/artefacts/am-i-getting-minimum-wage/current_payment_april_2016.html
@@ -35,8 +35,10 @@
     Will you be in the first year of an apprenticeship on 1 April 2016?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment.html
@@ -35,8 +35,10 @@
     Which year would you like to check past payments for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You can go back up to 6 years</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01.html
@@ -35,8 +35,10 @@
     Were you an apprentice at the time?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no.html
@@ -35,8 +35,10 @@
     How old were you at the time?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25.html
@@ -35,9 +35,11 @@
     How often did you get paid?
   </h2>
   <div class="question-body">
-    <p>This is your pay period.</p>
+    <article role="article">
+      <p>This is your pay period.</p>
 
 
+    </article>
 
       <p class="hint">You get paid every</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1.html
@@ -35,8 +35,10 @@
     How many hours did you work during the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Don’t include any overtime or other extra hours you worked.</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
@@ -35,8 +35,10 @@
     How much did your employer charge for accommodation per day?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.0/0.0/yes_free.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.0/0.0/yes_free.html
@@ -35,8 +35,10 @@
     How many days per week did you live in the accommodation?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.0/0.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.0/0.html
@@ -35,8 +35,10 @@
     Did your employer provide you with accommodation?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.0/8.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.0/8.html
@@ -35,8 +35,10 @@
     How much did you get paid for overtime per hour?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.0/100.html
@@ -35,8 +35,10 @@
     How many hours of overtime did you work during the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you didn’t work overtime enter 0</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.html
+++ b/test/artefacts/am-i-getting-minimum-wage/past_payment/2014-10-01/no/25/1/16.html
@@ -35,8 +35,10 @@
     How much were you paid in the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Don’t include payments for overtime or anything extra to your pay, eg money for clothes or goods.</p>
 

--- a/test/artefacts/am-i-getting-minimum-wage/y.html
+++ b/test/artefacts/am-i-getting-minimum-wage/y.html
@@ -35,8 +35,10 @@
     What would you like to check?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/apply-tier-4-visa/extend_general.html
+++ b/test/artefacts/apply-tier-4-visa/extend_general.html
@@ -35,8 +35,10 @@
     What is your Tier 4 sponsor number?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You can find your sponsor number on your certificate of acceptance for studies (CAS).</p>
 

--- a/test/artefacts/apply-tier-4-visa/y.html
+++ b/test/artefacts/apply-tier-4-visa/y.html
@@ -35,8 +35,10 @@
     Are you:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/benefit-cap-calculator/y.html
+++ b/test/artefacts/benefit-cap-calculator/y.html
@@ -35,8 +35,10 @@
     Do you receive Housing Benefit?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/benefit-cap-calculator/yes.html
+++ b/test/artefacts/benefit-cap-calculator/yes.html
@@ -35,8 +35,10 @@
     Do you qualify for Working Tax Credit?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You don't need to be getting Working Tax Credit, only qualify for it.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no.html
@@ -35,7 +35,8 @@
     Do you or someone in your household get any of the following benefits:
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>Attendance Allowance</li>
   <li>Disability Living Allowance</li>
   <li>Industrial Injuries Benefit</li>
@@ -47,6 +48,7 @@
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/benefit-cap-calculator/yes/no/no.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no.html
@@ -35,8 +35,10 @@
     Do you or someone in your household get any of the following benefits:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you do not receive any of these click Next step.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Widow's Pension (age related)?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Widowed Parent's Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Widowed Mother's Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Widow's Pension?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Severe Disability Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Maternity Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Jobseeker’s Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Income Support?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Incapacity Benefit?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Guardian's Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Employment and Support Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Child Tax Credits?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.0/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Child Benefits?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement,carers,child_benefit,child_tax,esa,guardian,incapacity,income_support,jsa,maternity,sda,widow_pension,widowed_mother,widowed_parent,widows_aged/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Carer's Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Bereavement Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.0/50.html
@@ -35,8 +35,10 @@
     Are you:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.html
+++ b/test/artefacts/benefit-cap-calculator/yes/no/no/bereavement/50.html
@@ -35,8 +35,10 @@
     How much do you or someone in your household get for Housing Benefit?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You need the whole amount before anything is taken off (eg utility bills or loan repayments) per week. You must enter the full amount you get for each benefit.</p>
 

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/different-number-of-days.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/different-number-of-days.html
@@ -35,8 +35,10 @@
     What date will your holiday start?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This is the first day that you will take off work as leave</p>
 

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/different-number-of-days/2015-02-01.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/different-number-of-days/2015-02-01.html
@@ -35,8 +35,10 @@
     How many days will you have worked between 1 October (the start of the leave year) and the start of your holiday?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This includes any days that you worked basic hours, took annual leave or were off sick (whether paid or not).</p>
 

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days.html
@@ -35,7 +35,8 @@
     How many days do you work per week?
   </h2>
   <div class="question-body">
-    <p>Include guaranteed overtime hours if:</p>
+    <article role="article">
+      <p>Include guaranteed overtime hours if:</p>
 
 <ul>
   <li>you have to work them as part of your contract</li>
@@ -43,6 +44,7 @@
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days/7-days.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days/7-days.html
@@ -35,8 +35,10 @@
     Have you worked for the same employer for a full year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days/7-days/multiple-employers.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/same-number-of-days/7-days/multiple-employers.html
@@ -35,8 +35,10 @@
     How many weeks have you worked continuously for your current employer?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/y.html
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/y.html
@@ -35,8 +35,10 @@
     Do you work the same number of days each week?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01.html
@@ -35,8 +35,10 @@
     How old was your employee on the date they were made redundant?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21.html
@@ -35,8 +35,10 @@
     Number of years they’ve worked for you
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Only count full years of service. For example, 3 years and 9 months count as 3 years.</p>
 

--- a/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21/3.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/2012-01-01/21/3.html
@@ -35,8 +35,10 @@
     What is their weekly pay before tax and any other deductions?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Examples of other deductions include student loans and child maintenance.</p>
 

--- a/test/artefacts/calculate-employee-redundancy-pay/y.html
+++ b/test/artefacts/calculate-employee-redundancy-pay/y.html
@@ -35,8 +35,10 @@
     What date was your employee made redundant?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Use the original redundancy date even if their notice is brought forward, they’re paid in lieu of notice or made redundant after trialing a new job.</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/y.html
+++ b/test/artefacts/calculate-married-couples-allowance/y.html
@@ -35,8 +35,10 @@
     Were you or your partner born before 6 April 1935?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You must be married or in a civil partnership to qualify.</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes.html
@@ -35,8 +35,10 @@
     Did you marry before 5 December 2005?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Before this date the husband's income is used to work out your allowance, after this date it's the income of the highest earner.</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/yes/no.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/no.html
@@ -35,8 +35,10 @@
     What's the highest earner's date of birth?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">We need your date of birth to work out your personal allowance (how much of your income is tax-free).</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/yes/no/1955-01-01.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/no/1955-01-01.html
@@ -35,8 +35,10 @@
     What's the highest earner's yearly income?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Add up your taxable income, eg earnings, pensions and any taxable benefits, eg Carer's Allowance.</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes.html
@@ -35,8 +35,10 @@
     What's the husband's date of birth?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">We need your date of birth to work out your personal allowance (how much of your income is tax-free).</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01.html
@@ -35,8 +35,10 @@
     What's the husband's yearly income?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Add up your taxable income, eg earnings, pensions and any taxable benefits, eg Carer’s Allowance.</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes.html
@@ -35,7 +35,8 @@
     How much do you expect to pay into a pension where your contributions are made before tax is taken away?
   </h2>
   <div class="question-body">
-    <p>Enter the total you expect to pay for the whole tax year into:</p>
+    <article role="article">
+      <p>Enter the total you expect to pay for the whole tax year into:</p>
 
 <ul>
   <li>pension schemes where your contributions are paid before your income is taxed (called ‘net pay arrangements’)</li>
@@ -43,6 +44,7 @@
 </ul>
 
 
+    </article>
 
       <p class="hint">If none, please enter 0.</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.0/5000.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.0/5000.html
@@ -35,8 +35,10 @@
     How much do you expect to donate to charity through Gift Aid during the entire tax year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Only enter what you pay - don’t include any tax relief. If none, please enter 0.</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.0/yes/10000.html
@@ -35,8 +35,10 @@
     How much do you expect to pay into a pension this tax year where your pension provider claims tax relief for you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Only enter what you pay - don’t include the tax relief. If none, please enter 0.</p>
 

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.html
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/27001.html
@@ -35,8 +35,10 @@
     Are you paying into a pension?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes.html
@@ -35,8 +35,10 @@
     Does your employee routinely work different days of the week?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no.html
@@ -35,8 +35,10 @@
     During their most recent period of sickness, when did your employee first become sick?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This includes non-working days and bank holidays.</p>
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02.html
@@ -35,8 +35,10 @@
     Enter the last day of sickness
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This can include non-working days and bank holidays</p>
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10.html
@@ -35,9 +35,11 @@
     Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?
   </h2>
   <div class="question-body">
-    <p>These are called ‘linked Periods of Incapacity for Work (<abbr title="Period of Incapacity for Work">PIW</abbr>)’. Check if an employee’s <a href="/government/publications/statutory-sick-pay-tables-for-linking-periods-of-incapacity-for-work"><abbr title="Period of Incapacity for Work">PIW</abbr> links to a previous one.</a></p>
+    <article role="article">
+      <p>These are called ‘linked Periods of Incapacity for Work (<abbr title="Period of Incapacity for Work">PIW</abbr>)’. Check if an employee’s <a href="/government/publications/statutory-sick-pay-tables-for-linking-periods-of-incapacity-for-work"><abbr title="Period of Incapacity for Work">PIW</abbr> links to a previous one.</a></p>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes.html
@@ -35,8 +35,10 @@
     Enter the start date for this linked period of sickness.
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01.html
@@ -35,8 +35,10 @@
     Enter the end date for this linked period of sickness.
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15.html
@@ -35,8 +35,10 @@
     On  1 February 2013 had you paid your employee at least 8 weeks of earnings?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly.html
@@ -35,8 +35,10 @@
     Enter how much you would have paid the employee on their first payday if they hadn’t been sick.
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.html
@@ -35,8 +35,10 @@
     How many days does the period represented by these earnings cover?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If it’s 2 weeks and 3 days enter ‘17’.</p>
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less.html
@@ -35,8 +35,10 @@
     Enter the total earnings paid before  1 February 2013.
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.html
@@ -35,8 +35,10 @@
     How many days does the period represented by these earnings cover?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If it’s 2 weeks and 3 days enter ‘17’.</p>
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more.html
@@ -35,8 +35,10 @@
     How often do you pay the employee?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly.html
@@ -35,8 +35,10 @@
     What was the last normal payday before  1 February 2013?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31.html
@@ -35,8 +35,10 @@
     What was the last normal payday on or before  3 February 2013?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31.html
@@ -35,9 +35,11 @@
     Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between  1 February 2013 and 31 March 2013.
   </h2>
   <div class="question-body">
-    <p>Different rules apply for <a href="/statutory-sick-pay-how-different-employment-types-affect-what-you-pay">directors of limited companies incorporated before 1 October 2009</a></p>
+    <article role="article">
+      <p>Different rules apply for <a href="/statutory-sick-pay-how-different-employment-types-affect-what-you-pay">directors of limited companies incorporated before 1 October 2009</a></p>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/200.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/200.html
@@ -35,8 +35,10 @@
     Which days of the week do they usually work?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_paternity_pay,statutory_adoption_pay.html
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_paternity_pay,statutory_adoption_pay.html
@@ -35,8 +35,10 @@
     Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-statutory-sick-pay/y.html
+++ b/test/artefacts/calculate-statutory-sick-pay/y.html
@@ -35,8 +35,10 @@
     Is your employee getting any of the following?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If none apply just click ‘Next step’</p>
 

--- a/test/artefacts/calculate-your-child-maintenance/pay.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay.html
@@ -35,8 +35,10 @@
     How many children are you paying child maintenance for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Enter the total number of children - including children that you have family based arrangements for. They will be included in the calculation and you'll need to supply information about them when arranging Child Maintenance.</p>
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child.html
@@ -35,7 +35,8 @@
     Do you get any of these benefits?
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>Income Support</li>
   <li>income-based Jobseeker’s Allowance</li>
   <li>income-related Employment and Support Allowance</li>
@@ -58,6 +59,7 @@
 </ul>
 
 
+    </article>
 
       <p class="hint">In Scotland, this also includes: Skillseekers training, War Widow’s, Widower’s or Surviving Civil Partner’s Pension</p>
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no.html
@@ -35,8 +35,10 @@
     What is your weekly gross income?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This is income before tax and National Insurance but after pension contributions.</p>
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/no/150.html
@@ -35,8 +35,10 @@
     How many other children live in your household?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Enter 0 if no children live there. Don’t count the children child maintenance has to be paid for.</p>
 

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes.html
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/yes.html
@@ -35,8 +35,10 @@
     On average, how many nights a year do the children stay over with you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-child-maintenance/y.html
+++ b/test/artefacts/calculate-your-child-maintenance/y.html
@@ -35,8 +35,10 @@
     Will you be paying or receiving child maintenance payments?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-holiday-entitlement/annualised-hours.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/annualised-hours.html
@@ -35,8 +35,10 @@
     How many hours will be worked a year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This is calculated by excluding statutory entitlement. This calculation isn't suitable for term-time workers.</p>
 

--- a/test/artefacts/calculate-your-holiday-entitlement/casual-or-irregular-hours.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/casual-or-irregular-hours.html
@@ -35,8 +35,10 @@
     How many hours have been worked in this leave year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The holiday entitlement may be calculated as the leave builds up ('accrues') for each hour worked.</p>
 

--- a/test/artefacts/calculate-your-holiday-entitlement/compressed-hours.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/compressed-hours.html
@@ -35,8 +35,10 @@
     How many hours are worked per week?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-holiday-entitlement/compressed-hours/8.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/compressed-hours/8.html
@@ -35,8 +35,10 @@
     Number of days per week worked?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week.html
@@ -35,8 +35,10 @@
     Do you want to work out holiday:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/full-year.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/full-year.html
@@ -35,8 +35,10 @@
     Number of days worked per week?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you work half-days enter .5 for a half, eg 3.5 for three and a half days.</p>
 

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/leaving.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/leaving.html
@@ -35,8 +35,10 @@
     What was the employment end date?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/starting.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/starting.html
@@ -35,8 +35,10 @@
     What was the employment start date?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/starting/2012-01-01.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/days-worked-per-week/starting/2012-01-01.html
@@ -35,8 +35,10 @@
     When does the leave year start?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This is usually in the employment contract. If it isn’t and the job was started after 1 October 1998, the leave year will start on the 1st day of the job. If the job was started on or before 1 October 1998, the leave year will start on 1 October.</p>
 

--- a/test/artefacts/calculate-your-holiday-entitlement/hours-worked-per-week/full-year.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/hours-worked-per-week/full-year.html
@@ -35,8 +35,10 @@
     Number of hours worked per week?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you work half-hours enter .5 for a half, eg 40.5.</p>
 

--- a/test/artefacts/calculate-your-holiday-entitlement/shift-worker.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/shift-worker.html
@@ -35,8 +35,10 @@
     Do you want to calculate the holiday:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year.html
@@ -35,8 +35,10 @@
     How many hours in each shift?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year/8.0/3.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year/8.0/3.html
@@ -35,8 +35,10 @@
     How many days in the shift pattern?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The shift pattern includes non-working days.</p>
 

--- a/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year/8.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/shift-worker/full-year/8.html
@@ -35,8 +35,10 @@
     How many shifts will be worked per shift pattern?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-holiday-entitlement/y.html
+++ b/test/artefacts/calculate-your-holiday-entitlement/y.html
@@ -35,8 +35,10 @@
     Is the holiday entitlement based on:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Check the employment contract if you’re not sure about the holiday entitlement.</p>
 

--- a/test/artefacts/calculate-your-redundancy-pay/2012-01-01.html
+++ b/test/artefacts/calculate-your-redundancy-pay/2012-01-01.html
@@ -35,8 +35,10 @@
     How old were you on the date you were made redundant?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21.html
+++ b/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21.html
@@ -35,8 +35,10 @@
     How many years have you worked for your employer?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Only count full years of service. For example, 3 years and 9 months count as 3 years.</p>
 

--- a/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21/3.html
+++ b/test/artefacts/calculate-your-redundancy-pay/2012-01-01/21/3.html
@@ -35,8 +35,10 @@
     What is your weekly pay before tax and any other deductions?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Examples of other deductions include student loans and child maintenance.</p>
 

--- a/test/artefacts/calculate-your-redundancy-pay/y.html
+++ b/test/artefacts/calculate-your-redundancy-pay/y.html
@@ -35,8 +35,10 @@
     What date were you made redundant?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Use the original redundancy date even if your notice is brought forward, you’re paid in lieu of notice or made redundant after trialing a new job.</p>
 

--- a/test/artefacts/check-uk-visa/afghanistan.html
+++ b/test/artefacts/check-uk-visa/afghanistan.html
@@ -35,8 +35,10 @@
     What are you coming to the UK to do?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/check-uk-visa/afghanistan/transit.html
+++ b/test/artefacts/check-uk-visa/afghanistan/transit.html
@@ -35,8 +35,10 @@
     Will you pass through UK Border Control?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You might pass through UK Border Control even if you don't leave the airport - eg your bags aren't checked through and you need to collect them before transferring to your outbound flight.</p>
 

--- a/test/artefacts/check-uk-visa/afghanistan/work.html
+++ b/test/artefacts/check-uk-visa/afghanistan/work.html
@@ -35,8 +35,10 @@
     How long are you planning to work in the UK for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/check-uk-visa/israel.html
+++ b/test/artefacts/check-uk-visa/israel.html
@@ -35,8 +35,10 @@
     What sort of passport do you have?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/check-uk-visa/y.html
+++ b/test/artefacts/check-uk-visa/y.html
@@ -35,8 +35,10 @@
     What passport or travel document do you have?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you're a refugee or don't have a passport or travel document, select stateless or refugee.</p>
 

--- a/test/artefacts/childcare-costs-for-tax-credits/no.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no.html
@@ -35,8 +35,10 @@
     How often do you use childcare?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year.html
@@ -35,8 +35,10 @@
     How often do you pay your childcare provider(s)?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_diff_amount.html
@@ -35,8 +35,10 @@
     How much do you expect to pay in total for childcare for the next 12 months?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Add up the amounts you expect to pay in total for the next 12 months - start from the day you’re doing the calculation</p>
 

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_same_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/monthly_same_amount.html
@@ -35,8 +35,10 @@
     How much do you pay each month?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/weekly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/weekly_diff_amount.html
@@ -35,8 +35,10 @@
     How much do you expect to pay in total for childcare for the next 52 weeks?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Add up the amounts you expect to pay in total for the next 52 weeks - start from the day you’re doing the calculation</p>
 

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year.html
@@ -35,7 +35,8 @@
     Do you pay the same each time?
   </h2>
   <div class="question-body">
-    <p>Sometimes you may pay - or expect to pay - different amounts for childcare (known as ‘variable costs’), for example:</p>
+    <article role="article">
+      <p>Sometimes you may pay - or expect to pay - different amounts for childcare (known as ‘variable costs’), for example:</p>
 
 <ul>
   <li>you regularly use childcare, but pay more during school holidays than you do at term time</li>
@@ -43,6 +44,7 @@
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/no.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/no.html
@@ -35,8 +35,10 @@
     How much have you spent on childcare in the last 12 months?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Add up how much you have spent in total over the last 12 months - start backwards from the date you’re doing the calculation.</p>
 

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes.html
@@ -35,8 +35,10 @@
     How often do you pay your childcare provider(s)?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/every_4_weeks.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/every_4_weeks.html
@@ -35,8 +35,10 @@
     How much do you pay every 4 weeks?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/fortnightly.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/fortnightly.html
@@ -35,8 +35,10 @@
     How much do you pay each fortnight?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/yearly.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/yearly.html
@@ -35,8 +35,10 @@
     How much do you pay every year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/y.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/y.html
@@ -35,8 +35,10 @@
     Are you currently claiming tax credits for childcare costs?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/yes.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes.html
@@ -35,8 +35,10 @@
     Have the costs of your childcare changed since you last made your claim?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes.html
@@ -35,8 +35,10 @@
     How often do you pay your childcare provider(s)?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_diff_amount.html
@@ -35,8 +35,10 @@
     How much do you expect to pay in total for childcare for the next 12 months?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount.html
@@ -35,8 +35,10 @@
     What's the new monthly cost of your childcare?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount/43.3.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_same_amount/43.3.html
@@ -35,11 +35,13 @@
     What was the old average weekly amount you gave the Tax Credit Office?
   </h2>
   <div class="question-body">
-    <p>If you don’t know what your previous childcare costs were, check your award or renewal notice.</p>
+    <article role="article">
+      <p>If you don’t know what your previous childcare costs were, check your award or renewal notice.</p>
 
 <p>Round the total up to the nearest pound.</p>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount.html
@@ -35,8 +35,10 @@
     How much do you expect to pay in total for childcare for the next 52 weeks?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount/520.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_diff_amount/520.html
@@ -35,11 +35,13 @@
     What was the old average weekly amount you gave the Tax Credit Office?
   </h2>
   <div class="question-body">
-    <p>If you don’t know what your previous childcare costs were, check your award or renewal notice.</p>
+    <article role="article">
+      <p>If you don’t know what your previous childcare costs were, check your award or renewal notice.</p>
 
 <p>Round the total up to the nearest pound.</p>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount.html
@@ -35,8 +35,10 @@
     What are your new weekly costs?
   </h2>
   <div class="question-body">
-    <p>Round the total up to the nearest pound.</p>
+    <article role="article">
+      <p>Round the total up to the nearest pound.</p>
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount/10.html
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/weekly_same_amount/10.html
@@ -35,11 +35,13 @@
     What was the old average weekly amount you gave the Tax Credit Office?
   </h2>
   <div class="question-body">
-    <p>If you don’t know what your previous childcare costs were, check your award or renewal notice.</p>
+    <article role="article">
+      <p>If you don’t know what your previous childcare costs were, check your award or renewal notice.</p>
 
 <p>Round the total up to the nearest pound.</p>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency.html
@@ -35,9 +35,11 @@
     What are your circumstances?
   </h2>
   <div class="question-body">
-    <p>Social housing tenants should talk to their social housing provider if they want to improve their energy efficiency.</p>
+    <article role="article">
+      <p>Social housing tenants should talk to their social housing provider if they want to improve their energy efficiency.</p>
 
 
+    </article>
 
       <p class="hint">Choose all that apply to you. If none apply just click ‘Next step’.</p>
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none.html
@@ -35,8 +35,10 @@
     When was your property built?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house.html
@@ -35,8 +35,10 @@
     Which  of these do you have:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house.html
@@ -35,8 +35,10 @@
     Which  of these do you have:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995.html
@@ -35,8 +35,10 @@
     What kind of property do you live in?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat.html
@@ -35,8 +35,10 @@
     Is it a top-floor or a ground-floor flat?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house.html
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house.html
@@ -35,8 +35,10 @@
     Which  of these do you have:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill.html
@@ -35,8 +35,10 @@
     What are your circumstances?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Choose all that apply to you. If none apply just click ‘Next step’.</p>
 

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01.html
@@ -35,8 +35,10 @@
     Which of these benefits do you get?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Choose all that apply to you. If none apply just click ‘Next step’.</p>
 

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01/pension_credit,income_support,jsa,esa,child_tax_credit,working_tax_credit.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill/benefits,property/1950-01-01/pension_credit,income_support,jsa,esa,child_tax_credit,working_tax_credit.html
@@ -35,8 +35,10 @@
     Are you elderly, disabled, or do you have children?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Choose all that apply to you. If none apply just click ‘Next step’.</p>
 

--- a/test/artefacts/energy-grants-calculator/help_with_fuel_bill/none.html
+++ b/test/artefacts/energy-grants-calculator/help_with_fuel_bill/none.html
@@ -35,8 +35,10 @@
     What’s your date of birth?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/energy-grants-calculator/y.html
+++ b/test/artefacts/energy-grants-calculator/y.html
@@ -35,8 +35,10 @@
     Are you looking for:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/estimate-self-assessment-penalties/2011-12.html
+++ b/test/artefacts/estimate-self-assessment-penalties/2011-12.html
@@ -35,8 +35,10 @@
     How did you send your Self Assessment tax return?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/estimate-self-assessment-penalties/2011-12/online.html
+++ b/test/artefacts/estimate-self-assessment-penalties/2011-12/online.html
@@ -35,8 +35,10 @@
     When did you send your Self Assessment tax return?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you sent it online, enter the date you submitted the return. If you sent it on paper, add 2 days to the date you posted it. If you haven’t sent it yet, enter the date you expect to send it.</p>
 

--- a/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07.html
+++ b/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07.html
@@ -35,8 +35,10 @@
     When did you pay the bill?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you haven’t paid yet, enter the date you expect HM Revenue &amp; Customs to get your payment</p>
 

--- a/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07/2013-03-02.html
+++ b/test/artefacts/estimate-self-assessment-penalties/2011-12/online/2012-04-07/2013-03-02.html
@@ -35,8 +35,10 @@
     Please enter how much your tax bill is (or an estimate if you don’t know)
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This calculator is anonymous. None of your details will be passed to HMRC.</p>
 

--- a/test/artefacts/estimate-self-assessment-penalties/y.html
+++ b/test/artefacts/estimate-self-assessment-penalties/y.html
@@ -35,8 +35,10 @@
     For which tax year do you want the estimate?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/help-if-you-are-arrested-abroad/y.html
+++ b/test/artefacts/help-if-you-are-arrested-abroad/y.html
@@ -35,8 +35,10 @@
     Which country?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales.html
@@ -35,8 +35,10 @@
     Is there a living husband, wife or civil partner?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">A surviving partner who wasn't married or in a civil partnership with the deceased has no automatic right to inherit.</p>
 

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no.html
@@ -35,8 +35,10 @@
     Are there any living parents?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no.html
@@ -35,8 +35,10 @@
     Did the deceased have any brothers or sisters?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no.html
@@ -35,8 +35,10 @@
     Did the deceased have any half-brothers or half-sisters?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no.html
@@ -35,8 +35,10 @@
     Are there any living grandparents?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no/no.html
@@ -35,8 +35,10 @@
     Did the deceased have any aunts or uncles?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/no/no/no/no/no/no/no.html
@@ -35,8 +35,10 @@
     Did the deceased have any half-aunts or half-uncles?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes.html
@@ -35,8 +35,10 @@
     Is the estate likely to be worth more than £250,000?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes/yes.html
+++ b/test/artefacts/inherits-someone-dies-without-will/england-and-wales/yes/yes.html
@@ -35,8 +35,10 @@
     Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Children include legally-adopted sons or daughters (but not stepchildren) and any children where the deceased had a parental role.</p>
 

--- a/test/artefacts/inherits-someone-dies-without-will/northern-ireland/yes/yes/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/northern-ireland/yes/yes/no/no.html
@@ -35,8 +35,10 @@
     Did the deceased have any brothers or sisters?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/northern-ireland/yes/yes/yes.html
+++ b/test/artefacts/inherits-someone-dies-without-will/northern-ireland/yes/yes/yes.html
@@ -35,8 +35,10 @@
     Did they have more than one child?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/inherits-someone-dies-without-will/scotland/no/no/no/no/no/no.html
+++ b/test/artefacts/inherits-someone-dies-without-will/scotland/no/no/no/no/no/no.html
@@ -35,8 +35,10 @@
     Are there any living great aunts or great uncles?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Great aunts and great uncles are brothers or sisters of the grandparents of the deceased.</p>
 

--- a/test/artefacts/inherits-someone-dies-without-will/y.html
+++ b/test/artefacts/inherits-someone-dies-without-will/y.html
@@ -35,8 +35,10 @@
     Where did the deceased live?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW.html
@@ -35,7 +35,8 @@
     Is the person renting the property as their main home?
   </h2>
   <div class="question-body">
-    <p>This includes:</p>
+    <article role="article">
+      <p>This includes:</p>
 
 <ul>
   <li>tenancy agreement</li>
@@ -46,6 +47,7 @@
   <li>house guests or family members who pay rent</li>
 </ul>
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/no.html
@@ -35,8 +35,10 @@
     What kind of property are you letting?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes.html
@@ -35,8 +35,10 @@
     Is the person at least 18 years of age?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes.html
@@ -35,8 +35,10 @@
     Does the person have a current or expired UK or Republic of Ireland passport or are they a named person in their parent’s UK or Republic of Ireland passport?
   </h2>
   <div class="question-body">
-    <p>A named person is someone who appears on someone else’s passport.</p>
+    <article role="article">
+      <p>A named person is someone who appears on someone else’s passport.</p>
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no.html
@@ -35,8 +35,10 @@
     Does the person have a certificate of right of abode in their passport?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no.html
@@ -35,8 +35,10 @@
     Does the person have a Certificate of Registration or Naturalisation as a British citizen?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no.html
@@ -35,8 +35,10 @@
     Is the person:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland.html
@@ -35,7 +35,8 @@
     Does the person have any of the following:
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>a Registration Certificate or Document Certifying Permanent Residence issued by the Home Office to a national of the EU, EEA or Switzerland</li>
   <li>a valid Biometric Residence Permit issued by the Home Office endorsed to show they’re allowed to stay indefinitely in the UK</li>
   <li>a Permanent Residence Card, indefinite leave to remain, indefinite leave to enter or no time limit card issued by the Home Office</li>
@@ -44,6 +45,7 @@
   <li>other documents exempting the person from immigration control (eg diplomatic passports, NATO ID card)</li>
 </ul>
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no.html
@@ -35,7 +35,8 @@
     Does the person have 2 of the following:
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>a full birth or adoption certificate (that shows details of at least one of the birth or adoptive parents) from the UK, the Channel Islands, the Isle of Man or Ireland</li>
   <li>a letter from a UK police force issued within the last 3 months confirming the person is a victim of crime and their documents have been stolen</li>
   <li>evidence that the person is currently serving in the UK armed forces or has previously served</li>
@@ -52,6 +53,7 @@
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no.html
@@ -35,12 +35,14 @@
     Does the person have any of the following:
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>a passport endorsed to show that the person can stay in the UK temporarily</li>
   <li>a current Biometric Residence Permit issued by the Home Office to the person showing that they can currently stay in the UK temporarily</li>
   <li>an Immigration Status Document issued by the Home Office with an endorsement showing the person can currently stay in the UK temporarily</li>
 </ul>
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no.html
@@ -35,8 +35,10 @@
     Does the person have a current Residence Card that is issued by the Home Office to a non-EEA national who is the family member of an EU, EEA or Swiss national?
   </h2>
   <div class="question-body">
-    <p>This includes a current Accession Card or Derivative Card.</p>
+    <article role="article">
+      <p>This includes a current Accession Card or Derivative Card.</p>
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no.html
@@ -35,8 +35,10 @@
     Does the person have an application for a Registration Card issued by the Home Office showing that they can stay in the UK?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no/no.html
+++ b/test/artefacts/landlord-immigration-check/B1 1PW/yes/yes/no/no/no/eu_eea_switzerland/no/no/no/no/no.html
@@ -35,8 +35,10 @@
     Does the person have an outstanding immigration case, immigration appeal or administrative review?
   </h2>
   <div class="question-body">
-    <p>They must also provide their Home Office reference number.</p>
+    <article role="article">
+      <p>They must also provide their Home Office reference number.</p>
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/landlord-immigration-check/y.html
+++ b/test/artefacts/landlord-immigration-check/y.html
@@ -35,8 +35,10 @@
     Enter the postcode of the property you want to let:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/legalisation-document-checker/y.html
+++ b/test/artefacts/legalisation-document-checker/y.html
@@ -35,8 +35,10 @@
     Which documents do you want legalised?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/marriage-abroad/albania.html
+++ b/test/artefacts/marriage-abroad/albania.html
@@ -35,8 +35,10 @@
     Where do you live?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/marriage-abroad/albania/uk.html
+++ b/test/artefacts/marriage-abroad/albania/uk.html
@@ -35,8 +35,10 @@
     What is your partner’s nationality?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/marriage-abroad/albania/uk/partner_british.html
+++ b/test/artefacts/marriage-abroad/albania/uk/partner_british.html
@@ -35,8 +35,10 @@
     Is your partner of the opposite sex, or the same sex?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/marriage-abroad/france.html
+++ b/test/artefacts/marriage-abroad/france.html
@@ -35,8 +35,10 @@
     Do you want to get married or enter into a PACS?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">PACS (‘pacte civil de solidarité’, or ‘civil solidarity pact’) is the French version of civil partnership, and can be entered into by same-sex or opposite-sex couples.</p>
 

--- a/test/artefacts/marriage-abroad/y.html
+++ b/test/artefacts/marriage-abroad/y.html
@@ -35,8 +35,10 @@
     Where do you want to get married?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/adoption.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption.html
@@ -35,8 +35,10 @@
     Is the employee taking paternity leave to adopt a child?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/adoption/no.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no.html
@@ -35,8 +35,10 @@
     When was the child matched with the employee?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">For overseas adoptions, enter the official notification date (the permission to adopt from abroad).</p>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05.html
@@ -35,8 +35,10 @@
     When will the child be placed with the employee?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">For overseas adoptions enter the date of arrival in the UK.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06.html
@@ -35,8 +35,10 @@
     Did the employee work for you on or before 18 October 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes.html
@@ -35,8 +35,10 @@
     Does the employee have an employment contract with you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes.html
@@ -35,8 +35,10 @@
     Was the employee (or will they be) on your payroll on 21 December 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes.html
@@ -35,8 +35,10 @@
     When does the employee want to start their leave?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Leave can’t start before 23 March 2015. For overseas adoptions your leave must start within 28 days of the child arriving in the UK.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06.html
@@ -35,8 +35,10 @@
     What was the last normal payday on or before Saturday, 11 April 2015?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01.html
@@ -35,8 +35,10 @@
     What was the last normal payday before Friday, 07 November 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01.html
@@ -35,8 +35,10 @@
     How often do you pay the employee?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If they’re paid irregularly choose ‘weekly’.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly.html
@@ -35,8 +35,10 @@
     What were the employee’s total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This is their earnings before deductions like PAYE, pension or National Insurance contributions.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly/3000.html
+++ b/test/artefacts/maternity-paternity-calculator/adoption/no/2015-04-05/2015-04-06/yes/yes/yes/2015-04-06/2015-01-01/2014-11-01/weekly/3000.html
@@ -35,8 +35,10 @@
     How do you want the adoption pay calculated?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity.html
@@ -35,8 +35,10 @@
     What is the baby’s due date?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01.html
@@ -35,8 +35,10 @@
     Does the employee have an employment contract with you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes.html
@@ -35,8 +35,10 @@
     When does the employee want to start their leave?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Based on the baby's due date, leave usually can’t start before 12 October 2014.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01.html
@@ -35,8 +35,10 @@
     Did the employee work for you on or before 29 March 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes.html
@@ -35,8 +35,10 @@
     Was the employee (or will they be) on your payroll on 14 September 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes.html
@@ -35,8 +35,10 @@
     What was the last normal payday on or before Saturday, 20 September 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19.html
@@ -35,8 +35,10 @@
     What was the last normal payday before Saturday, 26 July 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24.html
@@ -35,8 +35,10 @@
     How often do you pay the employee?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If they’re paid irregularly choose ‘weekly’.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates.html
@@ -35,8 +35,10 @@
     When in the month is the employee paid?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If the pay date is the 29th, 30th or 31st choose 'Last working day of the month'.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month.html
@@ -35,8 +35,10 @@
     What particular day of the month is the employee paid?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday.html
@@ -35,8 +35,10 @@
     Is the employee paid on the 1st, 2nd, 3rd, 4th or last Sunday?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month.html
@@ -35,8 +35,10 @@
     What days does the employee work?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/specific_date_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/monthly/100.0/usual_paydates/specific_date_each_month.html
@@ -35,8 +35,10 @@
     What specific date each month is the employee paid?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If they’re paid on the 25th enter "25". The calculator will treat an employee as paid on the last day of the month if you enter 29, 30 or 31.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly.html
@@ -35,8 +35,10 @@
     What were the employee’s total earnings between Friday, 25 July 2014 and Friday, 19 September 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This is their earnings before deductions like PAYE, pension or National Insurance contributions.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.0/usual_paydates.html
@@ -35,8 +35,10 @@
     When is your employee’s next pay day on or after  1 January 2015?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.html
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2015-01-01/yes/2015-01-01/yes/yes/2014-09-19/2014-07-24/weekly/100.html
@@ -35,8 +35,10 @@
     How do you want the SMP calculated?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity.html
@@ -35,8 +35,10 @@
     Is the paternity leave or pay for an adoption?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/no.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/no.html
@@ -35,8 +35,10 @@
     What is the baby’s due date?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/no/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/no/2015-01-01.html
@@ -35,8 +35,10 @@
     What is the actual birth date?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If unknown enter the due date.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/no/2015-01-01/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/no/2015-01-01/2015-01-01.html
@@ -35,8 +35,10 @@
     Is the employee responsible for the child’s upbringing and either the biological father or the mother’s husband or partner?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes.html
@@ -35,8 +35,10 @@
     When was the child matched with the employee?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01.html
@@ -35,8 +35,10 @@
     When will the child be placed with the employee?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01.html
@@ -35,8 +35,10 @@
     Is the employee responsible for the child's upbringing and the husband or partner of the adopter or the child's adopter?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes.html
@@ -35,8 +35,10 @@
     Did the employee work for you on or before 12 July 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes.html
@@ -35,8 +35,10 @@
     Does the employee have an employment contract with you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes.html
@@ -35,8 +35,10 @@
     Was the employee (or will they be) on your payroll on 14 September 2014?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes.html
@@ -35,8 +35,10 @@
     Will the employee still be employed by you on  1 January 2015?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes.html
@@ -35,8 +35,10 @@
     When does the employee want to start their paternity leave?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Leave cannot start before Thursday, 01 January 2015.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01.html
@@ -35,8 +35,10 @@
     How long is the employee's paternity leave?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week.html
@@ -35,8 +35,10 @@
     What was the last normal payday on or before Saturday, 03 January 2015
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01.html
@@ -35,8 +35,10 @@
     What was the last normal payday before Friday, 07 November 2014
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01.html
@@ -35,8 +35,10 @@
     How often do you pay the employee?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If they are paid irregularly choose 'weekly'.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates.html
@@ -35,8 +35,10 @@
     When in the month is the employee paid?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If the pay date is the 29th, 30th or 31st choose 'Last working day of the month'.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month.html
@@ -35,8 +35,10 @@
     What particular day of the month is the employee paid?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0.html
@@ -35,8 +35,10 @@
     Is the employee paid on the 1st, 2nd, 3rd, 4th or last Sunday?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month.html
@@ -35,8 +35,10 @@
     What days does the employee work?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/specific_date_each_month.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/monthly/3000.0/usual_paydates/specific_date_each_month.html
@@ -35,8 +35,10 @@
     What specific date each month is the employee paid?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If they are paid on the 25th enter '25'. The calculator will treat an employee as paid on the last day of the month if you enter '29', '30' or '31'.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly.html
@@ -35,8 +35,10 @@
     What were the employee's total earnings between Sunday, 02 November 2014 and Thursday, 01 January 2015?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This is the earnings before deductions like PAYE, pendion or National Insurance contributions.</p>
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.0/usual_paydates.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.0/usual_paydates.html
@@ -35,8 +35,10 @@
     When is your employee's next pay day on or after  1 January 2015
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.html
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2015-01-01/2015-01-01/yes/yes/yes/yes/yes/2015-01-01/one_week/2015-01-01/2014-11-01/weekly/3000.html
@@ -35,8 +35,10 @@
     How do you want the paternity pay calculated?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/maternity-paternity-calculator/y.html
+++ b/test/artefacts/maternity-paternity-calculator/y.html
@@ -35,8 +35,10 @@
     What do you want to check?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment.html
@@ -35,8 +35,10 @@
     Is the worker an apprentice?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If they’re 19 or over and past their first year they don’t count as an apprentice for minimum wage purposes.</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice.html
@@ -35,8 +35,10 @@
     How old is the worker?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25.html
@@ -35,9 +35,11 @@
     How often do you pay the worker?
   </h2>
   <div class="question-body">
-    <p>This is the pay period.</p>
+    <article role="article">
+      <p>This is the pay period.</p>
 
 
+    </article>
 
       <p class="hint">You pay the worker every</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1.html
@@ -35,8 +35,10 @@
     How many hours does the worker work during the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Don’t include any overtime or other extra hours the worker might work.</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_charged.html
@@ -35,8 +35,10 @@
     How much do you charge for accommodation per day?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.0/yes_free.html
@@ -35,8 +35,10 @@
     How many days per week does the worker live in the accommodation?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/0.html
@@ -35,8 +35,10 @@
     Do you provide accommodation?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.0/8.html
@@ -35,8 +35,10 @@
     How much do you pay the worker for overtime per hour?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.0/100.html
@@ -35,8 +35,10 @@
     How many hours of overtime does the worker work during the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If they don’t work overtime enter 0</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.html
+++ b/test/artefacts/minimum-wage-calculator-employers/current_payment/not_an_apprentice/25/1/16.html
@@ -35,8 +35,10 @@
     How much do you pay the worker in the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Don’t include payments for overtime or anything extra to their pay, eg money for clothes or goods.</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment.html
@@ -35,8 +35,10 @@
     Which year would you like to check past payments for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You can go back up to 6 years</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01.html
@@ -35,8 +35,10 @@
     Was the worker an apprentice at the time?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no.html
@@ -35,8 +35,10 @@
     How old was the worker at the time?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25.html
@@ -35,9 +35,11 @@
     How often did you pay the worker?
   </h2>
   <div class="question-body">
-    <p>This is the pay period.</p>
+    <article role="article">
+      <p>This is the pay period.</p>
 
 
+    </article>
 
       <p class="hint">You pay the worker every</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1.html
@@ -35,8 +35,10 @@
     How many hours did the worker work during the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Don’t include any overtime or other extra hours the worker worked.</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.0/0.0/yes_charged.html
@@ -35,8 +35,10 @@
     How much did you charge for accommodation per day?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.0/0.0/yes_free.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.0/0.0/yes_free.html
@@ -35,8 +35,10 @@
     How many days per week did the worker live in the accommodation?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.0/0.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.0/0.html
@@ -35,8 +35,10 @@
     Did you provide accommodation?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.0/8.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.0/8.html
@@ -35,8 +35,10 @@
     How much did you pay the worker for overtime per hour?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.0/100.html
@@ -35,8 +35,10 @@
     How many hours of overtime did the worker work during the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If they didn’t work overtime enter 0</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.html
+++ b/test/artefacts/minimum-wage-calculator-employers/past_payment/2014-10-01/no/25/1/16.html
@@ -35,8 +35,10 @@
     How much did you pay the worker in the pay period?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Don’t include payments for overtime or anything extra to their pay, eg money for clothes or goods.</p>
 

--- a/test/artefacts/minimum-wage-calculator-employers/y.html
+++ b/test/artefacts/minimum-wage-calculator-employers/y.html
@@ -35,8 +35,10 @@
     What would you like to check?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/overseas-passports/france.html
+++ b/test/artefacts/overseas-passports/france.html
@@ -35,8 +35,10 @@
     Are you renewing, replacing or applying for a first passport?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/overseas-passports/france/renewing_new.html
+++ b/test/artefacts/overseas-passports/france/renewing_new.html
@@ -35,8 +35,10 @@
     Do you need an adult or child passport?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/overseas-passports/france/renewing_old/adult.html
+++ b/test/artefacts/overseas-passports/france/renewing_old/adult.html
@@ -35,8 +35,10 @@
     Which country were you born in?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories.html
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories.html
@@ -35,8 +35,10 @@
     Where are you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/overseas-passports/y.html
+++ b/test/artefacts/overseas-passports/y.html
@@ -35,8 +35,10 @@
     Which country or territory are you in?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/y.html
+++ b/test/artefacts/pay-leave-for-parents/y.html
@@ -35,8 +35,10 @@
     Will you care for the child with a partner?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes.html
@@ -35,8 +35,10 @@
     When is the baby due?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01.html
@@ -35,8 +35,10 @@
     What’s the employment status of the mother?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee.html
@@ -35,8 +35,10 @@
     What’s the employment status of the mother’s partner?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee.html
@@ -35,8 +35,10 @@
     Did the mother start her current or most recent job before 30 April 2011?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes.html
@@ -35,8 +35,10 @@
     Was the mother (or will she be) still working in that job on 16 October 2011?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes.html
@@ -35,8 +35,10 @@
     How much does the mother earn (or did she earn, if she’s left her job)?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000-year.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000-year.html
@@ -35,8 +35,10 @@
     Has the mother earned (or will she have earned) more than £112 per week between 27 August 2011 and 22 October 2011?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no.html
@@ -35,8 +35,10 @@
     Did the mother work (or will she have worked) for at least 26 weeks between 24 October 2010 and 28 January 2012?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes.html
@@ -35,8 +35,10 @@
     Did the mother earn (or will she have earned) a total of £390 or more in any 13 weeks between 24 October 2010 and 28 January 2012?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes.html
@@ -35,8 +35,10 @@
     How much did the mother earn between 24 October 2010 and 28 January 2012?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes.html
@@ -35,8 +35,10 @@
     Did the mother’s partner start their current or most recent job before 30 April 2011?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes.html
@@ -35,8 +35,10 @@
     Was the mother’s partner (or will they be) still working in that job on 16 October 2011?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes.html
@@ -35,8 +35,10 @@
     How much does the mother’s partner earn (or did they earn, if they’ve left their job)?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000-year.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000-year.html
@@ -35,8 +35,10 @@
     Has the mother’s partner earned (or will they have earned) more than £112 per week between 27 August 2011 and 22 October 2011?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.html
@@ -35,8 +35,10 @@
     Did the mother’s partner work (or will they have worked) for at least 26 weeks between 29 December 2013 and  4 April 2015?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes.html
+++ b/test/artefacts/pay-leave-for-parents/yes/2015-04-05/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes.html
@@ -35,8 +35,10 @@
     Did the mother’s partner earn (or will they have earned) a total of £390 or more in any 13 weeks between 29 December 2013 and  4 April 2015?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pip-checker/y.html
+++ b/test/artefacts/pip-checker/y.html
@@ -35,8 +35,10 @@
     Are you getting Disability Living Allowance?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/pip-checker/yes.html
+++ b/test/artefacts/pip-checker/yes.html
@@ -35,8 +35,10 @@
     What's your date of birth?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you’re checking for someone else, enter their date of birth.</p>
 

--- a/test/artefacts/plan-adoption-leave/2015-01-01.html
+++ b/test/artefacts/plan-adoption-leave/2015-01-01.html
@@ -35,8 +35,10 @@
     When will the child start to live with you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This is sometimes known as the 'date of placement'.</p>
 

--- a/test/artefacts/plan-adoption-leave/2015-01-01/2015-02-08.html
+++ b/test/artefacts/plan-adoption-leave/2015-01-01/2015-02-08.html
@@ -35,8 +35,10 @@
     When do you want to start your adoption leave?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Leave can start up to 14 days before the child comes to live with you.</p>
 

--- a/test/artefacts/plan-adoption-leave/y.html
+++ b/test/artefacts/plan-adoption-leave/y.html
@@ -35,8 +35,10 @@
     When were you matched with the child?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-birth/afghanistan.html
+++ b/test/artefacts/register-a-birth/afghanistan.html
@@ -35,9 +35,11 @@
     Who has British nationality?
   </h2>
   <div class="question-body">
-    <p>If the British parent was born abroad, they may be a British citizen ‘by descent’. This means they may not be allowed to pass on their British nationality to a child also born abroad. <a href="/check-british-citizen">Check if the parent is a British citizen by descent</a>.</p>
+    <article role="article">
+      <p>If the British parent was born abroad, they may be a British citizen ‘by descent’. This means they may not be allowed to pass on their British nationality to a child also born abroad. <a href="/check-british-citizen">Check if the parent is a British citizen by descent</a>.</p>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-birth/afghanistan/father/no.html
+++ b/test/artefacts/register-a-birth/afghanistan/father/no.html
@@ -35,8 +35,10 @@
     What is your child’s date of birth?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-birth/afghanistan/mother.html
+++ b/test/artefacts/register-a-birth/afghanistan/mother.html
@@ -35,8 +35,10 @@
     Were you married to the other parent when your child was born?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes.html
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes.html
@@ -35,8 +35,10 @@
     Where are you now?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country.html
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country.html
@@ -35,8 +35,10 @@
     Which country?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-birth/y.html
+++ b/test/artefacts/register-a-birth/y.html
@@ -35,8 +35,10 @@
     Which country was the child born in?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-death/england_wales.html
+++ b/test/artefacts/register-a-death/england_wales.html
@@ -35,8 +35,10 @@
     Did the person die at home, in hospital or elsewhere?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-death/england_wales/at_home_hospital.html
+++ b/test/artefacts/register-a-death/england_wales/at_home_hospital.html
@@ -35,8 +35,10 @@
     Was the death expected?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-death/overseas.html
+++ b/test/artefacts/register-a-death/overseas.html
@@ -35,8 +35,10 @@
     Which country did the death happen in?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-death/overseas/libya.html
+++ b/test/artefacts/register-a-death/overseas/libya.html
@@ -35,8 +35,10 @@
     Where are you now?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-death/overseas/libya/another_country.html
+++ b/test/artefacts/register-a-death/overseas/libya/another_country.html
@@ -35,8 +35,10 @@
     Which country are you in now?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/register-a-death/y.html
+++ b/test/artefacts/register-a-death/y.html
@@ -35,8 +35,10 @@
     Where did the death happen?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/report-a-lost-or-stolen-passport/abroad.html
+++ b/test/artefacts/report-a-lost-or-stolen-passport/abroad.html
@@ -35,8 +35,10 @@
     In which country?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/report-a-lost-or-stolen-passport/y.html
+++ b/test/artefacts/report-a-lost-or-stolen-passport/y.html
@@ -35,8 +35,10 @@
     Where was the passport lost or stolen?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/simplified-expenses-checker/y.html
+++ b/test/artefacts/simplified-expenses-checker/y.html
@@ -35,8 +35,10 @@
     Have you claimed expenses for your current business before?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you’re a new business you won’t have claimed expenses before.</p>
 

--- a/test/artefacts/simplified-expenses-checker/yes.html
+++ b/test/artefacts/simplified-expenses-checker/yes.html
@@ -35,8 +35,10 @@
     Do you have any of these expenses as part of your business?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">If you don't have any of these expenses go to 'Next step'.</p>
 

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000.html
@@ -35,8 +35,10 @@
     On average, how many hours a month do you work or expect to work from home?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You have to work at least 25 hours per month from home to use simplified home expenses.</p>
 

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000/26.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van,using_home_for_business/yes/yes/35000.0/35.0/10000/26.html
@@ -35,8 +35,10 @@
     How much of your home costs do you expect to claim as business expenses this tax year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The business proportion of utility bills, eg gas and electricity. Don't include phone and internet bills.</p>
 

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van.html
@@ -35,8 +35,10 @@
     Are you buying a new car, van or motorcycle this tax year that you expect to use for your business?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/no.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/no.html
@@ -35,8 +35,10 @@
     Have you claimed Capital Allowances for your existing car, van or motorcycle before?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/no/no.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/no/no.html
@@ -35,8 +35,10 @@
     How much do you expect to claim as business expenses for running and maintaining your car, van or motorcycle over the tax year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Only include the business proportion of costs for your main vehicle, eg fuel, servicing, repairs and insurance.</p>
 

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes.html
@@ -35,8 +35,10 @@
     Is the vehicle you're buying green, ie a low emission vehicle?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes.html
@@ -35,8 +35,10 @@
     How much is the car, van or motorcycle you’re buying?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Include VAT unless your business is VAT registered.</p>
 

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes/35000.0/35.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes/35000.0/35.html
@@ -35,8 +35,10 @@
     How many miles do you expect to drive your car or van for business during the tax year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes/35000.html
+++ b/test/artefacts/simplified-expenses-checker/yes/car_or_van/yes/yes/35000.html
@@ -35,8 +35,10 @@
     How much of your driving time do you expect to be for business use?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500.html
+++ b/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500.html
@@ -35,8 +35,10 @@
     How much do you expect to deduct from your business expenses this tax year for your private use of the premises?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">For example, a proportion of your maintenance, utility and insurance bills.</p>
 

--- a/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500/789.html
+++ b/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.0/7500/789.html
@@ -35,8 +35,10 @@
     How many people normally live on the business premises?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Include children and non-paying guests. Don't include paying guests or anyone using the premises as part of your business. Give an average if there are more people at certain times of the year.</p>
 

--- a/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.html
+++ b/test/artefacts/simplified-expenses-checker/yes/live_on_business_premises,motorcycle/yes/yes/35000.0/35.html
@@ -35,8 +35,10 @@
     How many miles do you expect to drive your motorcycle for business during the tax year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/state-pension-age/age.html
+++ b/test/artefacts/state-pension-age/age.html
@@ -35,8 +35,10 @@
     What is your date of birth?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/state-pension-age/age/1949-02-01.html
+++ b/test/artefacts/state-pension-age/age/1949-02-01.html
@@ -35,8 +35,10 @@
     Are you a man or a woman?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/state-pension-age/y.html
+++ b/test/artefacts/state-pension-age/y.html
@@ -35,8 +35,10 @@
     What would you like to calculate?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/state-pension-through-partner/married.html
+++ b/test/artefacts/state-pension-through-partner/married.html
@@ -35,8 +35,10 @@
     When will you reach State Pension age?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/state-pension-through-partner/married/your_pension_age_after_specific_date/partner_pension_age_before_specific_date.html
+++ b/test/artefacts/state-pension-through-partner/married/your_pension_age_after_specific_date/partner_pension_age_before_specific_date.html
@@ -35,8 +35,10 @@
     Are you:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/state-pension-through-partner/married/your_pension_age_before_specific_date.html
+++ b/test/artefacts/state-pension-through-partner/married/your_pension_age_before_specific_date.html
@@ -35,8 +35,10 @@
     When will your spouse or civil partner reach State Pension age?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/state-pension-through-partner/y.html
+++ b/test/artefacts/state-pension-through-partner/y.html
@@ -35,8 +35,10 @@
     What is your marital status?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/state-pension-topup/1912-10-12.html
+++ b/test/artefacts/state-pension-topup/1912-10-12.html
@@ -35,8 +35,10 @@
     What is your gender?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/state-pension-topup/1912-10-12/male.html
+++ b/test/artefacts/state-pension-topup/1912-10-12/male.html
@@ -35,8 +35,10 @@
     How much extra State Pension would you like to get per week?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">Enter a number between 1 and 25.</p>
 

--- a/test/artefacts/state-pension-topup/y.html
+++ b/test/artefacts/state-pension-topup/y.html
@@ -35,8 +35,10 @@
     What is your date of birth?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-calculator/2015-2016.html
+++ b/test/artefacts/student-finance-calculator/2015-2016.html
@@ -35,8 +35,10 @@
     What type of student are you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-full-time.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-full-time.html
@@ -35,8 +35,10 @@
     How much are your tuition fees per year?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">The maximum is £9,000 for full-time students and £6,750 for part-time students.</p>
 

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home.html
@@ -35,8 +35,10 @@
     What's your annual household income?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">This is your parents’ or partner’s gross (pre-tax) income plus your own. It affects how much help you'll get with living costs.</p>
 

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income.html
@@ -35,8 +35,10 @@
     Are you studying one of these courses?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home/100000.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.0/at-home/100000.html
@@ -35,8 +35,10 @@
     Do any of the following apply? (you might get extra funding.)
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-full-time/6000.html
@@ -35,8 +35,10 @@
     Where will you live while studying?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-calculator/2015-2016/uk-part-time/6000.html
+++ b/test/artefacts/student-finance-calculator/2015-2016/uk-part-time/6000.html
@@ -35,8 +35,10 @@
     Do any of the following apply (you might get extra funding)?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-calculator/y.html
+++ b/test/artefacts/student-finance-calculator/y.html
@@ -35,8 +35,10 @@
     When does your course start?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-forms/uk-full-time.html
+++ b/test/artefacts/student-finance-forms/uk-full-time.html
@@ -35,8 +35,10 @@
     What do you need the form for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants.html
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants.html
@@ -35,8 +35,10 @@
     What academic year do you want funding for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516.html
+++ b/test/artefacts/student-finance-forms/uk-full-time/apply-loans-grants/year-1516.html
@@ -35,8 +35,10 @@
     Are you a continuing student?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You’re usually a continuing student if you got student finance last year.</p>
 

--- a/test/artefacts/student-finance-forms/uk-part-time.html
+++ b/test/artefacts/student-finance-forms/uk-part-time.html
@@ -35,8 +35,10 @@
     What do you need the form for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants.html
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants.html
@@ -35,8 +35,10 @@
     What academic year do you want funding for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/continuing-student.html
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1516/continuing-student.html
@@ -35,8 +35,10 @@
     Did your part-time course start before 1 September 2012?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/student-finance-forms/y.html
+++ b/test/artefacts/student-finance-forms/y.html
@@ -35,8 +35,10 @@
     What type of a student are you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/bus.html
+++ b/test/artefacts/towing-rules/bus.html
@@ -35,8 +35,10 @@
     Do you already have a full category D bus licence?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/bus/no.html
+++ b/test/artefacts/towing-rules/bus/no.html
@@ -35,8 +35,10 @@
     How old are you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/car-or-light-vehicle.html
+++ b/test/artefacts/towing-rules/car-or-light-vehicle.html
@@ -35,7 +35,8 @@
     Do you already have a driving licence with any of the following entitlements on it:
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>C1+E (towing with a medium sized vehicle)</li>
   <li>C+E (towing with a large vehicle)</li>
   <li>D1+E (towing with a minibus)</li>
@@ -43,6 +44,7 @@
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/car-or-light-vehicle/no.html
+++ b/test/artefacts/towing-rules/car-or-light-vehicle/no.html
@@ -35,8 +35,10 @@
     When did you pass your car driving test?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/car-or-light-vehicle/yes.html
+++ b/test/artefacts/towing-rules/car-or-light-vehicle/yes.html
@@ -35,8 +35,10 @@
     When did you get this entitlement on your licence?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/large-vehicle.html
+++ b/test/artefacts/towing-rules/large-vehicle.html
@@ -35,8 +35,10 @@
     Do you already have a category C large vehicle licence?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/large-vehicle/no.html
+++ b/test/artefacts/towing-rules/large-vehicle/no.html
@@ -35,8 +35,10 @@
     How old are you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/medium-sized-vehicle.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle.html
@@ -35,8 +35,10 @@
     Do you already have a C1 medium-sized vehicle licence?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/medium-sized-vehicle/no.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle/no.html
@@ -35,8 +35,10 @@
     Do you already have a driving licence with the C+E towing with a large vehicle entitlement on it?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/medium-sized-vehicle/no/no.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle/no/no.html
@@ -35,8 +35,10 @@
     When was your driving licence issued?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/medium-sized-vehicle/no/no/from-jan-1997.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle/no/no/from-jan-1997.html
@@ -35,8 +35,10 @@
     How old are you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/medium-sized-vehicle/yes.html
+++ b/test/artefacts/towing-rules/medium-sized-vehicle/yes.html
@@ -35,8 +35,10 @@
     How old are you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/minibus.html
+++ b/test/artefacts/towing-rules/minibus.html
@@ -35,8 +35,10 @@
     Did you pass your test before 1 January 1997?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/minibus/no.html
+++ b/test/artefacts/towing-rules/minibus/no.html
@@ -35,8 +35,10 @@
     Do you have a full category D+E towing with a bus licence?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/minibus/no/no.html
+++ b/test/artefacts/towing-rules/minibus/no/no.html
@@ -35,8 +35,10 @@
     Do you have a full category D1 minibus licence?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/minibus/no/no/no.html
+++ b/test/artefacts/towing-rules/minibus/no/no/no.html
@@ -35,8 +35,10 @@
     How old are you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/towing-rules/y.html
+++ b/test/artefacts/towing-rules/y.html
@@ -35,8 +35,10 @@
     What kind of vehicle do you want to tow with?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad.html
@@ -35,8 +35,10 @@
     Which benefit will you be claiming?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/child_benefit/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/child_benefit/austria.html
@@ -35,7 +35,8 @@
     Does the following apply to you?
   </h2>
   <div class="question-body">
-    <p>You&rsquo;re currently receiving at least one of the following UK benefits:</p>
+    <article role="article">
+      <p>You&rsquo;re currently receiving at least one of the following UK benefits:</p>
 
 <ul>
   <li>Bereavement benefits</li>
@@ -47,6 +48,7 @@
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits.html
@@ -35,8 +35,10 @@
     How long will you be abroad for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits/permanent/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/disability_benefits/permanent/austria.html
@@ -35,8 +35,10 @@
     Are you or a family member getting State Pension, Industrial Injuries Benefit, ESA (contributory) or bereavement benefits?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/esa.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/esa.html
@@ -35,8 +35,10 @@
     How long are you going abroad for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/iidb.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/iidb.html
@@ -35,8 +35,10 @@
     Are you currently receiving Industrial Injuries Disablement Benefit?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support.html
@@ -35,8 +35,10 @@
     How long are you going abroad for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">You can't apply for Income Support from abroad.</p>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other.html
@@ -35,7 +35,8 @@
     Are you travelling abroad with a partner who is getting Income Support with one of the following:
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li><a href="/income-support/what-youll-get">Pensioner premium</a></li>
   <li><a href="/income-support/what-youll-get">Higher Pensioner premium</a></li>
   <li><a href="/disability-premiums-income-support/eligibility">Disability premium</a></li>
@@ -43,6 +44,7 @@
 </ul>
 
 
+    </article>
 
       <p class="hint">Your partner must be getting the premium, not you.</p>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no.html
@@ -35,12 +35,14 @@
     Are you getting Income Support while either:
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>getting <a href="/statutory-sick-pay/">Statutory Sick Pay</a></li>
   <li>incapable of work, but being treated as capable of work because you are temporarily disqualified from receiving Income Support</li>
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/no.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/no.html
@@ -35,13 +35,15 @@
     Are you one of the following:
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>affected by a trades dispute (eg on strike)</li>
   <li>age 16 to 19 and in full-time secondary education</li>
   <li>appealing against a decision about your ability to work</li>
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes.html
@@ -35,8 +35,10 @@
     Are you going abroad to get medical treatment for the illness or disability that prevents you from working?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes/no.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/income_support/is_under_a_year_other/no/yes/no.html
@@ -35,12 +35,14 @@
     Have you been unable to work or received Statutory Sick Pay for one of the following:
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>364 days</li>
   <li>196 days if you&rsquo;re terminally ill, or getting the highest rate of Disability Living Allowance (care component) or the enhanced rate of Personal Independence Payment (daily living component)</li>
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/jsa.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/jsa.html
@@ -35,8 +35,10 @@
     If you're claiming JSA, how long are you going abroad for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/jsa/more_than_a_year.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/jsa/more_than_a_year.html
@@ -35,8 +35,10 @@
     Which country are you moving to?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan.html
@@ -35,8 +35,10 @@
     Is your employer paying National Insurance contributions for you?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan/yes.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/afghanistan/yes.html
@@ -35,9 +35,11 @@
     Are you eligible for Statutory Maternity Pay?
   </h2>
   <div class="question-body">
-    <p>If you&rsquo;re unsure you can read our <a href="/statutory-maternity-pay#eligibility">Maternity pay and leave guide</a></p>
+    <article role="article">
+      <p>If you&rsquo;re unsure you can read our <a href="/statutory-maternity-pay#eligibility">Maternity pay and leave guide</a></p>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/maternity_benefits/austria.html
@@ -35,9 +35,11 @@
     Are you working for a UK employer and paying Class 1 National Insurance Contributions?
   </h2>
   <div class="question-body">
-    <p>If you&rsquo;re unsure you can read our <a href="/national-insurance/how-much-national-insurance-you-pay">National Insurance Guide</a>.</p>
+    <article role="article">
+      <p>If you&rsquo;re unsure you can read our <a href="/national-insurance/how-much-national-insurance-you-pay">National Insurance Guide</a>.</p>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/ssp/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/ssp/austria.html
@@ -35,8 +35,10 @@
     Are you working for a UK employer?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits.html
@@ -35,8 +35,10 @@
     Are you or your partner one of the following?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
       <p class="hint">A Crown servant is someone who works for the UK government. A cross-border worker is someone who regularly travels to or from another country to work.</p>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above.html
@@ -35,8 +35,10 @@
     How long are you going abroad for?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year.html
@@ -35,8 +35,10 @@
     Do you have any children?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria.html
@@ -35,7 +35,8 @@
     Are you currently claiming State Pension or any of the following benefits?
   </h2>
   <div class="question-body">
-    <ul>
+    <article role="article">
+      <ul>
   <li>Incapacity Benefit</li>
   <li>Widow&rsquo;s Benefit</li>
   <li>Bereavement Benefit</li>
@@ -45,6 +46,7 @@
 </ul>
 
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year.html
@@ -35,8 +35,10 @@
     Why are you going abroad?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/uk-benefits-abroad/y.html
+++ b/test/artefacts/uk-benefits-abroad/y.html
@@ -35,8 +35,10 @@
     Are you currently:
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/vat-payment-deadlines/2015-01-31.html
+++ b/test/artefacts/vat-payment-deadlines/2015-01-31.html
@@ -35,8 +35,10 @@
     How do you want to pay?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">

--- a/test/artefacts/vat-payment-deadlines/y.html
+++ b/test/artefacts/vat-payment-deadlines/y.html
@@ -35,8 +35,10 @@
     When does your VAT accounting period end?
   </h2>
   <div class="question-body">
-    
+    <article role="article">
+      
 
+    </article>
 
 
     <div class="">


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/projects/1270592/stories/114770219

This PR started with the intention of rendering call outs within questions, just like outcomes and landing pages do.

The initial attempt made, wrapped the question div with the article container div (with the article tag following it), to allow the question share the same styling that is used by the outcome and landing pages.

This appeared to work initially, but broke a couple of other questions with form inputs like checkboxes etc.

A further wrapping of the question div in an article tag.


## Factcheck
https://smart-answers-pr-113993127.herokuapp.com/check-uk-visa/y/
https://smart-answers-pr-113993127.herokuapp.com/check-uk-visa/y/afghanistan/transit
## Expected Changes
[First URL on Gov.UK](https://www.gov.uk/check-uk-visa/y/)
[Second URL on Gov.UK](https://www.gov.uk/check-uk-visa/y/afghanistan/transit)
     * Changes made to the wording of a question 1 and question 3 in the check uk visa smart answer. These are only content changes and doesn't affect any logic or smart flow.


### Before

![screen shot 2016-03-02 at 09 23 52](https://cloud.githubusercontent.com/assets/84896/13455973/87bfe8a0-e058-11e5-94a9-aedadac1f456.png)

![screen shot 2016-03-02 at 09 23 39](https://cloud.githubusercontent.com/assets/84896/13455979/90a559be-e058-11e5-8e41-2b32641f9b83.png)



### After

![screen shot 2016-03-02 at 09 21 19](https://cloud.githubusercontent.com/assets/84896/13455991/9b0af878-e058-11e5-9c74-5f555aed45ce.png)


![screen shot 2016-03-02 at 09 22 44](https://cloud.githubusercontent.com/assets/84896/13455996/a4c47ae2-e058-11e5-8959-8c74da329f8b.png)