### PR TITLE
Remove incorrect permitted next node from check-uk-visa

### DIFF
--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -163,7 +163,6 @@ module SmartAnswer
           :outcome_transit_taiwan,
           :outcome_transit_taiwan_through_border_control,
           :outcome_transit_venezuela,
-          :outcome_visit_waiver
         ]
         next_node(permitted: permitted_next_nodes) do |response|
           calculator.passing_through_uk_border_control_answer = response

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/check-uk-visa.rb: 53e5e3dfa257186c7ccd020df65ac6fd
+lib/smart_answer_flows/check-uk-visa.rb: 41158023166e66efe67de462fa653218
 test/data/check-uk-visa-questions-and-responses.yml: db3081a2a7162f108baa5ff00706c9fd
 test/data/check-uk-visa-responses-and-expected-results.yml: 60d4090bdf290693442b66d5ab86102e
 lib/smart_answer_flows/check-uk-visa/check_uk_visa.govspeak.erb: a442b4ddd169b26a401c70d145e5b44e


### PR DESCRIPTION
The `outcome_visit_waiver` is not a valid return value for the `next_node` block for this question.

I came across this while double-checking that the mechanism for automatic detection of permitted next nodes was working correctly. The fact that this had managed to get out of sync highlights the duplication inherent in the current implementation and encourages me that the automatic detection mechanism will be an improvement.

### Expected changes

None