### PR TITLE
Refactor unit test for SmartAnswer::Question::Base

### DIFF
--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -1,15 +1,36 @@
 require_relative '../test_helper'
 
 class QuestionBaseTest < ActiveSupport::TestCase
-  should 'permitted next nodes must be supplied if next_node is called with block' do
-    e = assert_raises(ArgumentError) do
-      SmartAnswer::Question::Base.new(nil, :example) {
-        next_node do
-          :done
-        end
-      }
+  context '#next_node' do
+    should 'raise exception if called with block but no permitted next nodes' do
+      e = assert_raises(ArgumentError) do
+        SmartAnswer::Question::Base.new(nil, :example) {
+          next_node do
+            :done
+          end
+        }
+      end
+      assert_equal 'You must specify at least one permitted next node', e.message
     end
-    assert_equal 'You must specify at least one permitted next node', e.message
+
+    should 'single next node key must be supplied if next_node called without block' do
+      e = assert_raises(ArgumentError) do
+        SmartAnswer::Question::Base.new(nil, :example) {
+          next_node
+        }
+      end
+      assert_equal 'You must specify a block or a single next node key', e.message
+    end
+
+    should 'raise exception if next_node is invoked multiple times' do
+      e = assert_raises do
+        SmartAnswer::Question::Base.new(nil, :example) {
+          next_node :outcome_one
+          next_node :outcome_two
+        }
+      end
+      assert_equal 'Multiple calls to next_node are not allowed', e.message
+    end
   end
 
   should 'permitted next nodes supplied to next_node are stored' do
@@ -19,25 +40,6 @@ class QuestionBaseTest < ActiveSupport::TestCase
       end
     }
     assert_equal [:done], q.permitted_next_nodes
-  end
-
-  should 'single next node key must be supplied if next_node called without block' do
-    e = assert_raises(ArgumentError) do
-      SmartAnswer::Question::Base.new(nil, :example) {
-        next_node
-      }
-    end
-    assert_equal 'You must specify a block or a single next node key', e.message
-  end
-
-  should 'multiple calls to next_node are not allowed' do
-    e = assert_raises do
-      SmartAnswer::Question::Base.new(nil, :example) {
-        next_node :outcome_one
-        next_node :outcome_two
-      }
-    end
-    assert_equal 'Multiple calls to next_node are not allowed', e.message
   end
 
   context '#transition' do

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -190,14 +190,10 @@ class QuestionBaseTest < ActiveSupport::TestCase
     end
 
     should "raise an exception if next_node was not called for question" do
-      responses = [:blue, :red]
       initial_state = SmartAnswer::State.new(@question.name)
-      initial_state.responses << responses[0]
-      error = assert_raises(SmartAnswer::Question::Base::NextNodeUndefined) do
-        @question.next_node_for(initial_state, responses[1])
+      assert_raises(SmartAnswer::Question::Base::NextNodeUndefined) do
+        @question.next_node_for(initial_state, :response)
       end
-      expected_message = "Next node undefined. Node: #{@question.name}. Responses: #{responses}."
-      assert_equal expected_message, error.message
     end
   end
 end

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -116,7 +116,6 @@ class QuestionBaseTest < ActiveSupport::TestCase
     should "save path on new state" do
       @question.next_node :done
       initial_state = SmartAnswer::State.new(@question.name)
-      initial_state.current_node = @question.name
       new_state = @question.transition(initial_state, :red)
       assert_equal [@question.name], new_state.path
     end

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -177,7 +177,8 @@ class QuestionBaseTest < ActiveSupport::TestCase
     should "raise an exception if next_node does not return a node key" do
       responses = [:blue, :red]
       @question.next_node(permitted: [:skipped]) do
-        :skipped if false
+        skip = false
+        :skipped if skip
       end
       initial_state = SmartAnswer::State.new(@question.name)
       initial_state.responses << responses[0]

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -94,7 +94,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
         :done
       end
       initial_state = SmartAnswer::State.new(@question.name)
-      new_state = @question.transition(initial_state, 'something')
+      @question.transition(initial_state, 'something')
       assert_equal 'something', input_was
     end
 

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -1,13 +1,15 @@
 require_relative '../test_helper'
 
 class QuestionBaseTest < ActiveSupport::TestCase
+  setup do
+    @question = SmartAnswer::Question::Base.new(nil, :example_question)
+  end
+
   context '#next_node' do
     should 'raise exception if called with block but no permitted next nodes' do
       e = assert_raises(ArgumentError) do
-        SmartAnswer::Question::Base.new(nil, :example) do
-          next_node do
-            :done
-          end
+        @question.next_node do
+          :done
         end
       end
       assert_equal 'You must specify at least one permitted next node', e.message
@@ -15,19 +17,15 @@ class QuestionBaseTest < ActiveSupport::TestCase
 
     should 'single next node key must be supplied if next_node called without block' do
       e = assert_raises(ArgumentError) do
-        SmartAnswer::Question::Base.new(nil, :example) do
-          next_node
-        end
+        @question.next_node
       end
       assert_equal 'You must specify a block or a single next node key', e.message
     end
 
     should 'raise exception if next_node is invoked multiple times' do
       e = assert_raises do
