### PR TITLE
Remove marriage-abroad outcome path precalculate blocks

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -231,5 +231,13 @@ module SmartAnswer::Calculators
         @partner_nationality, @sex_of_your_partner
       ].join('/')
     end
+
+    def outcome_path_when_resident_in_ceremony_country
+      [
+        '', 'marriage-abroad', 'y',
+        @ceremony_country, 'ceremony_country',
+        @partner_nationality, @sex_of_your_partner
+      ].join('/')
+    end
   end
 end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -223,5 +223,13 @@ module SmartAnswer::Calculators
     def same_sex_alt_fees_table_country?
       @data_query.ss_alt_fees_table_country?(ceremony_country, self)
     end
+
+    def outcome_path_when_resident_in_uk
+      [
+        '', 'marriage-abroad', 'y',
+        @ceremony_country, 'uk',
+        @partner_nationality, @sex_of_your_partner
+      ].join('/')
+    end
   end
 end

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -225,17 +225,19 @@ module SmartAnswer::Calculators
     end
 
     def outcome_path_when_resident_in_uk
-      [
-        '', 'marriage-abroad', 'y',
-        @ceremony_country, 'uk',
-        @partner_nationality, @sex_of_your_partner
-      ].join('/')
+      outcome_path_when_resident_in('uk')
     end
 
     def outcome_path_when_resident_in_ceremony_country
+      outcome_path_when_resident_in('ceremony_country')
+    end
+
+  private
+
+    def outcome_path_when_resident_in(uk_or_ceremony_country)
       [
         '', 'marriage-abroad', 'y',
-        @ceremony_country, 'ceremony_country',
+        @ceremony_country, uk_or_ceremony_country,
         @partner_nationality, @sex_of_your_partner
       ].join('/')
     end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -216,10 +216,6 @@ module SmartAnswer
       outcome :outcome_os_germany
 
       outcome :outcome_os_kuwait do
-        precalculate :current_path do
-          (['/marriage-abroad/y'] + responses).join('/')
-        end
-
         precalculate :uk_residence_outcome_path do
           calculator.outcome_path_when_resident_in_uk
         end
@@ -254,10 +250,6 @@ module SmartAnswer
       outcome :outcome_monaco
 
       outcome :outcome_spain do
-        precalculate :current_path do
-          (['/marriage-abroad/y'] + responses).join('/')
-        end
-
         precalculate :uk_residence_outcome_path do
           calculator.outcome_path_when_resident_in_uk
         end
@@ -276,10 +268,6 @@ module SmartAnswer
       outcome :outcome_os_italy
 
       outcome :outcome_consular_cni_os_residing_in_third_country do
-        precalculate :current_path do
-          (['/marriage-abroad/y'] + responses).join('/')
-        end
-
         precalculate :uk_residence_outcome_path do
           calculator.outcome_path_when_resident_in_uk
         end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -225,7 +225,7 @@ module SmartAnswer
         end
 
         precalculate :ceremony_country_residence_outcome_path do
-          current_path.gsub('third_country', 'ceremony_country')
+          calculator.outcome_path_when_resident_in_ceremony_country
         end
       end
 
@@ -263,7 +263,7 @@ module SmartAnswer
         end
 
         precalculate :ceremony_country_residence_outcome_path do
-          current_path.gsub('third_country', 'ceremony_country')
+          calculator.outcome_path_when_resident_in_ceremony_country
         end
       end
 
@@ -285,7 +285,7 @@ module SmartAnswer
         end
 
         precalculate :ceremony_country_residence_outcome_path do
-          current_path.gsub('third_country', 'ceremony_country')
+          calculator.outcome_path_when_resident_in_ceremony_country
         end
       end
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -216,10 +216,6 @@ module SmartAnswer
       outcome :outcome_os_germany
 
       outcome :outcome_os_kuwait do
-        precalculate :uk_residence_outcome_path do
-          calculator.outcome_path_when_resident_in_uk
-        end
-
         precalculate :ceremony_country_residence_outcome_path do
           calculator.outcome_path_when_resident_in_ceremony_country
         end
@@ -250,10 +246,6 @@ module SmartAnswer
       outcome :outcome_monaco
 
       outcome :outcome_spain do
-        precalculate :uk_residence_outcome_path do
-          calculator.outcome_path_when_resident_in_uk
-        end
-
         precalculate :ceremony_country_residence_outcome_path do
           calculator.outcome_path_when_resident_in_ceremony_country
         end
@@ -268,10 +260,6 @@ module SmartAnswer
       outcome :outcome_os_italy
 
       outcome :outcome_consular_cni_os_residing_in_third_country do
