### PR TITLE
Fix marriage-abroad test data

### DIFF
--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/marriage-abroad.rb: 4bfc3759306b93273cd92f1c66a64d24
-test/data/marriage-abroad-questions-and-responses.yml: 85feca37588fbe9da8d56b382e6cdc23
-test/data/marriage-abroad-responses-and-expected-results.yml: e5f779e927f25f4b67316adb9dd54a57
+test/data/marriage-abroad-questions-and-responses.yml: 87f39a00d77fe0566a79e5cddbca765e
+test/data/marriage-abroad-responses-and-expected-results.yml: c388fc820b41309bb7594e9ef908a70e
 lib/smart_answer_flows/marriage-abroad/marriage_abroad.govspeak.erb: b4d0cfc1c7c4776d968c9b5b6df85027
 lib/smart_answer_flows/marriage-abroad/outcomes/_affirmation_os_translation_in_local_language_text.govspeak.erb: 4ac964ce5e41e3efaf0f43d11c71b2b7
 lib/smart_answer_flows/marriage-abroad/outcomes/_appointment_documents_in_vietnam.govspeak.erb: 6390e13560110a71b8a3c0dc018ff4cf

--- a/test/data/marriage-abroad-questions-and-responses.yml
+++ b/test/data/marriage-abroad-questions-and-responses.yml
@@ -85,6 +85,7 @@
 - serbia
 - singapore
 - slovakia
+- slovenia
 - south-africa
 - south-korea
 - spain

--- a/test/data/marriage-abroad-responses-and-expected-results.yml
+++ b/test/data/marriage-abroad-responses-and-expected-results.yml
@@ -2331,7 +2331,7 @@
   - uk
   - partner_british
   - same_sex
-  :next_node: :outcome_os_belarus
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -2354,7 +2354,7 @@
   - uk
   - partner_local
   - same_sex
-  :next_node: :outcome_os_belarus
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -2377,7 +2377,7 @@
   - uk
   - partner_other
   - same_sex
-  :next_node: :outcome_os_belarus
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses:
@@ -2406,7 +2406,7 @@
   - ceremony_country
   - partner_british
   - same_sex
-  :next_node: :outcome_os_belarus
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -2429,7 +2429,7 @@
   - ceremony_country
   - partner_local
   - same_sex
-  :next_node: :outcome_os_belarus
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -2452,7 +2452,7 @@
   - ceremony_country
   - partner_other
   - same_sex
-  :next_node: :outcome_os_belarus
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses:
@@ -2481,7 +2481,7 @@
   - third_country
   - partner_british
   - same_sex
-  :next_node: :outcome_os_belarus
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -2504,7 +2504,7 @@
   - third_country
   - partner_local
   - same_sex
-  :next_node: :outcome_os_belarus
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -2527,7 +2527,7 @@
   - third_country
   - partner_other
   - same_sex
-  :next_node: :outcome_os_belarus
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :country_of_ceremony?
   :responses:
@@ -4416,7 +4416,7 @@
   - uk
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_affirmation
+  :next_node: :outcome_os_cambodia
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -7676,7 +7676,7 @@
   - uk
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_germany
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -15083,7 +15083,7 @@
   - uk
   - partner_other
   - same_sex
-  :next_node: :outcome_os_oman
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses:
@@ -17537,463 +17537,463 @@
   :outcome_node: true
 - :current_node: :country_of_ceremony?
   :responses:
-  - seychelles
+  - saudi-arabia
   :next_node: :legal_residency?
   :outcome_node: false
 - :current_node: :legal_residency?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   :next_node: :what_is_your_partners_nationality?
   :outcome_node: false
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   - partner_british
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_other_countries
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   - partner_british
   - same_sex
-  :next_node: :outcome_ss_marriage_not_possible
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   - partner_local
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_other_countries
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   - partner_local
   - same_sex
-  :next_node: :outcome_ss_marriage_not_possible
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   - partner_other
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_other_countries
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - uk
   - partner_other
   - same_sex
-  :next_node: :outcome_ss_marriage_not_possible
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   :next_node: :what_is_your_partners_nationality?
   :outcome_node: false
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   - partner_british
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_no_cni
+  :next_node: :outcome_os_other_countries
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   - partner_british
   - same_sex
-  :next_node: :outcome_ss_marriage_not_possible
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   - partner_local
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_no_cni
+  :next_node: :outcome_os_other_countries
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   - partner_local
   - same_sex
-  :next_node: :outcome_ss_marriage_not_possible
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   - partner_other
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_no_cni
+  :next_node: :outcome_os_other_countries
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - ceremony_country
   - partner_other
   - same_sex
