### PR TITLE
Revert "Remove action mailer dependency"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,8 +1,9 @@
 require File.expand_path('../boot', __FILE__)
 
-# Don't include all of rails, we don't need activerecord or action_mailer
+# Don't include all of rails, we don't need activerecord
 require "action_controller/railtie"
 require "active_model/railtie"
+require "action_mailer/railtie"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,6 +12,9 @@ SmartAnswers::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  # Don't care if the mailer can't send
+  config.action_mailer.raise_delivery_errors = false
+
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,6 +48,9 @@ SmartAnswers::Application.configure do
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
   # config.assets.precompile += %w( search.js )
 
+  # Disable delivery errors, bad email addresses will be ignored
+  # config.action_mailer.raise_delivery_errors = false
+
   # Enable threaded mode
   # config.threadsafe!
 
@@ -59,6 +62,9 @@ SmartAnswers::Application.configure do
   config.active_support.deprecation = :notify
 
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
+
+  config.action_mailer.default_url_options = { host: Plek.new.find('smartanswers') }
+  config.action_mailer.delivery_method = :ses
 
   if ENV['RUNNING_ON_HEROKU'].blank?
     # Enable JSON-style logging

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,6 +23,11 @@ SmartAnswers::Application.configure do
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false
 
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :test delivery method accumulates sent emails in the
+  # ActionMailer::Base.deliveries array.
+  config.action_mailer.delivery_method = :test
+
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types


### PR DESCRIPTION
Reverts alphagov/smart-answers#2348

There seems to be a post deploy task that currently copies an initialiser ruby with `action_mailer` related configuration into the smart answers `config/intialisers` directory, which causes all the subsequent post-deploy tasks to fail afterwards, for example - as seen on integration:
```
ERROR MESSAGE:
NameError: uninitialized constant ActionMailer

WHERE:
rake#RAILS_ENV=production RAILS_GROUPS=assets assets:precompile


URL:
BROWSER:
100.0%	N/A


FULL BACKTRACE:
/data/vhost/smartanswers.integration.publishing.service.gov.uk/releases/20160311160629/config/initializers/mailer.rb:1
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/engine.rb:652
[GEM_ROOT]/gems/activesupport-4.2.6/lib/active_support/notifications.rb:166
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/engine.rb:651
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/engine.rb:616
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/engine.rb:615
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/engine.rb:615
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/initializable.rb:30
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/initializable.rb:30
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/initializable.rb:55
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:228
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:350
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:422
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:431
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:421
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/initializable.rb:44
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/initializable.rb:44
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:415
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:415
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:349
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:347
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:347
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:347
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:226
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:205
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/initializable.rb:54
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/application.rb:352
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/railtie.rb:194
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/railtie.rb:194
/data/vhost/smartanswers.integration.publishing.service.gov.uk/releases/20160311160629/config/environment.rb:5
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/application.rb:328
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/application.rb:328
[GEM_ROOT]/gems/railties-4.2.6/lib/rails/application.rb:457
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:240
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:235
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:235
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:179
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:214
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:172
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:165
[GEM_ROOT]/gems/sprockets-rails-3.0.4/lib/sprockets/rails/task.rb:62
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:240
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:235
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:235
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:179
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:214
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:172
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:201
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:199
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:199
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:178
/usr/lib/rbenv/versions/2.3.0/lib/ruby/2.3.0/monitor.rb:214
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:172
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/task.rb:165
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/application.rb:150
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/application.rb:106
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/application.rb:106
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/application.rb:106
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/application.rb:115
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/application.rb:100
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/application.rb:78
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/application.rb:176
[GEM_ROOT]/gems/rake-10.5.0/lib/rake/application.rb:75
[GEM_ROOT]/gems/rake-10.5.0/bin/rake:33
[GEM_ROOT]/bin/rake:23
[GEM_ROOT]/bin/rake:23
```
This PR reverts the removal of `action_mailer` until that script has been updated.