### PR TITLE
Remove `permitted` option from `next_node` with block

### DIFF
--- a/doc/next-node-rules.md
+++ b/doc/next-node-rules.md
@@ -12,24 +12,6 @@ next_node do |response|
 end
 ```
 
-## Explicitly setting permitted next nodes
-
-This approach is deprecated.
-
-```ruby
-permitted_next_nodes = [
-  :green,
-  :red
-]
-next_node(permitted: permitted_next_nodes) do |response|
-  if response == 'green'
-    :green # Go to the :green node
-  else
-    :red   # Go to the :red node
-  end
-end
-```
-
 ## Shortcut
 
 If the next node for a question is always the same then you can call `next_node` with a single node key. This will automatically add the specified node key to the list of permitted next nodes i.e. there is no need to specify the `:permitted` option.
@@ -51,17 +33,6 @@ next_node :red
 next_node :green
 ```
 
-### ArgumentError: You must specify at least one permitted next node
-
-Occurs if the list of permitted next nodes is empty.
-
-```ruby
-# For example
-next_node(permitted: []) do
-  :red
-end
-```
-
 ### ArgumentError: You must specify a block or a single next node key
 
 Occurs if `next_node` is called without a block and with no arguments.
@@ -77,19 +48,8 @@ Occurs if the `next_node` block returns something "falsey" (e.g. `nil`).
 
 ```ruby
 # For example
-next_node(permitted: [:red]) do
+next_node do
   nil
-end
-```
-
-### Next node not in list of permitted next nodes
-
-Occurs if the `next_node` block returns a value that doesn't appear in the array passed as the `permitted` option to the `next_node` block.
-
-```ruby
-# For example
-next_node(permitted: [:red]) do
-  :green
 end
 ```
 
@@ -99,7 +59,7 @@ This is similar to the previous error, but for `next_node` blocks where `permitt
 
 ```ruby
 # For example
-next_node(permitted: :auto) do
+next_node do
   :green
 end
 ```
@@ -110,8 +70,8 @@ Occurs if the `next_node` blocks returns a value that isn't defined as a questio
 
 ```ruby
 # For example
