### PR TITLE
Update sprockets-rails gem to version 3.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       builder (>= 2.1.2)
     cliver (0.3.2)
     coderay (1.1.0)
+    concurrent-ruby (1.0.1)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
@@ -92,7 +93,6 @@ GEM
     govuk_frontend_toolkit (4.8.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    hike (1.2.3)
     htmlentities (4.3.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -220,15 +220,13 @@ GEM
       rack (>= 1.3.5)
       rest-client
     slop (3.6.0)
-    sprockets (2.12.4)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.0.3)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -296,4 +294,4 @@ DEPENDENCIES
   webmock (= 1.20.4)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,9 @@ SmartAnswers::Application.configure do
   # Allow pass debug_assets=true as a query parameter to load pages with unpackaged assets
   config.assets.allow_debugging = true
 
+  # Disable checksum being created for assets in test
+  config.assets.digest = false
+
   if ENV["DISABLE_LOGGING_IN_TEST"]
     File.open(Rails.root.join("log", "test.log"), "a") do |file|
       file.puts "\n*NOTE* Disabling logging in an attempt to speed up the tests.\n\n"


### PR DESCRIPTION
Using: `bundle update sprockets-rails`

Upgrades the sprockets-rails gem in smart answers from version 2.3.3 to version 3.0.3. The major release from 2.x to 3.x introduces breaking changes, including enabling asset digests by default (JS and CSS files will receive a checksum value in the in filename).

[Sprockets-rails release note](https://github.com/rails/sprockets-rails/releases/tag/v3.0.0)
 * Enable digest by default rails/sprockets-rails#221

With the smart answers regression tests saving the generated HTML in the repository, change  `config.assets.digest` from the new default value of `true` to `false` to prevent all the artefacts changing as a result.

The upgrade to sprockets-rails in turn updates the sprockets gem from version 2.12.4 to 3.5.2. This major version brings a pretty significant list of changes, and notably brings smart answers inline with the major version 3.x which the `4-2-stable` branch of Rails itself is developed towards. 

See: https://github.com/rails/rails/blob/4-2-stable/Gemfile#L18

Running smart answers locally with this change, no assets appear to be failing and the browser console is free of errors. The [guide to upgrading sprockets from version 2.x to 3.x](https://github.com/rails/sprockets/blob/c49f42475335c2fbde2d5ad4346cc7a659d6890b/UPGRADING.md) suggests:

> For the most part, the application facing APIs have remained the same with the majority of the changes at the extension layer.

Smart Answers also seems unaffected by the following changes:

[Prefer just foo.coffee and foo.scss](https://github.com/rails/sprockets/blob/c49f42475335c2fbde2d5ad4346cc7a659d6890b/UPGRADING.md#prefer-just-foocoffee-and-fooscss)
 * The smart answers [SCSS files](https://github.com/alphagov/smart-answers/tree/master/app/assets/stylesheets) are already following this convention 

[Removed //= include directive](https://github.com/rails/sprockets/blob/c49f42475335c2fbde2d5ad4346cc7a659d6890b/UPGRADING.md#removed--include-directive)
 * Seems unused within smart answers

### Preview on Heroku

https://smart-answers-pr-2323.herokuapp.com/marriage-abroad