### PR TITLE
Replace LInks for Statutory maternity paternity calculator

### DIFF
--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
@@ -29,6 +29,6 @@
 
   + births 15 weeks before the due date
   + [Additional paternity Leave or Pay](/additional-paternity-leave-pay-employees)
-  + paternity leave or pay for [overseas adoptions](/paternity-leave-pay-employees)
+  + paternity leave or pay for [overseas adoptions](/employers-paternity-pay-leave/adoption)
   + [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide)
 <% end %>

--- a/test/artefacts/maternity-paternity-calculator/maternity-paternity-calculator.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity-paternity-calculator.txt
@@ -19,5 +19,5 @@ You can’t use the calculator for:
 
 + births 15 weeks before the due date
 + [Additional paternity Leave or Pay](/additional-paternity-leave-pay-employees)
-+ paternity leave or pay for [overseas adoptions](/paternity-leave-pay-employees)
++ paternity leave or pay for [overseas adoptions](/employers-paternity-pay-leave/adoption)
 + [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide)

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/maternity-paternity-calculator.rb: 0d35c271ee34e395afc1f71d649caf9e
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 1bf0c803cd8e8a091417b0e1e19d2bd2
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: a59f6821dd5b949861ab6261840e58e4
-lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: 912bfe601939f1391d5e54b11c146744
+lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: c8c17c5f5e46a1b74cc8a6a2445486f7
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_must_be_on_payroll.govspeak.erb: e79accc3a0b6e9060fb3fbf9dd5848ad
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_must_earn_over_threshold.govspeak.erb: d2367c7b156a37e88a81061ce890503a
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_not_worked_long_enough.govspeak.erb: 08e6560e8927136f1f2899c4d0b1648f


### PR DESCRIPTION
#PT Story: https://www.pivotaltracker.com/projects/1270592/stories/106299080

* Replace url path in smart answers /paternity-leave-pay-employees with /employers-paternity-pay-leave/adoption

## Factcheck
https://smart-answers-pr-106299080.herokuapp.com/maternity-paternity-calculator

### Expected changes
[URL on GOV.UK](//gov.uk/maternity-paternity-calculator)
* Change Url path in maternity-paternity-calculator from /paternity-leave-pay-employees to /employers-paternity-pay-leave/adoption

### Before
![screen shot 2016-03-03 at 17 25 05](https://cloud.githubusercontent.com/assets/84896/13502922/e63fde50-e164-11e5-9bed-0f6c9c515c53.png)

### After
 
![screen shot 2016-03-03 at 17 25 42](https://cloud.githubusercontent.com/assets/84896/13502950/fe903284-e164-11e5-9db1-2df6ce2d56cf.png)