-        precalculate :uk_residence_outcome_path do
-          calculator.outcome_path_when_resident_in_uk
-        end
-
         precalculate :ceremony_country_residence_outcome_path do
           calculator.outcome_path_when_resident_in_ceremony_country
         end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -221,7 +221,7 @@ module SmartAnswer
         end
 
         precalculate :uk_residence_outcome_path do
-          current_path.gsub('third_country', 'uk')
+          calculator.outcome_path_when_resident_in_uk
         end
 
         precalculate :ceremony_country_residence_outcome_path do
@@ -259,7 +259,7 @@ module SmartAnswer
         end
 
         precalculate :uk_residence_outcome_path do
-          current_path.gsub('third_country', 'uk')
+          calculator.outcome_path_when_resident_in_uk
         end
 
         precalculate :ceremony_country_residence_outcome_path do
@@ -281,7 +281,7 @@ module SmartAnswer
         end
 
         precalculate :uk_residence_outcome_path do
-          current_path.gsub('third_country', 'uk')
+          calculator.outcome_path_when_resident_in_uk
         end
 
         precalculate :ceremony_country_residence_outcome_path do

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -215,11 +215,7 @@ module SmartAnswer
 
       outcome :outcome_os_germany
 
-      outcome :outcome_os_kuwait do
-        precalculate :ceremony_country_residence_outcome_path do
-          calculator.outcome_path_when_resident_in_ceremony_country
-        end
-      end
+      outcome :outcome_os_kuwait
 
       outcome :outcome_os_indonesia
 
@@ -245,11 +241,7 @@ module SmartAnswer
 
       outcome :outcome_monaco
 
-      outcome :outcome_spain do
-        precalculate :ceremony_country_residence_outcome_path do
-          calculator.outcome_path_when_resident_in_ceremony_country
-        end
-      end
+      outcome :outcome_spain
 
       outcome :outcome_os_commonwealth
 
@@ -259,11 +251,7 @@ module SmartAnswer
 
       outcome :outcome_os_italy
 
-      outcome :outcome_consular_cni_os_residing_in_third_country do
-        precalculate :ceremony_country_residence_outcome_path do
-          calculator.outcome_path_when_resident_in_ceremony_country
-        end
-      end
+      outcome :outcome_consular_cni_os_residing_in_third_country
 
       outcome :outcome_os_consular_cni do
         precalculate :three_day_residency_requirement_applies do

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_consular_cni_os_residing_in_third_country.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_consular_cni_os_residing_in_third_country.govspeak.erb
@@ -20,7 +20,7 @@
   <% if calculator.ceremony_country == 'norway' %>
     You’ll need to prove that you’re allowed to marry. There are 2 ways you can do this:
 
-    - [go to the UK and post notice with a UK registrar](<%= uk_residence_outcome_path %>)
+    - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
     - [go to <%= calculator.country_name_lowercase_prefix %> and swear an affidavit (written statement of facts) that you’re free to marry](<%= ceremony_country_residence_outcome_path %>)
   <% else %>
     <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
@@ -28,7 +28,7 @@
     <% if calculator.ceremony_country == 'nicaragua' %>
       There are 2 ways you can get a CNI:
 
-      - [go to the UK and post notice with a UK registrar](<%= uk_residence_outcome_path %>)
+      - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
       - [arrange this through the British Embassy in Costa Rica](<%= ceremony_country_residence_outcome_path %>)
 
 
@@ -36,7 +36,7 @@
     <% else %>
       There are 2 ways you can get a CNI:
 
-      - [go to the UK and post notice with a UK registrar](<%= uk_residence_outcome_path %>)
+      - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
       - [go to <%= calculator.country_name_lowercase_prefix %> and post notice at the embassy or consulate there](<%= ceremony_country_residence_outcome_path %>)
 
       <% if calculator.ceremony_country == 'greece' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_consular_cni_os_residing_in_third_country.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_consular_cni_os_residing_in_third_country.govspeak.erb
@@ -21,7 +21,7 @@
     You’ll need to prove that you’re allowed to marry. There are 2 ways you can do this:
 
     - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
-    - [go to <%= calculator.country_name_lowercase_prefix %> and swear an affidavit (written statement of facts) that you’re free to marry](<%= ceremony_country_residence_outcome_path %>)
+    - [go to <%= calculator.country_name_lowercase_prefix %> and swear an affidavit (written statement of facts) that you’re free to marry](<%= calculator.outcome_path_when_resident_in_ceremony_country %>)
   <% else %>
     <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
 
@@ -29,7 +29,7 @@
       There are 2 ways you can get a CNI:
 
       - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