-next_node(permitted: [:red]) do
-  :red
+next_node do
+  outcome :red
 end
 outcome :green
 ```

--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -11,12 +11,12 @@ module SmartAnswer
         super
       end
 
-      def next_node(next_node = nil, permitted: :auto, &block)
+      def next_node(next_node = nil, &block)
         if @next_node_block.present?
           raise 'Multiple calls to next_node are not allowed'
         end
         if block_given?
-          @permitted_next_nodes = permitted
+          @permitted_next_nodes = :auto
           @next_node_block = block
           unless @permitted_next_nodes == :auto || @permitted_next_nodes.any?
             raise ArgumentError, 'You must specify at least one permitted next node'

--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -52,10 +52,6 @@ module SmartAnswer
           unless NextNodeBlock.permitted?(next_node)
             raise "Next node (#{next_node}) not returned via question or outcome method"
           end
-        else
-          unless @permitted_next_nodes.include?(next_node.to_sym)
-            raise "Next node (#{next_node}) not in list of permitted next nodes (#{@permitted_next_nodes.to_sentence})"
-          end
         end
         next_node.to_sym
       end

--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -18,9 +18,6 @@ module SmartAnswer
         if block_given?
           @permitted_next_nodes = :auto
           @next_node_block = block
-          unless @permitted_next_nodes == :auto || @permitted_next_nodes.any?
-            raise ArgumentError, 'You must specify at least one permitted next node'
-          end
         elsif next_node
           @permitted_next_nodes = [next_node]
           @next_node_block = lambda { |_| next_node }

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -40,7 +40,7 @@ module SmartAnswer
         option :gaza
         option :"jerusalem-or-westbank"
 
-        next_node(permitted: :auto) do |response|
+        next_node do |response|
           calculator.current_location = response
 
           question :renewing_replacing_applying?
@@ -54,7 +54,7 @@ module SmartAnswer
         option :applying
         option :replacing
 
-        next_node(permitted: :auto) do |response|
+        next_node do |response|
           calculator.application_action = response
 
           question :child_or_adult_passport?

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/overseas-passports.rb: 208590eed39b349fe645595a1d28f297
+lib/smart_answer_flows/overseas-passports.rb: bcefe18e039544b984cc13eb158f4922
 test/data/overseas-passports-questions-and-responses.yml: 4c6749fcf0a37deb135fc8c94fa52bc7
 test/data/overseas-passports-responses-and-expected-results.yml: aca0c7e72dfbf84606a47cb7d6d7f758
 lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb: 548eee239b4195e500d106f6b72f26ce

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -43,10 +43,10 @@ class FlowTest < ActiveSupport::TestCase
       multiple_choice :do_you_like_chocolate? do
         option :yes
         option :no
-        next_node(permitted: [:sweet_tooth, :savoury_tooth]) do |response|
+        next_node do |response|
           case response
-          when 'yes' then :sweet_tooth
-          when 'no' then :savoury_tooth
+          when 'yes' then outcome :sweet_tooth
+          when 'no' then outcome :savoury_tooth
           end
         end
       end
@@ -190,10 +190,10 @@ class FlowTest < ActiveSupport::TestCase
         multiple_choice :do_you_like_chocolate? do
           option :yes
           option :no
-          next_node(permitted: [:sweet, :do_you_like_jam?]) do |response|
+          next_node do |response|
             case response
-            when 'yes' then :sweet
-            when 'no' then :do_you_like_jam?
+            when 'yes' then outcome :sweet
+            when 'no' then question :do_you_like_jam?
             end
           end
         end
@@ -201,10 +201,10 @@ class FlowTest < ActiveSupport::TestCase
         multiple_choice :do_you_like_jam? do
           option :yes
           option :no
-          next_node(permitted: [:sweet, :savoury]) do |response|
+          next_node do |response|
             case response
-            when 'yes' then :sweet
-            when 'no' then :savoury
+            when 'yes' then outcome :sweet
+            when 'no' then outcome :savoury
             end
           end
         end
@@ -263,10 +263,10 @@ class FlowTest < ActiveSupport::TestCase
         option :red
         option :blue
 
-        next_node(permitted: [:when?, :blue]) do |response|
+        next_node do |response|
           case response
-          when 'red' then :when?
-          when 'blue' then :blue
+          when 'red' then question :when?
+          when 'blue' then outcome :blue
           end
         end
       end
@@ -332,10 +332,10 @@ class FlowTest < ActiveSupport::TestCase
 multiple_choice :do_you_like_chocolate? do
   option :yes
   option :no
-  next_node(permitted: [:sweet_tooth, :savoury_tooth]) do |response|
+  next_node do |response|
     case response
-    when 'yes' then :sweet_tooth
-    when 'no' then :savoury_tooth
+    when 'yes' then outcome :sweet_tooth
+    when 'no' then outcome :savoury_tooth
     end
   end
 end

--- a/test/unit/multiple_choice_question_test.rb
+++ b/test/unit/multiple_choice_question_test.rb
@@ -39,7 +39,7 @@ module SmartAnswer
       q = Question::MultipleChoice.new(nil, :example) do
         option :yes
         option :no
-        next_node(permitted: [:baz]) { :baz }
+        next_node { outcome :baz }
       end
 
       new_state = q.transition(State.new(:example), :no)


### PR DESCRIPTION
In #2374 auto-detecting of permitted next nodes was made the default behaviour and most of the flows were changed to not specify the `permitted` option on calls to `next_node`.

This PR does the following:

* Removes the few remaining occurrences of the deprecated `permitted` option
* Removes the ability to specify the deprecated `permitted` option
* Removes some code which becomes unreachable because of the latter change
* Updates the documentation to match the new behaviour

### Motivation

This is another small step towards simplifying the flow DSL and in particular the code in `SmartAnswer::Question::Base`.

Also it will prevent any accidental "regression" to the deprecated syntax.

### Internal changes

#### Before

Deprecated usage:

```ruby
next_node(permitted: [:green?, :red]) do |response|
  if response == 'green'
    :green?
  else
    :red
  end
end
```

#### After

The above is no longer allowed and *must* be written as:

```ruby
next_node do |response|
  if response == 'green'
    question :green?
  else
    outcome :red
  end
end
```

### External changes

None. This is just a refactoring and should not cause any externally visible changes.