-        SmartAnswer::Question::Base.new(nil, :example) do
-          next_node :outcome_one
-          next_node :outcome_two
-        end
+        @question.next_node :outcome_one
+        @question.next_node :outcome_two
       end
       assert_equal 'Multiple calls to next_node are not allowed', e.message
     end
@@ -35,156 +33,129 @@ class QuestionBaseTest < ActiveSupport::TestCase
 
   context '#permitted_next_nodes' do
     should 'return permitted next nodes if next_node called with block' do
-      q = SmartAnswer::Question::Base.new(nil, :example) do
-        next_node(permitted: [:done]) do
-          :done
-        end
+      @question.next_node(permitted: [:done]) do
+        :done
       end
-      assert_equal [:done], q.permitted_next_nodes
+      assert_equal [:done], @question.permitted_next_nodes
     end
 
     should 'return permitted next nodes if next_node called without block' do
-      q = SmartAnswer::Question::Base.new(nil, :example) do
-        next_node :done
-      end
-      assert_equal [:done], q.permitted_next_nodes
+      @question.next_node :done
+      assert_equal [:done], @question.permitted_next_nodes
     end
   end
 
   context '#transition' do
     should "copy values from initial state to new state" do
-      q = SmartAnswer::Question::Base.new(nil, :example) do
-        next_node :done
-      end
-      initial_state = SmartAnswer::State.new(q.name)
+      @question.next_node :done
+      initial_state = SmartAnswer::State.new(@question.name)
       initial_state.something_else = "Carried over"
-      new_state = q.transition(initial_state, :yes)
+      new_state = @question.transition(initial_state, :yes)
       assert_equal "Carried over", new_state.something_else
     end
 
     should "set current_node to value returned from next_node_for" do
-      q = SmartAnswer::Question::Base.new(nil, :example) do
-        next_node :done
-      end
-      initial_state = SmartAnswer::State.new(q.name)
-      q.stubs(:next_node_for).returns(:done)
-      new_state = q.transition(initial_state, :anything)
+      @question.next_node :done
+      initial_state = SmartAnswer::State.new(@question.name)
+      @question.stubs(:next_node_for).returns(:done)
+      new_state = @question.transition(initial_state, :anything)
       assert_equal :done, new_state.current_node
     end
 
     should "set current_node to node key passed into next_node method" do
-      q = SmartAnswer::Question::Base.new(nil, :example) do
-        next_node :done
-      end
-      initial_state = SmartAnswer::State.new(q.name)
-      new_state = q.transition(initial_state, :anything)
+      @question.next_node :done
+      initial_state = SmartAnswer::State.new(@question.name)
+      new_state = @question.transition(initial_state, :anything)
       assert_equal :done, new_state.current_node
     end
 
     should "set current_node to result of calling next_node block" do
-      q = SmartAnswer::Question::Base.new(nil, :example) do
-        next_node(permitted: [:done_done]) { :done_done }
-      end
-      initial_state = SmartAnswer::State.new(q.name)
-      new_state = q.transition(initial_state, :anything)
+      @question.next_node(permitted: [:done_done]) { :done_done }
+      initial_state = SmartAnswer::State.new(@question.name)
+      new_state = @question.transition(initial_state, :anything)
       assert_equal :done_done, new_state.current_node
     end
 
     should "make state available to code in next_node block" do
-      q = SmartAnswer::Question::Base.new(nil, :example) do
-        permitted_next_nodes = [:was_red, :wasnt_red]
-        next_node(permitted: permitted_next_nodes) do
-          colour == 'red' ? :was_red : :wasnt_red
-        end
+      permitted_next_nodes = [:was_red, :wasnt_red]
+      @question.next_node(permitted: permitted_next_nodes) do
+        colour == 'red' ? :was_red : :wasnt_red
       end
-      initial_state = SmartAnswer::State.new(q.name)
+      initial_state = SmartAnswer::State.new(@question.name)
       initial_state.colour = 'red'
-      new_state = q.transition(initial_state, 'anything')
+      new_state = @question.transition(initial_state, 'anything')
       assert_equal :was_red, new_state.current_node
     end
 
     should "pass input to next_node block" do
       input_was = nil
-      q = SmartAnswer::Question::Base.new(nil, :example) do
-        next_node(permitted: [:done]) do |input|
-          input_was = input
-          :done
-        end
+      @question.next_node(permitted: [:done]) do |input|
+        input_was = input
+        :done
       end
-      initial_state = SmartAnswer::State.new(q.name)
-      new_state = q.transition(initial_state, 'something')
+      initial_state = SmartAnswer::State.new(@question.name)
+      new_state = @question.transition(initial_state, 'something')
       assert_equal 'something', input_was
     end
 
     should "make save_input_as method available to code in next_node block" do
-      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
-        save_input_as :colour_preference
-        next_node :done
-      end
-      initial_state = SmartAnswer::State.new(q.name)
-      new_state = q.transition(initial_state, :red)
+      @question.save_input_as :colour_preference
+      @question.next_node :done
+      initial_state = SmartAnswer::State.new(@question.name)
+      new_state = @question.transition(initial_state, :red)
       assert_equal :red, new_state.colour_preference
     end
 
     should "save input sequence on new state" do
