### PR TITLE
Include file & line number in the messages of exceptions raised during eval of shared logic

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -24,7 +24,7 @@ module SmartAnswer
 
     def use_shared_logic(filename)
       path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")
-      eval File.read(path), binding
+      eval File.read(path), binding, path.to_s, 0
     end
 
     def name(name = nil)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -23,7 +23,8 @@ module SmartAnswer
     end
 
     def use_shared_logic(filename)
-      eval File.read(Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")), binding
+      path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")
+      eval File.read(path), binding
     end
 
     def name(name = nil)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -24,7 +24,7 @@ module SmartAnswer
 
     def use_shared_logic(filename)
       path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")
-      instance_eval File.read(path), path.to_s, 0
+      instance_eval File.read(path), path.to_s, first_line_number = 1
     end
 
     def name(name = nil)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -24,7 +24,7 @@ module SmartAnswer
 
     def use_shared_logic(filename)
       path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")
-      instance_eval File.read(path), path.to_s, first_line_number = 1
+      instance_eval File.read(path), path.to_s
     end
 
     def name(name = nil)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -24,7 +24,7 @@ module SmartAnswer
 
     def use_shared_logic(filename)
       path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")
-      eval File.read(path), binding, path.to_s, 0
+      instance_eval File.read(path), path.to_s, 0
     end
 
     def name(name = nil)

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -371,7 +371,7 @@ end
       end
     end
 
-    line_number = source.split($/).index { |line| line =~ /SyntaxError/ }
+    line_number = source.split($/).index { |line| line =~ /SyntaxError/ } + 1
     assert_match "#{path}:#{line_number}", e.message
   end
 end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -327,7 +327,8 @@ class FlowTest < ActiveSupport::TestCase
   end
 
   test "should allow using shared logic" do
-    File.stubs(:read).with(Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "test_flow_logic.rb")).returns(<<-EOT)
+    path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "test_flow_logic.rb")
+    File.stubs(:read).with(path).returns(<<-EOT)
 multiple_choice :do_you_like_chocolate? do
   option :yes
   option :no


### PR DESCRIPTION
Supersedes #2315.

This adds a file path and a line number to exceptions raised when evaluating shared logic files.

I recently ran into such an error and it wasn't immediately obvious where the syntax error was occurring.

I've added a unit test that checks for the new behaviour.

Before:

```
lib/smart_answer/flow.rb:27: syntax error, unexpected '=', expecting keyword_end
  1 + 1 = 2 # => SyntaxError
         ^
```

After:

```
lib/smart_answer_flows/shared_logic/test_flow_logic.rb:2: syntax error, unexpected '=', expecting keyword_end
  1 + 1 = 2 # => SyntaxError
         ^
```