-      - [arrange this through the British Embassy in Costa Rica](<%= ceremony_country_residence_outcome_path %>)
+      - [arrange this through the British Embassy in Costa Rica](<%= calculator.outcome_path_when_resident_in_ceremony_country %>)
 
 
       %If you choose to post notice in Costa Rica, you’ll normally have to wait at least 10 days before you can get married.%
@@ -37,7 +37,7 @@
       There are 2 ways you can get a CNI:
 
       - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
-      - [go to <%= calculator.country_name_lowercase_prefix %> and post notice at the embassy or consulate there](<%= ceremony_country_residence_outcome_path %>)
+      - [go to <%= calculator.country_name_lowercase_prefix %> and post notice at the embassy or consulate there](<%= calculator.outcome_path_when_resident_in_ceremony_country %>)
 
       <% if calculator.ceremony_country == 'greece' %>
         %If you choose to post notice in <%= calculator.country_name_lowercase_prefix %>, you’ll normally have to wait at least 14 days before you can apply to get married.%

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_kuwait.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_kuwait.govspeak.erb
@@ -88,7 +88,7 @@
     There are 2 ways you can get a CNI:
 
     - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
-    - [go to <%= calculator.country_name_lowercase_prefix %> and post notice at the embassy or consulate there](<%= ceremony_country_residence_outcome_path %>)
+    - [go to <%= calculator.country_name_lowercase_prefix %> and post notice at the embassy or consulate there](<%= calculator.outcome_path_when_resident_in_ceremony_country %>)
 
     <%= render partial: 'you_will_have_to_wait_to_get_married.govspeak.erb',
                locals: { calculator: calculator } %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_kuwait.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_kuwait.govspeak.erb
@@ -87,7 +87,7 @@
 
     There are 2 ways you can get a CNI:
 
-    - [go to the UK and post notice with a UK registrar](<%= uk_residence_outcome_path %>)
+    - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
     - [go to <%= calculator.country_name_lowercase_prefix %> and post notice at the embassy or consulate there](<%= ceremony_country_residence_outcome_path %>)
 
     <%= render partial: 'you_will_have_to_wait_to_get_married.govspeak.erb',

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
@@ -43,7 +43,7 @@
     There are 2 ways you can get these certificates:
 
     - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
-    - [go to <%= calculator.country_name_lowercase_prefix %> and post notice at the embassy or consulate there](<%= ceremony_country_residence_outcome_path %>)
+    - [go to <%= calculator.country_name_lowercase_prefix %> and post notice at the embassy or consulate there](<%= calculator.outcome_path_when_resident_in_ceremony_country %>)
 
     You need to apply for all certificates at least 3 months before the date you intend to get married.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb
@@ -42,7 +42,7 @@
 
     There are 2 ways you can get these certificates:
 
-    - [go to the UK and post notice with a UK registrar](<%= uk_residence_outcome_path %>)
+    - [go to the UK and post notice with a UK registrar](<%= calculator.outcome_path_when_resident_in_uk %>)
     - [go to <%= calculator.country_name_lowercase_prefix %> and post notice at the embassy or consulate there](<%= ceremony_country_residence_outcome_path %>)
 
     You need to apply for all certificates at least 3 months before the date you intend to get married.

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: 936669f936e6f8d0592e170ad8812fd7
+lib/smart_answer_flows/marriage-abroad.rb: 6a7a8f7746783fe15b843867d13fbd07
 test/data/marriage-abroad-questions-and-responses.yml: 87f39a00d77fe0566a79e5cddbca765e
 test/data/marriage-abroad-responses-and-expected-results.yml: c388fc820b41309bb7594e9ef908a70e
 lib/smart_answer_flows/marriage-abroad/marriage_abroad.govspeak.erb: b4d0cfc1c7c4776d968c9b5b6df85027