-      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
-        next_node :done
-      end
-      initial_state = SmartAnswer::State.new(q.name)
-      new_state = q.transition(initial_state, :red)
+      @question.next_node :done
+      initial_state = SmartAnswer::State.new(@question.name)
+      new_state = @question.transition(initial_state, :red)
       assert_equal [:red], new_state.responses
     end
 
     should "save path on new state" do
-      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?)
-      q.next_node :done
-      initial_state = SmartAnswer::State.new(q.name)
-      initial_state.current_node = q.name
-      new_state = q.transition(initial_state, :red)
-      assert_equal [:favourite_colour?], new_state.path
+      @question.next_node :done
+      initial_state = SmartAnswer::State.new(@question.name)
+      initial_state.current_node = @question.name
+      new_state = @question.transition(initial_state, :red)
+      assert_equal [@question.name], new_state.path
     end
 
     should "execute calculate block with response and save result on new state" do
-      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
-        calculate :complementary_colour do |response|
-          response == :red ? :green : :red
-        end
-        next_node :done
+      @question.calculate :complementary_colour do |response|
+        response == :red ? :green : :red
       end
-      initial_state = SmartAnswer::State.new(q.name)
-      new_state = q.transition(initial_state, :red)
+      @question.next_node :done
+      initial_state = SmartAnswer::State.new(@question.name)
+      new_state = @question.transition(initial_state, :red)
       assert_equal :green, new_state.complementary_colour
       assert new_state.frozen?
     end
 
     should "execute calculate block with saved input and save result on new state" do
-      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
-        save_input_as :colour_preference
-        calculate :complementary_colour do
-          colour_preference == :red ? :green : :red
-        end
-        next_node :done
+      @question.save_input_as :colour_preference
+      @question.calculate :complementary_colour do
+        colour_preference == :red ? :green : :red
       end
-      initial_state = SmartAnswer::State.new(q.name)
-      new_state = q.transition(initial_state, :red)
+      @question.next_node :done
+      initial_state = SmartAnswer::State.new(@question.name)
+      new_state = @question.transition(initial_state, :red)
       assert_equal :green, new_state.complementary_colour
       assert new_state.frozen?
     end
 
     should "execute next_node_calculation block before next_node" do
-      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
-        next_node_calculation :complementary_colour do |response|
-          response == :red ? :green : :red
-        end
-        next_node_calculation :blah do
-          "blah"
-        end
-        next_node(permitted: [:done]) do
-          :done if complementary_colour == :green
-        end
+      @question.next_node_calculation :complementary_colour do |response|
+        response == :red ? :green : :red
       end
-      initial_state = SmartAnswer::State.new(q.name)
-      new_state = q.transition(initial_state, :red)
+      @question.next_node_calculation :blah do
+        "blah"
+      end
+      @question.next_node(permitted: [:done]) do
+        :done if complementary_colour == :green
+      end
+      initial_state = SmartAnswer::State.new(@question.name)
+      new_state = @question.transition(initial_state, :red)
       assert_equal :green, new_state.complementary_colour
       assert_equal "blah", new_state.blah
       assert_equal :done, new_state.current_node
@@ -193,48 +164,39 @@ class QuestionBaseTest < ActiveSupport::TestCase
 
   context '#next_node_for' do
     should "raise an exception if next_node returns key not in permitted_next_nodes" do
-      q = SmartAnswer::Question::Base.new(flow = nil, :question_name) do
-        permitted_next_nodes = [:allowed_next_node_1, :allowed_next_node_2]
-        next_node(permitted: permitted_next_nodes) { :not_allowed_next_node }
-      end
-      state = SmartAnswer::State.new(q.name)
+      permitted_next_nodes = [:allowed_next_node_1, :allowed_next_node_2]
+      @question.next_node(permitted: permitted_next_nodes) { :not_allowed_next_node }
+      state = SmartAnswer::State.new(@question.name)
 
       expected_message = "Next node (not_allowed_next_node) not in list of permitted next nodes (allowed_next_node_1 and allowed_next_node_2)"
       exception = assert_raises do
-        q.next_node_for(state, 'response')
+        @question.next_node_for(state, 'response')
       end
       assert_equal expected_message, exception.message
     end
 
     should "raise an exception if next_node does not return a node key" do
-      question_name = :example
       responses = [:blue, :red]
-      q = SmartAnswer::Question::Base.new(nil, question_name) do
-        next_node(permitted: [:skipped]) do
-          :skipped if false
-        end
+      @question.next_node(permitted: [:skipped]) do
+        :skipped if false
       end
-      initial_state = SmartAnswer::State.new(q.name)
+      initial_state = SmartAnswer::State.new(@question.name)
       initial_state.responses << responses[0]
       error = assert_raises(SmartAnswer::Question::Base::NextNodeUndefined) do
-        q.next_node_for(initial_state, responses[1])
+        @question.next_node_for(initial_state, responses[1])
       end
