### PR TITLE
Added link to /green-deal-energy-saving-measures

### DIFF
--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -41,7 +41,7 @@ module SmartAnswer
         end
 
         calculate :warm_home_discount_amount do
-          ''
+          140
         end
 
         next_node(permitted: :auto) do |response|

--- a/lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_eco_help.govspeak.erb
+++ b/lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_eco_help.govspeak.erb
@@ -1,1 +1,1 @@
-You may also be able to get some of the following improvements without having to pay all the costs up front through the Green Deal:
+You may also be able to get some of the following improvements without having to pay all the costs up front through the [Green Deal](/green-deal-energy-saving-measures):


### PR DESCRIPTION
Relates to https://govuk.zendesk.com/agent/tickets/1232652

If possible, this should be included with existing pull request #2369 

Change the text in the callout to:
"The government has stopped funding the Green Deal Finance Company, which was set up to lend money to Green Deal providers. [Find out how this affects you](/green-deal-energy-saving-measures/changes)."