### PR TITLE
Update round_up_weekly.govspeak.erb

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/round_up_weekly.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/round_up_weekly.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :title do %>
-  Your weekly childcare costs are the total amount you pay each week rounded up to the nearest pound.
+  Round up the amount you pay each week to the nearest pound to get your weekly childcare cost.
 <% end %>
 
 <% content_for :body do %>
-  Use this figure on your claim form.
+  Use that figure on your claim form.
 <% end %>


### PR DESCRIPTION
CHANGED FROM

Your weekly childcare costs are the total amount you pay each week rounded up to the nearest pound. Use this figure on your claim form.

REASON

Users were reading "Your weekly childcare costs are ..." and "use this figure ..." and expecting to see a figure on the page. By changing the first part to an action ("Round up"), users will hopefully understand that there's something else they need to do to get the figure they need - rather than expecting the tool to do the calculation for them.