### PR TITLE
Use automatic next node detection in benefit-cap-calculator

### DIFF
--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -68,11 +68,8 @@ module SmartAnswer
         option :widow_pension
         option :widows_aged
 
-        next_node_calculation :benefit_related_questions do |response|
-          questions = response.split(",").map { |r| :"#{r}_amount?" }
-          questions << :housing_benefit_amount? if housing_benefit == 'yes'
-          questions << :single_couple_lone_parent?
-          questions
+        next_node_calculation :benefit_types do |response|
+          response.split(",").map(&:to_sym)
         end
 
         calculate :total_benefits do
@@ -83,32 +80,33 @@ module SmartAnswer
           0
         end
 
-        permitted_next_nodes = [
-          :outcome_not_affected,
-          :bereavement_amount?,
-          :carers_amount?,
-          :child_benefit_amount?,
-          :child_tax_amount?,
-          :esa_amount?,
-          :guardian_amount?,
-          :incapacity_amount?,
-          :income_support_amount?,
-          :jsa_amount?,
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do |response|
+        next_node(permitted: :auto) do |response|
           if response == "none"
-            :outcome_not_affected
+            outcome :outcome_not_affected
           else
-            benefit_related_questions.shift
+            case benefit_types.shift
+            when :bereavement then question :bereavement_amount?
+            when :carers then question :carers_amount?
+            when :child_benefit then question :child_benefit_amount?
+            when :child_tax then question :child_tax_amount?
+            when :esa then question :esa_amount?
+            when :guardian then question :guardian_amount?
+            when :incapacity then question :incapacity_amount?
+            when :income_support then question :income_support_amount?
+            when :jsa then question :jsa_amount?
+            when :maternity then question :maternity_amount?
+            when :sda then question :sda_amount?
+            when :widowed_mother then question :widowed_mother_amount?
+            when :widowed_parent then question :widowed_parent_amount?
+            when :widow_pension then question :widow_pension_amount?
+            when :widows_aged then question :widows_aged_amount?
+            else
+              if housing_benefit == 'yes'
+                question :housing_benefit_amount?
+              else
+                question :single_couple_lone_parent?
+              end
+            end
           end
         end
       end
@@ -120,27 +118,29 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :carers_amount?,
-          :child_benefit_amount?,
-          :child_tax_amount?,
-          :esa_amount?,
-          :guardian_amount?,
-          :incapacity_amount?,
-          :income_support_amount?,
-          :jsa_amount?,
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :carers then question :carers_amount?
+          when :child_benefit then question :child_benefit_amount?
+          when :child_tax then question :child_tax_amount?
+          when :esa then question :esa_amount?
+          when :guardian then question :guardian_amount?
+          when :incapacity then question :incapacity_amount?
+          when :income_support then question :income_support_amount?
+          when :jsa then question :jsa_amount?
+          when :maternity then question :maternity_amount?
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -151,26 +151,28 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :child_benefit_amount?,
-          :child_tax_amount?,
-          :esa_amount?,
-          :guardian_amount?,
-          :incapacity_amount?,
-          :income_support_amount?,
-          :jsa_amount?,
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :child_benefit then question :child_benefit_amount?
+          when :child_tax then question :child_tax_amount?
+          when :esa then question :esa_amount?
+          when :guardian then question :guardian_amount?
+          when :incapacity then question :incapacity_amount?
+          when :income_support then question :income_support_amount?
+          when :jsa then question :jsa_amount?
+          when :maternity then question :maternity_amount?
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -181,25 +183,27 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :child_tax_amount?,
-          :esa_amount?,
-          :guardian_amount?,
-          :incapacity_amount?,
-          :income_support_amount?,
-          :jsa_amount?,
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :child_tax then question :child_tax_amount?
+          when :esa then question :esa_amount?
+          when :guardian then question :guardian_amount?
+          when :incapacity then question :incapacity_amount?
+          when :income_support then question :income_support_amount?
+          when :jsa then question :jsa_amount?
+          when :maternity then question :maternity_amount?
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -210,24 +214,26 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :esa_amount?,
-          :guardian_amount?,
-          :incapacity_amount?,
-          :income_support_amount?,
-          :jsa_amount?,
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :esa then question :esa_amount?
+          when :guardian then question :guardian_amount?
+          when :incapacity then question :incapacity_amount?
+          when :income_support then question :income_support_amount?
+          when :jsa then question :jsa_amount?
+          when :maternity then question :maternity_amount?
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -238,23 +244,25 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :guardian_amount?,
-          :incapacity_amount?,
-          :income_support_amount?,
-          :jsa_amount?,
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :guardian then question :guardian_amount?
+          when :incapacity then question :incapacity_amount?
+          when :income_support then question :income_support_amount?
+          when :jsa then question :jsa_amount?
+          when :maternity then question :maternity_amount?
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -265,22 +273,24 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :incapacity_amount?,
-          :income_support_amount?,
-          :jsa_amount?,
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :incapacity then question :incapacity_amount?
+          when :income_support then question :income_support_amount?
+          when :jsa then question :jsa_amount?
+          when :maternity then question :maternity_amount?
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -291,21 +301,23 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :income_support_amount?,
-          :jsa_amount?,
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :income_support then question :income_support_amount?
+          when :jsa then question :jsa_amount?
+          when :maternity then question :maternity_amount?
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -316,20 +328,22 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :jsa_amount?,
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :jsa then question :jsa_amount?
+          when :maternity then question :maternity_amount?
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -340,19 +354,21 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :maternity_amount?,
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :maternity then question :maternity_amount?
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -363,18 +379,20 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :sda_amount?,
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :sda then question :sda_amount?
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -385,17 +403,19 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :widow_pension_amount?,
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widow_pension then question :widow_pension_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -406,16 +426,18 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :widowed_mother_amount?,
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :widowed_mother then question :widowed_mother_amount?
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -426,15 +448,17 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :widowed_parent_amount?,
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :widowed_parent then question :widowed_parent_amount?
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -445,14 +469,16 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :widows_aged_amount?,
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          case benefit_types.shift
+          when :widows_aged then question :widows_aged_amount?
+          else
+            if housing_benefit == 'yes'
+              question :housing_benefit_amount?
+            else
+              question :single_couple_lone_parent?
+            end
+          end
         end
       end
 
@@ -463,13 +489,12 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [
-          :housing_benefit_amount?,
-          :single_couple_lone_parent?
-        ]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          if housing_benefit == 'yes'
+            question :housing_benefit_amount?
+          else
+            question :single_couple_lone_parent?
+          end
         end
       end
 
@@ -482,10 +507,8 @@ module SmartAnswer
           total_benefits + response.to_f
         end
 
-        permitted_next_nodes = [:single_couple_lone_parent?]
-
-        next_node(permitted: permitted_next_nodes) do
-          benefit_related_questions.shift
+        next_node(permitted: :auto) do
+          question :single_couple_lone_parent?
         end
       end
 

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -68,11 +68,10 @@ module SmartAnswer
         option :widow_pension
         option :widows_aged
 
-        calculate :benefit_related_questions do |response|
+        next_node_calculation :benefit_related_questions do |response|
           questions = response.split(",").map { |r| :"#{r}_amount?" }
           questions << :housing_benefit_amount? if housing_benefit == 'yes'
           questions << :single_couple_lone_parent?
-          questions.shift
           questions
         end
 
@@ -106,11 +105,10 @@ module SmartAnswer
         ]
 
         next_node(permitted: permitted_next_nodes) do |response|