@@ -89,7 +89,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/os_affirmation/_contact.govspeak
 lib/smart_answer_flows/marriage-abroad/outcomes/os_affirmation/_fees.govspeak.erb: 91a208d92860e994e6f903cbd8a0d90a
 lib/smart_answer_flows/marriage-abroad/outcomes/os_affirmation/_what_you_need_to_do.govspeak.erb: f3b26a16b87e458dec9f089f527061a1
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_brazil_not_living_in_the_uk.govspeak.erb: e3fb0ad81caf8965909db65b7e14603f
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_consular_cni_os_residing_in_third_country.govspeak.erb: 611b13466b903e147bf7c6d4bd9442e2
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_consular_cni_os_residing_in_third_country.govspeak.erb: 1e7a021cd26dda11e159552200f61920
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_all_other_countries.govspeak.erb: 7e4e34579ba21e10c2a36b0a11241c24
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_commonwealth_countries.govspeak.erb: 19bb1b2a9333666a3cc254bfbc863ee2
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_consular.govspeak.erb: 501fc24c313947ce7c541d785b0fe7cb
@@ -113,7 +113,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_indonesia.govspeak.er
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_italy.govspeak.erb: 3ea5afa19033b886f75fdb0b0f0733de
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_japan.govspeak.erb: 12f014b4ee31161a7f5a63291ec4dbae
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_kosovo.govspeak.erb: c4885ff578037256da2ac442212ef797
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_kuwait.govspeak.erb: 6e146806532d41312428c5441bd28dbc
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_kuwait.govspeak.erb: ce1cc1249bd11dc2e8c96ad1db0d6f21
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_laos.govspeak.erb: 9b46da7e894654d0c83bd6d5a53f8a35
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_marriage_impossible_no_laos_locals.govspeak.erb: 23fc1e82a139254773a19515d8cb73b7
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_no_cni.govspeak.erb: 5f136e2925649eb32a8769ada47adb79
@@ -122,7 +122,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_other_countries.govsp
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_poland.govspeak.erb: 7d0b5e2490e3fd1d8b2657a5881533ad
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_slovenia.govspeak.erb: fedf4a19edb9a7677d59b27ad0e491dc
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_portugal.govspeak.erb: 7928e930761d5d6d2f32491194004c15
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb: fee5ed8d96ede70c1dd3a97b4cfc8362
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_spain.govspeak.erb: 0695f1ee4b15779de0023eadd377f8e8
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ss_affirmation.govspeak.erb: cb480b319be828564ae5577ff5558034
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ss_marriage.govspeak.erb: d35500623beb6fd1efc1ecbf9ff92eb9
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_ss_marriage_malta.govspeak.erb: 198f2cf34a2c9e2f91466fcbb6ceb15d
@@ -133,7 +133,7 @@ lib/smart_answer_flows/marriage-abroad/questions/legal_residency.govspeak.erb: 7
 lib/smart_answer_flows/marriage-abroad/questions/marriage_or_pacs.govspeak.erb: a51aecfac697188f90ca9efefcb2e0ea
 lib/smart_answer_flows/marriage-abroad/questions/partner_opposite_or_same_sex.govspeak.erb: 40d0c99a5be50f0625c6562f06fe4afd
 lib/smart_answer_flows/marriage-abroad/questions/what_is_your_partners_nationality.govspeak.erb: 80e04f36c75c232bede1a244d621471e
-lib/smart_answer/calculators/marriage_abroad_calculator.rb: a6a7bcf0ca3c850249e972a752d1a68a
+lib/smart_answer/calculators/marriage_abroad_calculator.rb: 3c6d8901ef96ccdb50bb16a36382aae4
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 80043ce123ab86befc4def86361abb81
 lib/smart_answer/calculators/country_name_formatter.rb: 69a0726640385f42de50b80fdb144ff8

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -354,7 +354,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/estonia/ceremony_country/partner_british/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/estonia/uk/partner_british/opposite_sex"
     end
   end
 
@@ -408,7 +407,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/italy/ceremony_country/partner_other/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/italy/uk/partner_other/opposite_sex"
     end
   end
 
@@ -521,7 +519,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/denmark/ceremony_country/partner_british/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/denmark/uk/partner_british/opposite_sex"
     end
   end
 
@@ -577,7 +574,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       should "go to outcome_spain with third country OS specific phrases" do
         assert_current_node :outcome_spain
         assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/spain/ceremony_country/partner_other/opposite_sex"
-        assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/spain/uk/partner_other/opposite_sex"
       end
     end
 
@@ -603,7 +599,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       should "go to outcome_spain with third country SS specific phrases" do
         assert_current_node :outcome_spain
         assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/spain/ceremony_country/partner_other/same_sex"
-        assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/spain/uk/partner_other/same_sex"
       end
     end
   end
@@ -645,7 +640,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/azerbaijan/ceremony_country/partner_local/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/azerbaijan/uk/partner_local/opposite_sex"
     end
   end
 
@@ -660,7 +654,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/poland/ceremony_country/partner_british/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/poland/uk/partner_british/opposite_sex"
     end
   end
 
@@ -966,7 +959,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/macedonia/ceremony_country/partner_other/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/macedonia/uk/partner_other/opposite_sex"
     end
   end
 
@@ -1782,7 +1774,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/kazakhstan/ceremony_country/partner_british/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/kazakhstan/uk/partner_british/opposite_sex"
     end
   end
 
