### PR TITLE
Improve message of exceptions raised in eval of shared logic (v2)

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -24,7 +24,9 @@ module SmartAnswer
 
     def use_shared_logic(filename)
       path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")
+      # rubocop:disable Lint/Eval
       eval File.read(path), binding, path.to_s
+      # rubocop:enable Lint/Eval
     end
 
     def name(name = nil)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -24,7 +24,7 @@ module SmartAnswer
 
     def use_shared_logic(filename)
       path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")
-      eval File.read(path), binding
+      eval File.read(path), binding, path.to_s
     end
 
     def name(name = nil)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -23,7 +23,8 @@ module SmartAnswer
     end
 
     def use_shared_logic(filename)
-      eval File.read(Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")), binding
+      path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "#{filename}.rb")
+      eval File.read(path), binding
     end
 
     def name(name = nil)

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -327,7 +327,8 @@ class FlowTest < ActiveSupport::TestCase
   end
 
   test "should allow using shared logic" do
-    File.stubs(:read).with(Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "test_flow_logic.rb")).returns(<<-EOT)
+    path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "test_flow_logic.rb")
+    File.stubs(:read).with(path).returns(<<-EOT)
 multiple_choice :do_you_like_chocolate? do
   option :yes
   option :no

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -354,4 +354,24 @@ outcome :savoury_tooth
     assert_equal 2, s.outcomes.size
     assert_equal [:sweet_tooth, :savoury_tooth], s.outcomes.map(&:name)
   end
+
+  test "should report file and line number of syntax error in shared logic" do
+    path = Rails.root.join('lib', 'smart_answer_flows', 'shared_logic', "test_flow_logic.rb")
+    source = <<-EOT
+multiple_choice :question_containing_syntax_error? do
+  1 + 1 = 2 # => SyntaxError
+end
+    EOT
+
+    File.stubs(:read).with(path).returns(source)
+
+    e = assert_raises(SyntaxError) do
+      SmartAnswer::Flow.new do
+        use_shared_logic 'test_flow_logic'
+      end
+    end
+
+    line_number = source.split($/).index { |line| line =~ /SyntaxError/ } + 1
+    assert_match "#{path}:#{line_number}", e.message
+  end
 end


### PR DESCRIPTION
This means any exception raised during the evaluation will report a sensible file path and line number rather than the file path and line number of the `Flow#use_shared_logic` method.

I recently ran into such an error and it wasn't immediately obvious where the syntax error was occurring.

I've added a unit test that checks for the new behaviour.

Before:

```
lib/smart_answer/flow.rb:27: syntax error, unexpected '=', expecting keyword_end
  1 + 1 = 2 # => SyntaxError
         ^
```

After:

```
lib/smart_answer_flows/shared_logic/test_flow_logic.rb:2: syntax error, unexpected '=', expecting keyword_end
  1 + 1 = 2 # => SyntaxError
         ^
```

Note that I've temporarily suppressed a Rubocop rule in order to make this change. See the 3rd commit message for details.

Note also previous failed attempts at doing this in #2321 and #2315.
