### PR TITLE
Correction to student finance forms

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1617.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1617.govspeak.erb
@@ -4,14 +4,14 @@
 
 <% content_for :body do %>
 
-  Some student finance (eg a Maintenance Grant) is based on income.
+  Some student finance is based on income.
 
   You must send your income details for the 2014 to 2015 tax year. Do this online as part of the [student’s application](/apply-online-for-student-finance). If you can’t do it online, use form PFF2.
 
   If you think your income has dropped by 15% or more since the 2014 to 2015 tax year you’ll need to do both of the following:
 
   + submit your 2014 to 2015 income details using form PFF2
-  + complete a CYI form (to ask for the student finance to be based on your expected 2015 to 2016 tax year income)
+  + complete a CYI form (to ask for the student finance to be based on your expected 2016 to 2017 tax year income)
 
   The CYI form will be available when the new tax year starts in April.
 

--- a/test/artefacts/student-finance-forms/uk-full-time/income-details/year-1617.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/income-details/year-1617.txt
@@ -1,14 +1,14 @@
 Parents and partners - forms
 
 
-Some student finance (eg a Maintenance Grant) is based on income.
+Some student finance is based on income.
 
 You must send your income details for the 2014 to 2015 tax year. Do this online as part of the [student’s application](/apply-online-for-student-finance). If you can’t do it online, use form PFF2.
 
 If you think your income has dropped by 15% or more since the 2014 to 2015 tax year you’ll need to do both of the following:
 
 + submit your 2014 to 2015 income details using form PFF2
-+ complete a CYI form (to ask for the student finance to be based on your expected 2015 to 2016 tax year income)
++ complete a CYI form (to ask for the student finance to be based on your expected 2016 to 2017 tax year income)
 
 The CYI form will be available when the new tax year starts in April.
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -23,7 +23,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1415_new.gov
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_continuing.govspeak.erb: 55351c7141a8a6d6ea8d7c2f53475f4e
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.govspeak.erb: 28de0237e7549876939a4b0b38a16300
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1516.govspeak.erb: 27880afc7ba3477ed3ee6c9a1e4c4182
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1617.govspeak.erb: fd929e0913da6c9ba5aa137b3c7cc75f
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1617.govspeak.erb: 0c16e9b7559d128047f3b43926cc1c35
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1415.govspeak.erb: 37bef7c56749133977f3927a55d0138d
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1516.govspeak.erb: 1503d5117dc579523d0ffb3b627175c1
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_proof_identity_1617.govspeak.erb: 6a57b5c992b299981e407b3c08894848


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/n/projects/503131/stories/114789765

Corrects tax information outcome for the student finance forms smart answer.

## Fact check

https://smart-answers-pr-2335.herokuapp.com/student-finance-forms
https://smart-answers-pr-2335.herokuapp.com/student-finance-forms/y/uk-full-time/income-details/year-1617

## Expected changes
 [URL on gov.uk](https://www.gov.uk/student-finance-forms/y/uk-full-time/income-details/year-1617)
 * Remove copy "(eg a Maintenance Grant)" from first sentence on page
 * Update the year values in the second bullet from "2015 to 2016" to "2016 to 2017"

### Before
![screen shot 2016-03-07 at 9 38 52 am](https://cloud.githubusercontent.com/assets/351763/13565565/b51f5792-e448-11e5-9c9b-5df65ded3f02.png)

### After
![screen shot 2016-03-07 at 9 39 13 am](https://cloud.githubusercontent.com/assets/351763/13565569/b94cfb30-e448-11e5-9f38-4f16e97ce361.png)

Note: this PR supersedes #2332 