@@ -1930,7 +1921,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'opposite_sex'
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/mexico/ceremony_country/partner_british/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/mexico/uk/partner_british/opposite_sex"
     end
 
     should "show outcome_os_consular_cni when partner is local" do
@@ -1959,7 +1949,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "lead to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/albania/ceremony_country/partner_british/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/albania/uk/partner_british/opposite_sex"
     end
   end
 
@@ -1974,7 +1963,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "lead to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
       assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/democratic-republic-of-congo/ceremony_country/partner_british/opposite_sex"
-      assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/democratic-republic-of-congo/uk/partner_british/opposite_sex"
     end
   end
 
@@ -2107,7 +2095,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       should "leads to outcome_consular_cni_os_residing_in_third_country" do
         assert_current_node :outcome_consular_cni_os_residing_in_third_country
         assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/greece/ceremony_country/partner_other/opposite_sex"
-        assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/greece/uk/partner_other/opposite_sex"
       end
     end
 

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -353,7 +353,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/estonia/ceremony_country/partner_british/opposite_sex"
     end
   end
 
@@ -406,7 +405,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/italy/ceremony_country/partner_other/opposite_sex"
     end
   end
 
@@ -518,7 +516,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/denmark/ceremony_country/partner_british/opposite_sex"
     end
   end
 
@@ -573,7 +570,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "go to outcome_spain with third country OS specific phrases" do
         assert_current_node :outcome_spain
-        assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/spain/ceremony_country/partner_other/opposite_sex"
       end
     end
 
@@ -598,7 +594,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "go to outcome_spain with third country SS specific phrases" do
         assert_current_node :outcome_spain
-        assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/spain/ceremony_country/partner_other/same_sex"
       end
     end
   end
@@ -639,7 +634,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/azerbaijan/ceremony_country/partner_local/opposite_sex"
     end
   end
 
@@ -653,7 +647,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/poland/ceremony_country/partner_british/opposite_sex"
     end
   end
 
@@ -958,7 +951,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/macedonia/ceremony_country/partner_other/opposite_sex"
     end
   end
 
@@ -1773,7 +1765,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/kazakhstan/ceremony_country/partner_british/opposite_sex"
     end
   end
 
@@ -1920,7 +1911,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'partner_british'
       add_response 'opposite_sex'
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/mexico/ceremony_country/partner_british/opposite_sex"
     end
 
     should "show outcome_os_consular_cni when partner is local" do
@@ -1948,7 +1938,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "lead to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/albania/ceremony_country/partner_british/opposite_sex"
     end
   end
 
@@ -1962,7 +1951,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "lead to outcome_consular_cni_os_residing_in_third_country" do
       assert_current_node :outcome_consular_cni_os_residing_in_third_country
-      assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/democratic-republic-of-congo/ceremony_country/partner_british/opposite_sex"
     end
   end
 
@@ -2094,7 +2082,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "leads to outcome_consular_cni_os_residing_in_third_country" do
         assert_current_node :outcome_consular_cni_os_residing_in_third_country
-        assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/greece/ceremony_country/partner_other/opposite_sex"
       end
     end
 

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -722,6 +722,18 @@ module SmartAnswer
           assert_equal 'same-sex-alt-fees-table', calculator.same_sex_alt_fees_table_country?
         end
       end
+
+      context '#outcome_path_when_resident_in_uk' do
+        should 'build the path' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'ceremony-country'
+          calculator.partner_nationality = 'partner-nationality'
+          calculator.sex_of_your_partner = 'sex-of-your-partner'
+
+          expected_path = '/marriage-abroad/y/ceremony-country/uk/partner-nationality/sex-of-your-partner'
+          assert_equal expected_path, calculator.outcome_path_when_resident_in_uk
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -734,6 +734,18 @@ module SmartAnswer
           assert_equal expected_path, calculator.outcome_path_when_resident_in_uk
         end
       end
+
+      context '#outcome_path_when_resident_in_ceremony_country' do
+        should 'build the path' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'ceremony-country'
+          calculator.partner_nationality = 'partner-nationality'
+          calculator.sex_of_your_partner = 'sex-of-your-partner'
+
+          expected_path = '/marriage-abroad/y/ceremony-country/ceremony_country/partner-nationality/sex-of-your-partner'
+          assert_equal expected_path, calculator.outcome_path_when_resident_in_ceremony_country
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I'm continuing to refactor marriage-abroad. This branch removes the `precalculate` blocks from outcome_os_kuwait, outcome_spain and outcome_consular_cni_os_residing_in_third_country by moving logic to the `MarriageAbroadCalculator.`