### PR TITLE
Remove unnecessary instance variable assignment in SmartAnswer::Question::Base

### DIFF
--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -4,7 +4,6 @@ module SmartAnswer
       class NextNodeUndefined < StandardError; end
 
       def initialize(flow, name, options = {}, &block)
-        @save_input_as = nil
         @validations = []
         @default_next_node_block = lambda { |_| nil }
         @permitted_next_nodes = []


### PR DESCRIPTION
### Description

Instance variables are set to `nil` by default, so this assignment is unnecessary.

### External changes

None.