### PR TITLE
Remove unused `state` attribute from flow

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -13,7 +13,6 @@ module SmartAnswer
 
     def initialize(&block)
       @nodes = []
-      @state = nil
       instance_eval(&block) if block_given?
     end
 

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 module SmartAnswer
   class Flow
     attr_reader :nodes, :outcomes
-    attr_accessor :state, :status, :need_id
+    attr_accessor :status, :need_id
 
     def self.build
       new.tap do |flow|


### PR DESCRIPTION
### Description

As far as I can tell this is not used and I'm pretty sure it's *never* been used. The state for a request seems to be handled entirely locally within the `Flow#process` method.

### External changes

None.