-  :next_node: :outcome_ss_marriage_not_possible
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   :next_node: :what_is_your_partners_nationality?
   :outcome_node: false
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   - partner_british
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_no_cni
+  :next_node: :outcome_os_other_countries
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   - partner_british
   - same_sex
-  :next_node: :outcome_ss_marriage_not_possible
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   - partner_local
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_no_cni
+  :next_node: :outcome_os_other_countries
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   - partner_local
   - same_sex
-  :next_node: :outcome_ss_marriage_not_possible
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   - partner_other
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_no_cni
+  :next_node: :outcome_os_other_countries
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - seychelles
+  - saudi-arabia
   - third_country
   - partner_other
   - same_sex
-  :next_node: :outcome_ss_marriage_not_possible
+  :next_node: :outcome_cp_all_other_countries
   :outcome_node: true
 - :current_node: :country_of_ceremony?
   :responses:
-  - saudi-arabia
+  - seychelles
   :next_node: :legal_residency?
   :outcome_node: false
 - :current_node: :legal_residency?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   :next_node: :what_is_your_partners_nationality?
   :outcome_node: false
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   - partner_british
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_other_countries
+  :next_node: :outcome_os_commonwealth
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   - partner_british
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_ss_marriage_not_possible
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   - partner_local
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_other_countries
+  :next_node: :outcome_os_commonwealth
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   - partner_local
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_ss_marriage_not_possible
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   - partner_other
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_other_countries
+  :next_node: :outcome_os_commonwealth
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - uk
   - partner_other
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_ss_marriage_not_possible
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   :next_node: :what_is_your_partners_nationality?
   :outcome_node: false
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   - partner_british
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_other_countries
+  :next_node: :outcome_os_commonwealth
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   - partner_british
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_ss_marriage_not_possible
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   - partner_local
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_other_countries
+  :next_node: :outcome_os_commonwealth
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   - partner_local
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_ss_marriage_not_possible
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   - partner_other
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_other_countries
+  :next_node: :outcome_os_commonwealth
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - ceremony_country
   - partner_other
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_ss_marriage_not_possible
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   :next_node: :what_is_your_partners_nationality?
   :outcome_node: false
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   - partner_british
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_other_countries
+  :next_node: :outcome_os_commonwealth
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   - partner_british
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_ss_marriage_not_possible
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   - partner_local
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_other_countries
+  :next_node: :outcome_os_commonwealth
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   - partner_local
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_ss_marriage_not_possible
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   - partner_other
   :next_node: :partner_opposite_or_same_sex?
   :outcome_node: false
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_other_countries
+  :next_node: :outcome_os_commonwealth
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
-  - saudi-arabia
+  - seychelles
   - third_country
   - partner_other
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_ss_marriage_not_possible
   :outcome_node: true
 - :current_node: :country_of_ceremony?
   :responses:
@@ -18717,7 +18717,7 @@
   - uk
   - partner_british
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_cp_or_equivalent
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -18740,7 +18740,7 @@
   - uk
   - partner_local
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_cp_or_equivalent
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -18763,7 +18763,7 @@
   - uk
   - partner_other
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_cp_or_equivalent
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses:
@@ -18792,7 +18792,7 @@
   - ceremony_country
   - partner_british
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_cp_or_equivalent
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -18815,7 +18815,7 @@
   - ceremony_country
   - partner_local
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_cp_or_equivalent
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -18838,7 +18838,7 @@
   - ceremony_country
   - partner_other
   - same_sex
-  :next_node: :outcome_os_slovenia
+  :next_node: :outcome_cp_or_equivalent
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses:
@@ -18859,7 +18859,7 @@
   - third_country
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_slovenia
+  :next_node: :outcome_consular_cni_os_residing_in_third_country
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -18867,7 +18867,7 @@
   - third_country
   - partner_british
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_cp_or_equivalent
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -18882,7 +18882,7 @@
   - third_country
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_slovenia
+  :next_node: :outcome_consular_cni_os_residing_in_third_country
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -18890,7 +18890,7 @@
   - third_country
   - partner_local
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_cp_or_equivalent
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses:
@@ -18905,7 +18905,7 @@
   - third_country
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_slovenia
+  :next_node: :outcome_consular_cni_os_residing_in_third_country
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -18913,7 +18913,7 @@
   - third_country
   - partner_other
   - same_sex
-  :next_node: :outcome_cp_all_other_countries
+  :next_node: :outcome_cp_or_equivalent
   :outcome_node: true
 - :current_node: :country_of_ceremony?
   :responses:


### PR DESCRIPTION
I noticed that the responses-and-expected-results.yml file was no longer in sync with the questions-and-responses.yml.

This branch updates them so that they're back in sync.

The marriage-abroad regression tests continue to pass after these changes.