### PR TITLE
Prevent duplicate permitted next nodes

### DIFF
--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -34,7 +34,7 @@ module SmartAnswer
           parser = NextNodeBlock::Parser.new
           @permitted_next_nodes = parser.possible_next_nodes(@next_node_block)
         end
-        @permitted_next_nodes
+        @permitted_next_nodes.uniq
       end
 
       def validate(message = nil, &block)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -306,7 +306,6 @@ module SmartAnswer
           :not_earned_enough,
           :maximum_entitlement_reached,
           :entitled_to_sick_pay,
-          :maximum_entitlement_reached,
           :not_entitled_3_days_not_paid
         ]
         next_node(permitted: permitted_next_nodes) do |response|

--- a/lib/smart_answer_flows/pay-leave-for-parents.rb
+++ b/lib/smart_answer_flows/pay-leave-for-parents.rb
@@ -127,7 +127,6 @@ module SmartAnswer
           :outcome_mat_pay,
           :partner_started_working_before_continuity_start_date,
           :partner_worked_at_least_26_weeks,
-          :outcome_mat_leave_mat_pay,
           :mother_worked_at_least_26_weeks
         ]
         next_node(permitted: permitted_next_nodes) do |response|

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-statutory-sick-pay.rb: 0f9e3f075417480564caa5d34b3a4eda
+lib/smart_answer_flows/calculate-statutory-sick-pay.rb: e6ecafcf953264457fa795c583b08c27
 test/data/calculate-statutory-sick-pay-questions-and-responses.yml: dfd8baf65a8c26430cf17958e8908202
 test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: b42519fbb030e7eaf0912d1de0b8ff47
 lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: f91dc1d321c164a06271889100875600

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/pay-leave-for-parents.rb: 1c29ac285bf104fbda7c7592a590aae1
+lib/smart_answer_flows/pay-leave-for-parents.rb: 30c6bb47eebae4f5a3130103c45534b4
 test/data/pay-leave-for-parents-questions-and-responses.yml: 6aae67d1b585e8445878fb2994bac8d1
 test/data/pay-leave-for-parents-responses-and-expected-results.yml: 2cdd65aad00267bdf9a534e22858f03d
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_leave.govspeak.erb: dcede84d936f876a3c91c1457c3afc01

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -32,39 +32,45 @@ class QuestionBaseTest < ActiveSupport::TestCase
   end
 
   context '#permitted_next_nodes' do
-    should 'return permitted next nodes if next_node called with block' do
-      @question.next_node(permitted: [:done]) do
-        :done
+    context 'next_node called without block' do
+      should 'return the one node passed to next_node' do
+        @question.next_node :done
+        assert_equal [:done], @question.permitted_next_nodes
       end
-      assert_equal [:done], @question.permitted_next_nodes
     end
 
-    should 'return permitted next nodes if next_node called without block' do
-      @question.next_node :done
-      assert_equal [:done], @question.permitted_next_nodes
-    end
-
-    should 'return nodes returned via syntactic sugar methods' do
-      @question.next_node(permitted: :auto) do |response|
-        if response == 'yes'
-          outcome :done
-        else
-          question :another_question
+    context 'next_node called with block specifying permitted next nodes' do
+      should 'return the specified permitted next nodes' do
+        @question.next_node(permitted: [:done]) do
+          :done
         end
+        assert_equal [:done], @question.permitted_next_nodes
       end
-      assert_equal [:done, :another_question], @question.permitted_next_nodes
     end
 
-    should 'not return nodes not returned via syntactic sugar methods' do
-      @question.next_node(permitted: :auto) do |response|
-        if response == 'yes'
-          outcome :done
-        else
-          :another_question
+    context 'next_node called with block set to auto-detect permitted next nodes' do
+      should 'return nodes returned via syntactic sugar methods' do
+        @question.next_node(permitted: :auto) do |response|
+          if response == 'yes'
+            outcome :done
+          else
+            question :another_question
+          end
         end
+        assert_equal [:done, :another_question], @question.permitted_next_nodes
       end
-      assert @question.permitted_next_nodes.include?(:done)
-      refute @question.permitted_next_nodes.include?(:another_question)
+
+      should 'not return nodes not returned via syntactic sugar methods' do
+        @question.next_node(permitted: :auto) do |response|
+          if response == 'yes'
+            outcome :done
+          else
+            :another_question
+          end
+        end
+        assert @question.permitted_next_nodes.include?(:done)
+        refute @question.permitted_next_nodes.include?(:another_question)
+      end
     end
   end
 

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -46,6 +46,13 @@ class QuestionBaseTest < ActiveSupport::TestCase
         end
         assert_equal [:done], @question.permitted_next_nodes
       end
+
+      should 'not return duplicate permitted next nodes' do
+        @question.next_node(permitted: [:done, :done]) do
+          :done
+        end
+        assert_equal [:done], @question.permitted_next_nodes
+      end
     end
 
     context 'next_node called with block set to auto-detect permitted next nodes' do
@@ -70,6 +77,17 @@ class QuestionBaseTest < ActiveSupport::TestCase
         end
         assert @question.permitted_next_nodes.include?(:done)
         refute @question.permitted_next_nodes.include?(:another_question)
+      end
+
+      should 'not return duplicate permitted next nodes' do
+        @question.next_node(permitted: :auto) do |response|
+          if response == 'yes'
+            outcome :done
+          else
+            outcome :done
+          end
+        end
+        assert_equal [:done], @question.permitted_next_nodes
       end
     end
   end


### PR DESCRIPTION
### Manually specified permitted next nodes

It's possible for a developer to accidentally include the same node key in the list of permitted next nodes multiple times. However, from a visualisation point-of-view, we don't want the same node to appear more than once. There were a couple of duplicates in the existing flows and so I've included commits to remove them.

### Automatically detected permitted next nodes

Likewise, when auto-detecting permitted next nodes, it's legitimate for a `next_node` block to have multiple execution paths which return the same next node key. But we still don't want the same node to appear more than once in the visualisation. I've been working on converting all the existing flows to use the auto-detect mechanism and I know that (without this fix) some of them would indeed generate duplicates like this.

### Expected changes

None