### PR TITLE
Update outcome in childcare cost for tax credits

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/round_up_weekly.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/round_up_weekly.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :title do %>
-  Your weekly childcare costs are the total amount you pay each week rounded up to the nearest pound.
+  Round up the amount you pay each week to the nearest pound to get your weekly childcare cost.
 <% end %>
 
 <% content_for :body do %>
-  Use this figure on your claim form.
+  Use that figure on your claim form.
 <% end %>

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/weekly_same_amount.txt
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_less_than_year/weekly_same_amount.txt
@@ -1,4 +1,4 @@
-Your weekly childcare costs are the total amount you pay each week rounded up to the nearest pound.
+Round up the amount you pay each week to the nearest pound to get your weekly childcare cost.
 
-Use this figure on your claim form.
+Use that figure on your claim form.
 

--- a/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/weekly.txt
+++ b/test/artefacts/childcare-costs-for-tax-credits/no/regularly_more_than_year/yes/weekly.txt
@@ -1,4 +1,4 @@
-Your weekly childcare costs are the total amount you pay each week rounded up to the nearest pound.
+Round up the amount you pay each week to the nearest pound to get your weekly childcare cost.
 
-Use this figure on your claim form.
+Use that figure on your claim form.
 

--- a/test/data/childcare-costs-for-tax-credits-files.yml
+++ b/test/data/childcare-costs-for-tax-credits-files.yml
@@ -8,7 +8,7 @@ lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/call_helpline_pl
 lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/cost_changed.govspeak.erb: 68cbb48b19bdacb30e684b3d55d5c389
 lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_change.govspeak.erb: 229bd94a79a2576e79b94f214fea410c
 lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_longer_paying.govspeak.erb: 4e79f424125d07a011078d27c757a62d
-lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/round_up_weekly.govspeak.erb: bad7e4ff3d6acf67d0ce2e84d1c13c07
+lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/round_up_weekly.govspeak.erb: 09ca1b6f92a1eb424cf114c3156071c2
 lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/weekly_costs_are_x.govspeak.erb: f3686b4c4947b88d4ed8d29a48e3a1ba
 lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/currently_claiming.govspeak.erb: 093e0969c49f5a5dd1f7e043ce6d099d
 lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/have_costs_changed.govspeak.erb: bffda60c1614832b1626f20799eaa9d5


### PR DESCRIPTION
CHANGED FROM

Your weekly childcare costs are the total amount you pay each week rounded up to the nearest pound. Use this figure on your claim form.

REASON

Users were reading "Your weekly childcare costs are ..." and "use this figure ..." and expecting to see a figure on the page. By changing the first part to an action ("Round up"), users will hopefully understand that there's something else they need to do to get the figure they need - rather than expecting the tool to do the calculation for them.

Note: this PR supesedes #2333, cherry-picking the content change and adding updated regression test artefacts and file checksums