-          first_value = response.split(",").first
           if response == "none"
             :outcome_not_affected
           else
-            :"#{first_value}_amount?"
+            benefit_related_questions.shift
           end
         end
       end

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/benefit-cap-calculator.rb: 8d0a35d30925354045bad4d463c49da9
+lib/smart_answer_flows/benefit-cap-calculator.rb: 00d009787e89adc22d09d1d78ddef52f
 test/data/benefit-cap-calculator-questions-and-responses.yml: b608788e9eb18ad20a066de99259aa84
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 497ab9a2846c8821e61ac28c5b0d6cc1
 lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: ce5203f11989c0b35bd9c53ade1f3f82

--- a/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
+++ b/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
@@ -64,7 +64,7 @@ class BenefitCapCalculatorTest < ActiveSupport::TestCase
 
             #Q5f
             should "ask how much for guardian allowance benefit" do
-              assert_state_variable :benefit_related_questions, [:sda_amount?, :housing_benefit_amount?, :single_couple_lone_parent?]
+              assert_state_variable :benefit_types, [:sda]
               assert_current_node :guardian_amount?
               assert_state_variable :total_benefits, 0
             end
@@ -74,7 +74,7 @@ class BenefitCapCalculatorTest < ActiveSupport::TestCase
 
               #Q5k
               should "ask how much for severe disability allowance" do
