### PR TITLE
Fix bug in validation of linked PIW end date in SSP Calculator

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -65,8 +65,8 @@ module SmartAnswer
       end
 
       def within_eight_weeks_of_current_sickness_period?(value)
-        earliest_allowed_date = sick_start_date - 8.weeks
-        value > earliest_allowed_date
+        earliest_allowed_date = sick_start_date - 8.weeks - 1.day
+        value >= earliest_allowed_date
       end
 
       def at_least_1_day_before_first_sick_day?(value)

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -65,8 +65,8 @@ module SmartAnswer
       end
 
       def within_eight_weeks_of_current_sickness_period?(value)
-        furthest_allowed_date = sick_start_date - 8.weeks
-        value > furthest_allowed_date
+        earliest_allowed_date = sick_start_date - 8.weeks
+        value > earliest_allowed_date
       end
 
       def at_least_1_day_before_first_sick_day?(value)

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -64,9 +64,9 @@ module SmartAnswer
         sick_start_date > value
       end
 
-      def within_eight_weeks_of_current_sickness_period?(value)
+      def within_eight_weeks_of_current_sickness_period?(previous_sickness_end_date)
         earliest_allowed_date = sick_start_date - 8.weeks - 1.day
-        value >= earliest_allowed_date
+        previous_sickness_end_date >= earliest_allowed_date
       end
 
       def at_least_1_day_before_first_sick_day?(value)

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -29,6 +29,6 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/questions/pay_amount_if_not_
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_before_sick_period.govspeak.erb: 46ce81328d55d2bef88bb1047cf047cd
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.govspeak.erb: 77831bed05434968d38648a40d3ce6e9
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/usual_work_days.govspeak.erb: 5570b649de33ac95bf274bcae70895a9
-lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 0fa9f00b11c092206ef230fbeb5c2f2e
+lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 721d60e221806043c9e4acacc39409c9
 lib/smart_answer/calculators/rates_query.rb: c9568eac2742cad26f93458ed2276876
 lib/data/rates/statutory_sick_pay.yml: de2d34118e3016d1137c394745d33280

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -610,7 +610,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "not allow a day before the earliest linked end date" do
-      add_response (@earliest_linked_sickness_end_date - 1.day).to_s
+      add_response((@earliest_linked_sickness_end_date - 1.day).to_s)
       assert_current_node_is_error "must_be_within_eight_weeks"
     end
   end

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -586,7 +586,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :yes
       add_response "2015-03-20"
       assert_current_node :linked_sickness_end_date?
-      @earliest_linked_sickness_end_date = Date.parse("2015-03-27") # (Date.parse("2015-05-21") - 8.weeks).tomorrow
+      @earliest_linked_sickness_end_date = Date.parse("2015-03-25") # Date.parse("2015-05-21") - 8.weeks - 1.day
     end
 
     should "not allow dates before 2010" do

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -586,7 +586,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :yes
       add_response "2015-03-20"
       assert_current_node :linked_sickness_end_date?
-      @furthest_linked_sickness_end_date = Date.parse("2015-03-27") # (Date.parse("2015-05-21") - 8.weeks).tomorrow
+      @earliest_linked_sickness_end_date = Date.parse("2015-03-27") # (Date.parse("2015-05-21") - 8.weeks).tomorrow
     end
 
     should "not allow dates before 2010" do
@@ -604,13 +604,13 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       assert_current_node_is_error
     end
 
-    should "allow the latest allowed end date" do
-      add_response @furthest_linked_sickness_end_date.to_s
+    should "allow the earliest linked end date" do
+      add_response @earliest_linked_sickness_end_date.to_s
       assert_current_node :paid_at_least_8_weeks?
     end
 
-    should "not allow a day before the latest allowed date" do
-      add_response (@furthest_linked_sickness_end_date - 1.day).to_s
+    should "not allow a day before the earliest linked end date" do
+      add_response (@earliest_linked_sickness_end_date - 1.day).to_s
       assert_current_node_is_error "must_be_within_eight_weeks"
     end
   end


### PR DESCRIPTION
This addressed a bug I identified in the SSP Calculator while refactoring the code as part of #2280. It is also being tracked in [this Pivotal Tracker story][1].

In summary, the validation was incorrectly including the last day of the previous PIW and the first day of the current PIW when calculating the gap between them. The gap is supposed to be 8 weeks (56 days) or less, but because of the bug, this gap was effectively reduced by 2 days to 54 days.

## Before

* [A gap of 54 days][54] correctly gave no validation error.
* [A gap of 55 days][55] **incorrectly** gave a validation error: "You need to enter a date within 8 weeks of the current period of sickness or it isn't a linked period of sickness."
* [A gap of 56 days][56] **incorrectly** gave the same validation error.
* [A gap of 57 days][57] correctly gave the same validation error.

## After 

* [A gap of 54 days][54] should still give no validation error.
* [A gap of 55 days][55] should give **no** validation error.
* [A gap of 56 days][56] should give **no** validation error.
* [A gap of 57 days][57] should still give the same validation error.

See the 2nd commit note for further details.

[1]: https://www.pivotaltracker.com/story/show/108237210
[54]: https://www.gov.uk/calculate-statutory-sick-pay/y/statutory_paternity_pay/yes/no/2015-05-01/2015-05-15/yes/2015-02-15/2015-03-07
[55]: https://www.gov.uk/calculate-statutory-sick-pay/y/statutory_paternity_pay/yes/no/2015-05-01/2015-05-15/yes/2015-02-15/2015-03-06
[56]: https://www.gov.uk/calculate-statutory-sick-pay/y/statutory_paternity_pay/yes/no/2015-05-01/2015-05-15/yes/2015-02-15/2015-03-05
[57]: https://www.gov.uk/calculate-statutory-sick-pay/y/statutory_paternity_pay/yes/no/2015-05-01/2015-05-15/yes/2015-02-15/2015-03-04