### PR TITLE
Remove marriage-abroad outcome_cp_consular precalculate blocks

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -223,5 +223,13 @@ module SmartAnswer::Calculators
     def same_sex_alt_fees_table_country?
       @data_query.ss_alt_fees_table_country?(ceremony_country, self)
     end
+
+    def civil_partnership_institution_name
+      if ceremony_country == 'cyprus'
+        'High Commission'
+      else
+        'British embassy or consulate'
+      end
+    end
   end
 end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -342,11 +342,7 @@ module SmartAnswer
 
       outcome :outcome_cp_consular do
         precalculate :institution_name do
-          if calculator.ceremony_country == 'cyprus'
-            "High Commission"
-          else
-            "British embassy or consulate"
-          end
+          calculator.civil_partnership_institution_name
         end
       end
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -340,11 +340,7 @@ module SmartAnswer
 
       outcome :outcome_cp_commonwealth_countries
 
-      outcome :outcome_cp_consular do
-        precalculate :institution_name do
-          calculator.civil_partnership_institution_name
-        end
-      end
+      outcome :outcome_cp_consular
 
       outcome :outcome_cp_all_other_countries
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_consular.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_consular.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :body do %>
-  You may be able to register a civil partnership at the <%= institution_name %> in <%= calculator.country_name_lowercase_prefix %>.
+  You may be able to register a civil partnership at the <%= calculator.civil_partnership_institution_name %> in <%= calculator.country_name_lowercase_prefix %>.
 
   <% if %w(croatia bulgaria).include?(calculator.ceremony_country) && calculator.partner_is_national_of_ceremony_country? %>
     %However, they can’t register a civil partnership between a British national and a national of <%= calculator.country_name_lowercase_prefix %>.%
@@ -16,7 +16,7 @@
 
   ##What documents you’ll need
 
-  You’ll need proof that you’ve been resident in the area covered by the <%= institution_name %> for at least 7 days, like an employer’s letter or a bank statement.
+  You’ll need proof that you’ve been resident in the area covered by the <%= calculator.civil_partnership_institution_name %> for at least 7 days, like an employer’s letter or a bank statement.
 
 
   You’ll both need your original passports. If either of you have been divorced, widowed or in a civil partnership before, you’ll also need:
@@ -36,12 +36,12 @@
 
   ###What you need to do
 
-  Once you’ve made your appointment, the <%= institution_name %> will give you:
+  Once you’ve made your appointment, the <%= calculator.civil_partnership_institution_name %> will give you:
 
   - a notice of registration
   - a declaration that you and your partner will need to swear, stating that you’re legally entitled to enter into a civil partnership
 
-  Once you’ve submitted these and paid the registration fee (see below), the <%= institution_name %> will display your notice publicly for 14 days.
+  Once you’ve submitted these and paid the registration fee (see below), the <%= calculator.civil_partnership_institution_name %> will display your notice publicly for 14 days.
 
   As long as nobody has registered an objection after this time, the registration officer can then register your partnership any time until 3 months after the date you gave notice.
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: 936669f936e6f8d0592e170ad8812fd7
+lib/smart_answer_flows/marriage-abroad.rb: ed2aff846cd31fbdc8cdad871069f758
 test/data/marriage-abroad-questions-and-responses.yml: 87f39a00d77fe0566a79e5cddbca765e
 test/data/marriage-abroad-responses-and-expected-results.yml: c388fc820b41309bb7594e9ef908a70e
 lib/smart_answer_flows/marriage-abroad/marriage_abroad.govspeak.erb: b4d0cfc1c7c4776d968c9b5b6df85027
@@ -92,7 +92,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/outcome_brazil_not_living_in_the
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_consular_cni_os_residing_in_third_country.govspeak.erb: 611b13466b903e147bf7c6d4bd9442e2
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_all_other_countries.govspeak.erb: 7e4e34579ba21e10c2a36b0a11241c24
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_commonwealth_countries.govspeak.erb: 19bb1b2a9333666a3cc254bfbc863ee2
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_consular.govspeak.erb: 501fc24c313947ce7c541d785b0fe7cb
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_consular.govspeak.erb: ea8d9a8a82daae843679eff7d942a627
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_france_pacs.govspeak.erb: 71ed894fbccf1cd2249915ceca553bf4
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_no_cni.govspeak.erb: d016ac758c0f76f20f0fc2de524b7065
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_cp_or_equivalent.govspeak.erb: 4f8a188718b127da5d74371b6563941f
@@ -133,7 +133,7 @@ lib/smart_answer_flows/marriage-abroad/questions/legal_residency.govspeak.erb: 7
 lib/smart_answer_flows/marriage-abroad/questions/marriage_or_pacs.govspeak.erb: a51aecfac697188f90ca9efefcb2e0ea
 lib/smart_answer_flows/marriage-abroad/questions/partner_opposite_or_same_sex.govspeak.erb: 40d0c99a5be50f0625c6562f06fe4afd
 lib/smart_answer_flows/marriage-abroad/questions/what_is_your_partners_nationality.govspeak.erb: 80e04f36c75c232bede1a244d621471e
-lib/smart_answer/calculators/marriage_abroad_calculator.rb: a6a7bcf0ca3c850249e972a752d1a68a
+lib/smart_answer/calculators/marriage_abroad_calculator.rb: 1805a4e2e55cbd297c4eea99aaa435e8
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 80043ce123ab86befc4def86361abb81
 lib/smart_answer/calculators/country_name_formatter.rb: 69a0726640385f42de50b80fdb144ff8

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -287,7 +287,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cp outcome" do
       assert_current_node :outcome_cp_consular
-      assert_state_variable :institution_name, "High Commission"
     end
   end
 
@@ -493,7 +492,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to outcome_cp_consular outcome for same sex marriage" do
       add_response 'same_sex'
       assert_current_node :outcome_cp_consular
-      assert_state_variable :institution_name, "British embassy or consulate"
     end
   end
   #variant for local resident, ceremony not in italy or germany

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -722,6 +722,20 @@ module SmartAnswer
           assert_equal 'same-sex-alt-fees-table', calculator.same_sex_alt_fees_table_country?
         end
       end
+
+      context '#civil_partnership_institution_name' do
+        should 'return "High Commission" if the ceremony country is cyprus' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'cyprus'
+          assert_equal 'High Commission', calculator.civil_partnership_institution_name
+        end
+
+        should 'return "British embassy or consulate" if the ceremony country is not cyprus' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'not-cyprus'
+          assert_equal 'British embassy or consulate', calculator.civil_partnership_institution_name
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I'm continuing to refactor marriage-abroad. This branch removes the `precalculate` blocks from outcome_cp_consular by adding logic to the `MarriageAbroadCalculator`.