-      expected_message = "Next node undefined. Node: #{question_name}. Responses: #{responses}."
+      expected_message = "Next node undefined. Node: #{@question.name}. Responses: #{responses}."
       assert_equal expected_message, error.message
     end
 
     should "raise an exception if next_node was not called for question" do
-      question_name = :example
       responses = [:blue, :red]
-      q = SmartAnswer::Question::Base.new(nil, question_name) do
-        # no call to next_node
-      end
-      initial_state = SmartAnswer::State.new(q.name)
+      initial_state = SmartAnswer::State.new(@question.name)
       initial_state.responses << responses[0]
       error = assert_raises(SmartAnswer::Question::Base::NextNodeUndefined) do
-        q.next_node_for(initial_state, responses[1])
+        @question.next_node_for(initial_state, responses[1])
       end
-      expected_message = "Next node undefined. Node: #{question_name}. Responses: #{responses}."
+      expected_message = "Next node undefined. Node: #{@question.name}. Responses: #{responses}."
       assert_equal expected_message, error.message
     end
   end

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -42,6 +42,13 @@ class QuestionBaseTest < ActiveSupport::TestCase
       }
       assert_equal [:done], q.permitted_next_nodes
     end
+
+    should 'return permitted next nodes if next_node called without block' do
+      q = SmartAnswer::Question::Base.new(nil, :example) {
+        next_node :done
+      }
+      assert_equal [:done], q.permitted_next_nodes
+    end
   end
 
   context '#transition' do

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 class QuestionBaseTest < ActiveSupport::TestCase
-  test "#next_node_for raises an exception when the next node isn't in the list of permitted next nodes" do
+  should "#next_node_for raises an exception when the next node isn't in the list of permitted next nodes" do
     q = SmartAnswer::Question::Base.new(flow = nil, :question_name) {
       permitted_next_nodes = [:allowed_next_node_1, :allowed_next_node_2]
       next_node(permitted: permitted_next_nodes) { :not_allowed_next_node }
@@ -15,7 +15,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal expected_message, exception.message
   end
 
-  test 'permitted next nodes must be supplied if next_node is called with block' do
+  should 'permitted next nodes must be supplied if next_node is called with block' do
     e = assert_raises(ArgumentError) do
       SmartAnswer::Question::Base.new(nil, :example) {
         next_node do
@@ -26,7 +26,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal 'You must specify at least one permitted next node', e.message
   end
 
-  test 'permitted next nodes supplied to next_node are stored' do
+  should 'permitted next nodes supplied to next_node are stored' do
     q = SmartAnswer::Question::Base.new(nil, :example) {
       next_node(permitted: [:done]) do
         :done
@@ -35,7 +35,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal [:done], q.permitted_next_nodes
   end
 
-  test 'single next node key must be supplied if next_node called without block' do
+  should 'single next node key must be supplied if next_node called without block' do
     e = assert_raises(ArgumentError) do
       SmartAnswer::Question::Base.new(nil, :example) {
         next_node
@@ -44,7 +44,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal 'You must specify a block or a single next node key', e.message
   end
 
-  test 'multiple calls to next_node are not allowed' do
+  should 'multiple calls to next_node are not allowed' do
     e = assert_raises do
       SmartAnswer::Question::Base.new(nil, :example) {
         next_node :outcome_one
@@ -54,7 +54,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal 'Multiple calls to next_node are not allowed', e.message
   end
 
-  test "State is carried over on a state transition" do
+  should "State is carried over on a state transition" do
     q = SmartAnswer::Question::Base.new(nil, :example) {
       next_node :done
     }
@@ -64,7 +64,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal "Carried over", new_state.something_else
   end
 
-  test "Next node is taken from next_node_for method" do
+  should "Next node is taken from next_node_for method" do
     q = SmartAnswer::Question::Base.new(nil, :example) {
       next_node :done
     }
@@ -74,7 +74,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal :done, new_state.current_node
   end
 
-  test "Can define next_node by passing a value" do
+  should "Can define next_node by passing a value" do
     q = SmartAnswer::Question::Base.new(nil, :example) {
       next_node :done
     }
@@ -83,7 +83,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal :done, new_state.current_node
   end
 
-  test "Can define next_node by giving a block, provided that next node is declared" do
+  should "Can define next_node by giving a block, provided that next node is declared" do
     q = SmartAnswer::Question::Base.new(nil, :example) {
       next_node(permitted: [:done_done]) { :done_done }
     }
@@ -92,7 +92,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal :done_done, new_state.current_node
   end
 
-  test "next_node block can refer to state" do
+  should "next_node block can refer to state" do
     q = SmartAnswer::Question::Base.new(nil, :example) {
       permitted_next_nodes = [:was_red, :wasnt_red]
       next_node(permitted: permitted_next_nodes) do
@@ -105,7 +105,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal :was_red, new_state.current_node
   end
 
-  test "next_node block is passed input" do
+  should "next_node block is passed input" do
     input_was = nil
     q = SmartAnswer::Question::Base.new(nil, :example) {
       next_node(permitted: [:done]) do |input|
@@ -118,7 +118,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal 'something', input_was
   end
 
-  test "Input can be saved into the state" do
+  should "Input can be saved into the state" do
     q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
       save_input_as :colour_preference
       next_node :done
@@ -128,7 +128,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal :red, new_state.colour_preference
   end
 
-  test "Input sequence is saved into responses" do
+  should "Input sequence is saved into responses" do
     q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) {
       next_node :done
     }
@@ -137,7 +137,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal [:red], new_state.responses
   end
 
-  test "Node path is saved in state" do
+  should "Node path is saved in state" do
     q = SmartAnswer::Question::Base.new(nil, :favourite_colour?)
     q.next_node :done
     initial_state = SmartAnswer::State.new(q.name)
@@ -146,7 +146,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal [:favourite_colour?], new_state.path
   end
 
-  test "Can calculate other variables based on input" do
+  should "Can calculate other variables based on input" do
     q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
       calculate :complementary_colour do |response|
         response == :red ? :green : :red
@@ -159,7 +159,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert new_state.frozen?
   end
 
-  test "Can calculate other variables based on saved input" do
+  should "Can calculate other variables based on saved input" do
     q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
       save_input_as :colour_preference
       calculate :complementary_colour do
@@ -173,7 +173,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert new_state.frozen?
   end
 
-  test "Can perform next_node_calculation which is evaluated before next_node" do
+  should "Can perform next_node_calculation which is evaluated before next_node" do
     q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
       next_node_calculation :complementary_colour do |response|
         response == :red ? :green : :red
@@ -192,7 +192,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal :done, new_state.current_node
   end
 
-  test "error if no conditional transitions found and no fallback" do
+  should "error if no conditional transitions found and no fallback" do
     question_name = :example
     responses = [:blue, :red]
     q = SmartAnswer::Question::Base.new(nil, question_name) {
@@ -209,7 +209,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal expected_message, error.message
   end
 
-  test "error if next_node was not called for question" do
+  should "error if next_node was not called for question" do
     question_name = :example
     responses = [:blue, :red]
     q = SmartAnswer::Question::Base.new(nil, question_name) {

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -33,13 +33,15 @@ class QuestionBaseTest < ActiveSupport::TestCase
     end
   end
 
-  should 'permitted next nodes supplied to next_node are stored' do
-    q = SmartAnswer::Question::Base.new(nil, :example) {
-      next_node(permitted: [:done]) do
-        :done
-      end
-    }
-    assert_equal [:done], q.permitted_next_nodes
+  context '#permitted_next_nodes' do
+    should 'return permitted next nodes if next_node called with block' do
+      q = SmartAnswer::Question::Base.new(nil, :example) {
+        next_node(permitted: [:done]) do
+          :done
+        end
+      }
+      assert_equal [:done], q.permitted_next_nodes
+    end
   end
 
   context '#transition' do

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -40,142 +40,144 @@ class QuestionBaseTest < ActiveSupport::TestCase
     assert_equal 'Multiple calls to next_node are not allowed', e.message
   end
 
-  should "State is carried over on a state transition" do
-    q = SmartAnswer::Question::Base.new(nil, :example) {
-      next_node :done
-    }
-    initial_state = SmartAnswer::State.new(q.name)
-    initial_state.something_else = "Carried over"
-    new_state = q.transition(initial_state, :yes)
-    assert_equal "Carried over", new_state.something_else
-  end
-
-  should "Next node is taken from next_node_for method" do
-    q = SmartAnswer::Question::Base.new(nil, :example) {
-      next_node :done
-    }
-    initial_state = SmartAnswer::State.new(q.name)
-    q.stubs(:next_node_for).returns(:done)
-    new_state = q.transition(initial_state, :anything)
-    assert_equal :done, new_state.current_node
-  end
-
-  should "Can define next_node by passing a value" do
-    q = SmartAnswer::Question::Base.new(nil, :example) {
-      next_node :done
-    }
-    initial_state = SmartAnswer::State.new(q.name)
-    new_state = q.transition(initial_state, :anything)
-    assert_equal :done, new_state.current_node
-  end
-
-  should "Can define next_node by giving a block, provided that next node is declared" do
-    q = SmartAnswer::Question::Base.new(nil, :example) {
-      next_node(permitted: [:done_done]) { :done_done }
-    }
-    initial_state = SmartAnswer::State.new(q.name)
-    new_state = q.transition(initial_state, :anything)
-    assert_equal :done_done, new_state.current_node
-  end
-
-  should "next_node block can refer to state" do
-    q = SmartAnswer::Question::Base.new(nil, :example) {
-      permitted_next_nodes = [:was_red, :wasnt_red]
-      next_node(permitted: permitted_next_nodes) do
-        colour == 'red' ? :was_red : :wasnt_red
-      end
-    }
-    initial_state = SmartAnswer::State.new(q.name)
-    initial_state.colour = 'red'
-    new_state = q.transition(initial_state, 'anything')
-    assert_equal :was_red, new_state.current_node
-  end
-
-  should "next_node block is passed input" do
-    input_was = nil
-    q = SmartAnswer::Question::Base.new(nil, :example) {
-      next_node(permitted: [:done]) do |input|
-        input_was = input
-        :done
-      end
-    }
-    initial_state = SmartAnswer::State.new(q.name)
-    new_state = q.transition(initial_state, 'something')
-    assert_equal 'something', input_was
-  end
-
-  should "Input can be saved into the state" do
-    q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
-      save_input_as :colour_preference
-      next_node :done
+  context '#transition' do
+    should "copy values from initial state to new state" do
+      q = SmartAnswer::Question::Base.new(nil, :example) {
+        next_node :done
+      }
+      initial_state = SmartAnswer::State.new(q.name)
+      initial_state.something_else = "Carried over"
+      new_state = q.transition(initial_state, :yes)
+      assert_equal "Carried over", new_state.something_else
     end
-    initial_state = SmartAnswer::State.new(q.name)
-    new_state = q.transition(initial_state, :red)
-    assert_equal :red, new_state.colour_preference
-  end
 
-  should "Input sequence is saved into responses" do
-    q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) {
-      next_node :done
-    }
-    initial_state = SmartAnswer::State.new(q.name)
-    new_state = q.transition(initial_state, :red)
-    assert_equal [:red], new_state.responses
-  end
-
-  should "Node path is saved in state" do
-    q = SmartAnswer::Question::Base.new(nil, :favourite_colour?)
-    q.next_node :done
-    initial_state = SmartAnswer::State.new(q.name)
-    initial_state.current_node = q.name
-    new_state = q.transition(initial_state, :red)
-    assert_equal [:favourite_colour?], new_state.path
-  end
-
-  should "Can calculate other variables based on input" do
-    q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
-      calculate :complementary_colour do |response|
-        response == :red ? :green : :red
-      end
-      next_node :done
+    should "set current_node to value returned from next_node_for" do
+      q = SmartAnswer::Question::Base.new(nil, :example) {
+        next_node :done
+      }
+      initial_state = SmartAnswer::State.new(q.name)
+      q.stubs(:next_node_for).returns(:done)
+      new_state = q.transition(initial_state, :anything)
+      assert_equal :done, new_state.current_node
     end
-    initial_state = SmartAnswer::State.new(q.name)
-    new_state = q.transition(initial_state, :red)
-    assert_equal :green, new_state.complementary_colour
-    assert new_state.frozen?
-  end
 
-  should "Can calculate other variables based on saved input" do
-    q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
-      save_input_as :colour_preference
-      calculate :complementary_colour do
-        colour_preference == :red ? :green : :red
-      end
-      next_node :done
+    should "set current_node to node key passed into next_node method" do
+      q = SmartAnswer::Question::Base.new(nil, :example) {
+        next_node :done
+      }
+      initial_state = SmartAnswer::State.new(q.name)
+      new_state = q.transition(initial_state, :anything)
+      assert_equal :done, new_state.current_node
     end
-    initial_state = SmartAnswer::State.new(q.name)
-    new_state = q.transition(initial_state, :red)
-    assert_equal :green, new_state.complementary_colour
-    assert new_state.frozen?
-  end
 
-  should "Can perform next_node_calculation which is evaluated before next_node" do
-    q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
-      next_node_calculation :complementary_colour do |response|
-        response == :red ? :green : :red
-      end
-      next_node_calculation :blah do
-        "blah"
-      end
-      next_node(permitted: [:done]) do
-        :done if complementary_colour == :green
-      end
+    should "set current_node to result of calling next_node block" do
+      q = SmartAnswer::Question::Base.new(nil, :example) {
+        next_node(permitted: [:done_done]) { :done_done }
+      }
+      initial_state = SmartAnswer::State.new(q.name)
+      new_state = q.transition(initial_state, :anything)
+      assert_equal :done_done, new_state.current_node
     end
-    initial_state = SmartAnswer::State.new(q.name)
-    new_state = q.transition(initial_state, :red)
-    assert_equal :green, new_state.complementary_colour
-    assert_equal "blah", new_state.blah
-    assert_equal :done, new_state.current_node
+
+    should "make state available to code in next_node block" do
+      q = SmartAnswer::Question::Base.new(nil, :example) {
+        permitted_next_nodes = [:was_red, :wasnt_red]
+        next_node(permitted: permitted_next_nodes) do
+          colour == 'red' ? :was_red : :wasnt_red
+        end
+      }
+      initial_state = SmartAnswer::State.new(q.name)
+      initial_state.colour = 'red'
+      new_state = q.transition(initial_state, 'anything')
+      assert_equal :was_red, new_state.current_node
+    end
+
+    should "pass input to next_node block" do
+      input_was = nil
+      q = SmartAnswer::Question::Base.new(nil, :example) {
+        next_node(permitted: [:done]) do |input|
+          input_was = input
+          :done
+        end
+      }
+      initial_state = SmartAnswer::State.new(q.name)
+      new_state = q.transition(initial_state, 'something')
+      assert_equal 'something', input_was
+    end
+
+    should "make save_input_as method available to code in next_node block" do
+      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
+        save_input_as :colour_preference
+        next_node :done
+      end
+      initial_state = SmartAnswer::State.new(q.name)
+      new_state = q.transition(initial_state, :red)
+      assert_equal :red, new_state.colour_preference
+    end
+
+    should "save input sequence on new state" do
+      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) {
+        next_node :done
+      }
+      initial_state = SmartAnswer::State.new(q.name)
+      new_state = q.transition(initial_state, :red)
+      assert_equal [:red], new_state.responses
+    end
+
+    should "save path on new state" do
+      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?)
+      q.next_node :done
+      initial_state = SmartAnswer::State.new(q.name)
+      initial_state.current_node = q.name
+      new_state = q.transition(initial_state, :red)
+      assert_equal [:favourite_colour?], new_state.path
+    end
+
+    should "execute calculate block with response and save result on new state" do
+      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
+        calculate :complementary_colour do |response|
+          response == :red ? :green : :red
+        end
+        next_node :done
+      end
+      initial_state = SmartAnswer::State.new(q.name)
+      new_state = q.transition(initial_state, :red)
+      assert_equal :green, new_state.complementary_colour
+      assert new_state.frozen?
+    end
+
+    should "execute calculate block with saved input and save result on new state" do
+      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
+        save_input_as :colour_preference
+        calculate :complementary_colour do
+          colour_preference == :red ? :green : :red
+        end
+        next_node :done
+      end
+      initial_state = SmartAnswer::State.new(q.name)
+      new_state = q.transition(initial_state, :red)
+      assert_equal :green, new_state.complementary_colour
+      assert new_state.frozen?
+    end
+
+    should "execute next_node_calculation block before next_node" do
+      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
+        next_node_calculation :complementary_colour do |response|
+          response == :red ? :green : :red
+        end
+        next_node_calculation :blah do
+          "blah"
+        end
+        next_node(permitted: [:done]) do
+          :done if complementary_colour == :green
+        end
+      end
+      initial_state = SmartAnswer::State.new(q.name)
+      new_state = q.transition(initial_state, :red)
+      assert_equal :green, new_state.complementary_colour
+      assert_equal "blah", new_state.blah
+      assert_equal :done, new_state.current_node
+    end
   end
 
   context '#next_node_for' do

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -4,30 +4,30 @@ class QuestionBaseTest < ActiveSupport::TestCase
   context '#next_node' do
     should 'raise exception if called with block but no permitted next nodes' do
       e = assert_raises(ArgumentError) do
-        SmartAnswer::Question::Base.new(nil, :example) {
+        SmartAnswer::Question::Base.new(nil, :example) do
           next_node do
             :done
           end
-        }
+        end
       end
       assert_equal 'You must specify at least one permitted next node', e.message
     end
 
     should 'single next node key must be supplied if next_node called without block' do
       e = assert_raises(ArgumentError) do
-        SmartAnswer::Question::Base.new(nil, :example) {
+        SmartAnswer::Question::Base.new(nil, :example) do
           next_node
-        }
+        end
       end
       assert_equal 'You must specify a block or a single next node key', e.message
     end
 
     should 'raise exception if next_node is invoked multiple times' do
       e = assert_raises do
-        SmartAnswer::Question::Base.new(nil, :example) {
+        SmartAnswer::Question::Base.new(nil, :example) do
           next_node :outcome_one
           next_node :outcome_two
-        }
+        end
       end
       assert_equal 'Multiple calls to next_node are not allowed', e.message
     end
@@ -35,27 +35,27 @@ class QuestionBaseTest < ActiveSupport::TestCase
 
   context '#permitted_next_nodes' do
     should 'return permitted next nodes if next_node called with block' do
-      q = SmartAnswer::Question::Base.new(nil, :example) {
+      q = SmartAnswer::Question::Base.new(nil, :example) do
         next_node(permitted: [:done]) do
           :done
         end
-      }
+      end
       assert_equal [:done], q.permitted_next_nodes
     end
 
     should 'return permitted next nodes if next_node called without block' do
-      q = SmartAnswer::Question::Base.new(nil, :example) {
+      q = SmartAnswer::Question::Base.new(nil, :example) do
         next_node :done
-      }
+      end
       assert_equal [:done], q.permitted_next_nodes
     end
   end
 
   context '#transition' do
     should "copy values from initial state to new state" do
-      q = SmartAnswer::Question::Base.new(nil, :example) {
+      q = SmartAnswer::Question::Base.new(nil, :example) do
         next_node :done
-      }
+      end
       initial_state = SmartAnswer::State.new(q.name)
       initial_state.something_else = "Carried over"
       new_state = q.transition(initial_state, :yes)
@@ -63,9 +63,9 @@ class QuestionBaseTest < ActiveSupport::TestCase
     end
 
     should "set current_node to value returned from next_node_for" do
-      q = SmartAnswer::Question::Base.new(nil, :example) {
+      q = SmartAnswer::Question::Base.new(nil, :example) do
         next_node :done
-      }
+      end
       initial_state = SmartAnswer::State.new(q.name)
       q.stubs(:next_node_for).returns(:done)
       new_state = q.transition(initial_state, :anything)
@@ -73,30 +73,30 @@ class QuestionBaseTest < ActiveSupport::TestCase
     end
 
     should "set current_node to node key passed into next_node method" do
-      q = SmartAnswer::Question::Base.new(nil, :example) {
+      q = SmartAnswer::Question::Base.new(nil, :example) do
         next_node :done
-      }
+      end
       initial_state = SmartAnswer::State.new(q.name)
       new_state = q.transition(initial_state, :anything)
       assert_equal :done, new_state.current_node
     end
 
     should "set current_node to result of calling next_node block" do
-      q = SmartAnswer::Question::Base.new(nil, :example) {
+      q = SmartAnswer::Question::Base.new(nil, :example) do
         next_node(permitted: [:done_done]) { :done_done }
-      }
+      end
       initial_state = SmartAnswer::State.new(q.name)
       new_state = q.transition(initial_state, :anything)
       assert_equal :done_done, new_state.current_node
     end
 
     should "make state available to code in next_node block" do
-      q = SmartAnswer::Question::Base.new(nil, :example) {
+      q = SmartAnswer::Question::Base.new(nil, :example) do
         permitted_next_nodes = [:was_red, :wasnt_red]
         next_node(permitted: permitted_next_nodes) do
           colour == 'red' ? :was_red : :wasnt_red
         end
-      }
+      end
       initial_state = SmartAnswer::State.new(q.name)
       initial_state.colour = 'red'
       new_state = q.transition(initial_state, 'anything')
@@ -105,12 +105,12 @@ class QuestionBaseTest < ActiveSupport::TestCase
 
     should "pass input to next_node block" do
       input_was = nil
-      q = SmartAnswer::Question::Base.new(nil, :example) {
+      q = SmartAnswer::Question::Base.new(nil, :example) do
         next_node(permitted: [:done]) do |input|
           input_was = input
           :done
         end
-      }
+      end
       initial_state = SmartAnswer::State.new(q.name)
       new_state = q.transition(initial_state, 'something')
       assert_equal 'something', input_was
@@ -127,9 +127,9 @@ class QuestionBaseTest < ActiveSupport::TestCase
     end
 
     should "save input sequence on new state" do
-      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) {
+      q = SmartAnswer::Question::Base.new(nil, :favourite_colour?) do
         next_node :done
-      }
+      end
       initial_state = SmartAnswer::State.new(q.name)
       new_state = q.transition(initial_state, :red)
       assert_equal [:red], new_state.responses
@@ -193,10 +193,10 @@ class QuestionBaseTest < ActiveSupport::TestCase
 
   context '#next_node_for' do
     should "raise an exception if next_node returns key not in permitted_next_nodes" do
-      q = SmartAnswer::Question::Base.new(flow = nil, :question_name) {
+      q = SmartAnswer::Question::Base.new(flow = nil, :question_name) do
         permitted_next_nodes = [:allowed_next_node_1, :allowed_next_node_2]
         next_node(permitted: permitted_next_nodes) { :not_allowed_next_node }
-      }
+      end
       state = SmartAnswer::State.new(q.name)
 
       expected_message = "Next node (not_allowed_next_node) not in list of permitted next nodes (allowed_next_node_1 and allowed_next_node_2)"
@@ -209,11 +209,11 @@ class QuestionBaseTest < ActiveSupport::TestCase
     should "raise an exception if next_node does not return a node key" do
       question_name = :example
       responses = [:blue, :red]
-      q = SmartAnswer::Question::Base.new(nil, question_name) {
+      q = SmartAnswer::Question::Base.new(nil, question_name) do
         next_node(permitted: [:skipped]) do
           :skipped if false
         end
-      }
+      end
       initial_state = SmartAnswer::State.new(q.name)
       initial_state.responses << responses[0]
       error = assert_raises(SmartAnswer::Question::Base::NextNodeUndefined) do
@@ -226,9 +226,9 @@ class QuestionBaseTest < ActiveSupport::TestCase
     should "raise an exception if next_node was not called for question" do
       question_name = :example
       responses = [:blue, :red]
-      q = SmartAnswer::Question::Base.new(nil, question_name) {
+      q = SmartAnswer::Question::Base.new(nil, question_name) do
         # no call to next_node
-      }
+      end
       initial_state = SmartAnswer::State.new(q.name)
       initial_state.responses << responses[0]
       error = assert_raises(SmartAnswer::Question::Base::NextNodeUndefined) do


### PR DESCRIPTION
This follows on from #2319 and is further work in preparation for a proper version of #2311.

I was finding it increasingly hard to read and edit the unit test for `SmartAnswer::Question::Base`, so I decided to to some preparatory refactoring.

The main change in this PR is the grouping together of related tests into Shoulda contexts. I hope the commits are small enough that you can see what's going on in the diffs - you might need to ignore whitespace changes to make things clearer. I've also extracted a method to DRY up the test code a bit.

See the individual commit notes for details.

Given that I've only made changes to a single unit test and no "production" code, these changes should be pretty low risk, but it would be good if someone could give them the once over.