### PR TITLE
Replace appointment booking link (Marriage abroad Moldova)

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -205,6 +205,27 @@
 
       [British Embassy Khartoum - opening hours](/government/world/organisations/british-embassy-khartoum/office/british-embassy-khartoum-main-contact)
       $C
+
+    <% elsif calculator.ceremony_country == 'moldova' %>
+      Contact the embassy or consulate to make an appointment.
+
+      $A
+      British Embassy Chisinau
+      18 Nicolae Iorga Str.
+      Chisinau
+      MD-2012
+      Moldova
+      $A
+
+      $C
+      Telephone: (+373) (22) 225 902
+      Fax: (+373) (22) 251 859
+
+      Email: <Enquiries.Chisinau@fco.gov.uk>
+
+      [British Embassy Chisinau - opening hours](/government/world/organisations/british-embassy-chisinau/office/british-embassy)
+      $C
+
     <% else %>
       <%= render partial: 'contact_method.govspeak.erb',
                  locals: { calculator: calculator } %>

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -105,7 +105,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_bot.govspeak.erb: f9c
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_cambodia.govspeak.erb: b693e25f4030a1d19c6acd7cf1b3debe
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_colombia.govspeak.erb: a0860f0581acfa1e5533f3114569301c
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_commonwealth.govspeak.erb: 8709a00e420b96ca7378b89053e638f1
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb: 19f8d618dbd8323785fadf78c382d758
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb: 8d8a0e2cff275e3b6e14fe4b79d153a1
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_france_or_fot.govspeak.erb: 71d74db77499d680423d7586ba9e0e61
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_germany.govspeak.erb: e5e8a3e5209c68f513e9dbe145a5b671
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_hong_kong.govspeak.erb: 9c1686c0a3ba24dff0297e4e04f2fae6


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/projects/1270592/stories/109439130

* Replace the appointment booking link with Embassy address details

## Factcheck
https://smart-answers-pr-109439130.herokuapp.com/marriage-abroad
https://smart-answers-pr-109439130.herokuapp.com/marriage-abroad/y/moldova/ceremony_country/partner_local/opposite_sex

### Expected changes
*  [URL on GOV.UK](//gov.uk/marriage-abroad/y/moldova/ceremony_country/partner_local/opposite_sex)

### Before

![screen shot 2016-03-02 at 11 51 45](https://cloud.githubusercontent.com/assets/84896/13459660/2e0d9860-e06d-11e5-8fcb-7036c9383982.png)


### After
 
![screen shot 2016-03-14 at 12 15 02](https://cloud.githubusercontent.com/assets/84896/13744242/6bb6575e-e9de-11e5-9247-dbb45e955b41.png)

