### PR TITLE
Remove action mailer dependency

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,9 +1,8 @@
 require File.expand_path('../boot', __FILE__)
 
-# Don't include all of rails, we don't need activerecord
+# Don't include all of rails, we don't need activerecord or action_mailer
 require "action_controller/railtie"
 require "active_model/railtie"
-require "action_mailer/railtie"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,9 +12,6 @@ SmartAnswers::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send
-  config.action_mailer.raise_delivery_errors = false
-
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,9 +48,6 @@ SmartAnswers::Application.configure do
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
   # config.assets.precompile += %w( search.js )
 
-  # Disable delivery errors, bad email addresses will be ignored
-  # config.action_mailer.raise_delivery_errors = false
-
   # Enable threaded mode
   # config.threadsafe!
 
@@ -62,9 +59,6 @@ SmartAnswers::Application.configure do
   config.active_support.deprecation = :notify
 
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
-
-  config.action_mailer.default_url_options = { host: Plek.new.find('smartanswers') }
-  config.action_mailer.delivery_method = :ses
 
   if ENV['RUNNING_ON_HEROKU'].blank?
     # Enable JSON-style logging

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,11 +23,6 @@ SmartAnswers::Application.configure do
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types


### PR DESCRIPTION
It doesn't appear smart answers uses any of the Rails mailer functionality, so this PR removes the requiring of the `action_mailer` gem that is in the project Gemfile.lock via the `rails` dependency, and removes the mailer related config and directory in the application.

For further detail regarding why `action_mailer` may exist in smart_answers (along with other gov.uk projects) see alphagov/frontend#930