### PR TITLE
Remove Japan from marriage-abroad outcome_os_consular_cni

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -192,7 +192,7 @@
 
 
     <% end %>
-    <% unless %w(germany japan).include?(calculator.ceremony_country) %>
+    <% unless %w(germany).include?(calculator.ceremony_country) %>
       <% if calculator.ceremony_country == 'macedonia' %>
         Contact a notary public or British Embassy in Macedonia to get advice:
 
@@ -225,7 +225,7 @@
     <%= render partial: 'required_supporting_documents_philippines.govspeak.erb' %>
   <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'macao' %>
     <%= render partial: 'required_supporting_documents_macao.govspeak.erb' %>
-  <% elsif calculator.resident_of_ceremony_country? && %w(germany japan).exclude?(calculator.ceremony_country) %>
+  <% elsif calculator.resident_of_ceremony_country? && %w(germany).exclude?(calculator.ceremony_country) %>
     <% if birth_cert_inclusion && notary_public_inclusion %>
       You’ll need to provide supporting documents, including:
 
@@ -282,7 +282,7 @@
 
     <% end %>
   <% else %>
-    <% if calculator.partner_is_same_sex? || no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) && (cni_notary_public_countries + %w(japan macedonia) - %w(greece tunisia)).include?(calculator.ceremony_country) %>
+    <% if calculator.partner_is_same_sex? || no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) && (cni_notary_public_countries + %w(macedonia) - %w(greece tunisia)).include?(calculator.ceremony_country) %>
       <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
 
     <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -3,22 +3,21 @@
 <% end %>
 
 <% content_for :body do %>
-  <% if %(japan).exclude?(calculator.ceremony_country) %>
-    <% if calculator.resident_of_uk? %>
-      <% if calculator.ceremony_country_is_dutch_caribbean_island? %>
-        <%= calculator.country_name_uppercase_prefix %> is one of the Dutch Caribbean islands.
+  <% if calculator.resident_of_uk? %>
+    <% if calculator.ceremony_country_is_dutch_caribbean_island? %>
+      <%= calculator.country_name_uppercase_prefix %> is one of the Dutch Caribbean islands.
 
-        Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local marriage laws, including what documents you’ll need
+      Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local marriage laws, including what documents you’ll need
 
-      <% else %>
-        <%= render partial: 'contact_embassy_of_ceremony_country_in_uk_marriage.govspeak.erb',
-                   locals: { calculator: calculator } %>
-      <% end %>
     <% else %>
-      <%= render partial: 'contact_local_authorities_in_country_marriage.govspeak.erb',
+      <%= render partial: 'contact_embassy_of_ceremony_country_in_uk_marriage.govspeak.erb',
                  locals: { calculator: calculator } %>
     <% end %>
+  <% else %>
+    <%= render partial: 'contact_local_authorities_in_country_marriage.govspeak.erb',
+               locals: { calculator: calculator } %>
   <% end %>
+
   <% if %w(jordan oman qatar).include?(calculator.ceremony_country) %>
     <%= render partial: 'gulf_states_os_consular_cni.govspeak.erb',
                locals: { calculator: calculator } %>
@@ -28,14 +27,12 @@
 
     <% end %>
   <% end %>
-  <% if %(japan).exclude?(calculator.ceremony_country) %>
 
-    <% if calculator.resident_of_ceremony_country? %>
-      <%= render partial: 'get_legal_advice.govspeak.erb' %>
-    <% else %>
-      <%= render partial: 'get_legal_and_travel_advice.govspeak.erb',
-                 locals: { calculator: calculator } %>
-    <% end %>
+  <% if calculator.resident_of_ceremony_country? %>
+    <%= render partial: 'get_legal_advice.govspeak.erb' %>
+  <% else %>
+    <%= render partial: 'get_legal_and_travel_advice.govspeak.erb',
+               locals: { calculator: calculator } %>
   <% end %>
 
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
@@ -344,7 +341,7 @@
 
       [Make an appointment to collect your CNI at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker).
 
-    <% elsif cni_notary_public_countries.include?(calculator.ceremony_country) || calculator.ceremony_country == 'japan' %>
+    <% elsif cni_notary_public_countries.include?(calculator.ceremony_country) %>
       ###What happens next
 
       The embassy or notary public will charge a fee for taking the oath.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -3,12 +3,6 @@
 <% end %>
 
 <% content_for :body do %>
-  <% if calculator.ceremony_country == 'japan' %>
-    Contact your [nearest embassy or consulate](http://www.mofa.go.jp/about/emb_cons/over/index.html) of Japan to find out about local marriage laws, including what documents you’ll need.
-
-    ^You should [get legal advice](/government/publications/japan-list-of-lawyers) and check the [travel advice for Japan](/foreign-travel-advice/japan) before making any plans.^
-
-  <% end %>
   <% if %(japan).exclude?(calculator.ceremony_country) %>
     <% if calculator.resident_of_uk? %>
       <% if calculator.ceremony_country_is_dutch_caribbean_island? %>
@@ -271,22 +265,7 @@
 
     <% end %>
   <% end %>
-  <% if calculator.resident_of_ceremony_country? %>
-    <% if calculator.ceremony_country == 'japan' %>
-      <%= render partial: 'contact_method.govspeak.erb',
-                 locals: { calculator: calculator } %>
 
-      ##Giving notice of marriage
-
-      You’ll need to provide supporting documents, including:
-
-      - your passport, showing that you’ve been in Japan for at least 3 days (if you’ve been outside of Japan for a short period and recently returned, a residence visa is normally acceptable)
-      - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
-      - evidence of parental consent if you’re below the age you can legally get married without consent in the country you’re from (eg 18 in England and Wales)
-      - equivalent documents for your partner
-
-    <% end %>
-  <% end %>
   <% if calculator.resident_of_ceremony_country? %>
     <% if calculator.ceremony_country == 'greece' %>
       You’ll need to fill in forms for your notice of marriage, and complete an affirmation (non-religious) or affidavit (religious) stating that you’re free to marry.

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -110,7 +110,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_bot.govspeak.erb: f9c
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_cambodia.govspeak.erb: 5dbe3487ec6513617f2f00ed89b30672
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_colombia.govspeak.erb: a0860f0581acfa1e5533f3114569301c
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_commonwealth.govspeak.erb: 7ed275a2c4647d85076d77ddf3eda685
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb: 58baa72cd8735ab8ac8145fce355c3c7
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb: ed51c20edf5fc0df14131f231779f0b3
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_france_or_fot.govspeak.erb: 71d74db77499d680423d7586ba9e0e61
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_germany.govspeak.erb: 3f5150acb8ad77d3a5d56909e60a8000
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_hong_kong.govspeak.erb: 9c1686c0a3ba24dff0297e4e04f2fae6


### PR DESCRIPTION
At some point, information about opposite sex marriages in Japan was moved from the outcome_os_consular_cni outcome to outcome_os_japan. This branch removes the now unused code from outcome_os_consular_cni.