-                assert_state_variable :benefit_related_questions, [:housing_benefit_amount?, :single_couple_lone_parent?]
+                assert_state_variable :benefit_types, []
                 assert_current_node :sda_amount?
                 assert_state_variable :total_benefits, 300
               end
@@ -84,7 +84,7 @@ class BenefitCapCalculatorTest < ActiveSupport::TestCase
 
                 #Q5p
                 should "ask how much for housing benefit" do
-                  assert_state_variable :benefit_related_questions, [:single_couple_lone_parent?]
+                  assert_state_variable :benefit_types, []
                   assert_state_variable :total_benefits, 600
                   assert_current_node :housing_benefit_amount?
                 end
@@ -113,7 +113,7 @@ class BenefitCapCalculatorTest < ActiveSupport::TestCase
             setup { add_response 'esa,maternity' }
 
             should "ask ask how much for esa benefit" do
-              assert_state_variable :benefit_related_questions, [:maternity_amount?, :housing_benefit_amount?, :single_couple_lone_parent?]
+              assert_state_variable :benefit_types, [:maternity]
               assert_current_node :esa_amount?
             end
 
@@ -121,7 +121,7 @@ class BenefitCapCalculatorTest < ActiveSupport::TestCase
               setup { add_response "10" }
 
               should "ask how much for maternity benefits" do
-                assert_state_variable :benefit_related_questions, [:housing_benefit_amount?, :single_couple_lone_parent?]
+                assert_state_variable :benefit_types, []
                 assert_current_node :maternity_amount?
               end
 
@@ -129,7 +129,7 @@ class BenefitCapCalculatorTest < ActiveSupport::TestCase
                 setup { add_response "10" }
 
                 should "ask how much for housing benefits" do
-                  assert_state_variable :benefit_related_questions, [:single_couple_lone_parent?]
+                  assert_state_variable :benefit_types, []
                   assert_current_node :housing_benefit_amount?
                 end
 


### PR DESCRIPTION
### Description

In #2368 I didn't manage to convert all of the questions in the `benefit-cap-calculator` flow to use automatic detection of permitted next nodes. This PR converts the remaining questions in that flow to do so.

This PR is based on #2368 and starts with a squashed merge commit of its changes. That initial squash commit will be removed before this PR is merged.

By using case statements to convert from benefit type to the relevant benefit amount question, we can make the `next_node` logic less "dynamic" i.e. we can explicitly enumerate all the possible results from the `next_node` blocks.

I'm not really very happy with this solution, but I don't think it's any worse than the previous implementation and doing this means that we should be able to remove the logic which deals with permitted next nodes that are explicitly passed into a `next_node` block.

The main commit is the one entitled: "Auto-detect permitted next nodes in benefit-cap-calculator". See individual commit notes for further details.

### Notes

I'm not convinced that the visualisation for this flow is actually that useful, particularly regarding the optional benefit amount questions. We could probably get something that was almost as useful by extracting the "full" case statement from the first of these questions into a method and re-using it in each question. This would imply that you could always get to any other benefit amount question from any benefit amount question. Obviously this isn't actually accurate, but the resulting visualisation might be good enough.

Before attempting any better solutions for this flow, I think it would also be worth considering whether the user experience for this flow is actually that good e.g. it might be better to group all the benefit amount questions onto a single page.

### Testing

I added a script (borrowed from #2368) to generate a YAML representation of the possible next nodes for all the flows. I ran this script before and after the changes to double-check that using the automatic detection hadn't changed anything. However, the fact that the existing tests (including the regression tests) all pass also give me a lot of confidence.

### Expected changes

None. However it might be worth checking that the [flow visualisation URL][1] works OK (not forgetting that the visualisation is [currently broken in Chrome][2] for other reasons).

[1]: https://www.gov.uk/benefit-cap-calculator/visualise
[2]: https://trello.com/c/9qXvwUXM
