### PR TITLE
Remove marriage-abroad outcome_os_consular_cni precalculate blocks

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -240,6 +240,10 @@ module SmartAnswer::Calculators
       outcome_path_when_resident_in('ceremony_country')
     end
 
+    def three_day_residency_requirement_applies?
+      MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES.include?(ceremony_country)
+    end
+
   private
 
     def outcome_path_when_resident_in(uk_or_ceremony_country)

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -244,6 +244,10 @@ module SmartAnswer::Calculators
       MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES.include?(ceremony_country)
     end
 
+    def cni_posted_after_14_days?
+      MarriageAbroadDataQuery::CNI_POSTED_AFTER_14_DAYS_COUNTRIES.include?(ceremony_country)
+    end
+
   private
 
     def outcome_path_when_resident_in(uk_or_ceremony_country)

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -256,6 +256,10 @@ module SmartAnswer::Calculators
       MarriageAbroadDataQuery::CNI_NOTARY_PUBLIC_COUNTRIES.include?(ceremony_country)
     end
 
+    def document_download_link_if_opposite_sex_resident_of_uk_countries?
+      MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES.exclude?(ceremony_country)
+    end
+
   private
 
     def outcome_path_when_resident_in(uk_or_ceremony_country)

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -251,7 +251,11 @@ module SmartAnswer::Calculators
     def birth_certificate_required_as_supporting_document?
       MarriageAbroadDataQuery::NO_BIRTH_CERT_REQUIREMENT.exclude?(ceremony_country)
     end
-    
+
+    def notary_public_ceremony_country?
+      MarriageAbroadDataQuery::CNI_NOTARY_PUBLIC_COUNTRIES.include?(ceremony_country)
+    end
+
   private
 
     def outcome_path_when_resident_in(uk_or_ceremony_country)

--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -248,6 +248,10 @@ module SmartAnswer::Calculators
       MarriageAbroadDataQuery::CNI_POSTED_AFTER_14_DAYS_COUNTRIES.include?(ceremony_country)
     end
 
+    def birth_certificate_required_as_supporting_document?
+      MarriageAbroadDataQuery::NO_BIRTH_CERT_REQUIREMENT.exclude?(ceremony_country)
+    end
+    
   private
 
     def outcome_path_when_resident_in(uk_or_ceremony_country)

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -56,6 +56,8 @@ module SmartAnswer::Calculators
 
     THREE_DAY_RESIDENCY_HANDLED_BY_EXCEPTION = %w(croatia italy russia)
 
+    NO_BIRTH_CERT_REQUIREMENT = THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES - ['italy']
+
     def os_21_days_residency_required_countries?(country_slug)
       OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES.include?(country_slug)
     end

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -54,6 +54,8 @@ module SmartAnswer::Calculators
 
     THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria chile croatia cuba democratic-republic-of-congo denmark dominican-republic el-salvador estonia ethiopia georgia greece guatemala honduras hungary iceland italy kazakhstan kosovo kuwait kyrgyzstan latvia lithuania luxembourg macedonia mexico moldova montenegro nepal panama romania russia serbia slovenia sudan sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
 
+    THREE_DAY_RESIDENCY_HANDLED_BY_EXCEPTION = %w(croatia italy russia)
+
     def os_21_days_residency_required_countries?(country_slug)
       OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES.include?(country_slug)
     end

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -58,6 +58,8 @@ module SmartAnswer::Calculators
 
     NO_BIRTH_CERT_REQUIREMENT = THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES - ['italy']
 
+    CNI_NOTARY_PUBLIC_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland kazakhstan kuwait kyrgyzstan libya lithuania luxembourg mexico moldova montenegro russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+
     def os_21_days_residency_required_countries?(country_slug)
       OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES.include?(country_slug)
     end

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -60,6 +60,8 @@ module SmartAnswer::Calculators
 
     CNI_NOTARY_PUBLIC_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland kazakhstan kuwait kyrgyzstan libya lithuania luxembourg mexico moldova montenegro russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
 
+    NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+
     def os_21_days_residency_required_countries?(country_slug)
       OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES.include?(country_slug)
     end

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -62,6 +62,8 @@ module SmartAnswer::Calculators
 
     NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
 
+    CNI_POSTED_AFTER_14_DAYS_COUNTRIES = %w(jordan qatar saudi-arabia united-arab-emirates yemen)
+
     def os_21_days_residency_required_countries?(country_slug)
       OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES.include?(country_slug)
     end

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -54,8 +54,6 @@ module SmartAnswer::Calculators
 
     THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria chile croatia cuba democratic-republic-of-congo denmark dominican-republic el-salvador estonia ethiopia georgia greece guatemala honduras hungary iceland italy kazakhstan kosovo kuwait kyrgyzstan latvia lithuania luxembourg macedonia mexico moldova montenegro nepal panama romania russia serbia slovenia sudan sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
 
-    THREE_DAY_RESIDENCY_HANDLED_BY_EXCEPTION = %w(croatia italy russia)
-
     NO_BIRTH_CERT_REQUIREMENT = THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES - ['italy']
 
     CNI_NOTARY_PUBLIC_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland kazakhstan kuwait kyrgyzstan libya lithuania luxembourg mexico moldova montenegro russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -48,7 +48,7 @@ module SmartAnswer::Calculators
 
     SS_ALT_FEES_TABLE_OR_OUTCOME_GROUP_B = %w(azerbaijan chile dominican-republic kosovo latvia)
 
-    OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES = %(jordan oman qatar yemen)
+    OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES = %w(jordan oman qatar yemen)
 
     SS_UNKNOWN_NO_EMBASSIES = %w(st-martin saint-barthelemy)
 

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -52,6 +52,8 @@ module SmartAnswer::Calculators
 
     SS_UNKNOWN_NO_EMBASSIES = %w(st-martin saint-barthelemy)
 
+    THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria chile croatia cuba democratic-republic-of-congo denmark dominican-republic el-salvador estonia ethiopia georgia greece guatemala honduras hungary iceland italy kazakhstan kosovo kuwait kyrgyzstan latvia lithuania luxembourg macedonia mexico moldova montenegro nepal panama romania russia serbia slovenia sudan sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+
     def os_21_days_residency_required_countries?(country_slug)
       OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES.include?(country_slug)
     end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -264,7 +264,7 @@ module SmartAnswer
           Calculators::MarriageAbroadDataQuery::NO_BIRTH_CERT_REQUIREMENT
         end
         precalculate :cni_notary_public_countries do
-          %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland kazakhstan kuwait kyrgyzstan libya lithuania luxembourg mexico moldova montenegro russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+          Calculators::MarriageAbroadDataQuery::CNI_NOTARY_PUBLIC_COUNTRIES
         end
         precalculate :no_document_download_link_if_os_resident_of_uk_countries do
           %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -257,9 +257,6 @@ module SmartAnswer
         precalculate :no_document_download_link_if_os_resident_of_uk_countries do
           Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
         end
-        precalculate :notary_public_inclusion do
-          Calculators::MarriageAbroadDataQuery::CNI_NOTARY_PUBLIC_COUNTRIES.include?(calculator.ceremony_country)
-        end
       end
 
       outcome :outcome_os_france_or_fot

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -270,7 +270,7 @@ module SmartAnswer
           Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
         end
         precalculate :cni_posted_after_14_days_countries do
-          %w(jordan qatar saudi-arabia united-arab-emirates yemen)
+          Calculators::MarriageAbroadDataQuery::CNI_POSTED_AFTER_14_DAYS_COUNTRIES
         end
         precalculate :ceremony_and_residency_in_croatia do
           (calculator.ceremony_country == 'croatia' && calculator.resident_of_ceremony_country?)

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -261,7 +261,7 @@ module SmartAnswer
           Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
         end
         precalculate :notary_public_inclusion do
-          cni_notary_public_countries.include?(calculator.ceremony_country) || %w(macedonia).include?(calculator.ceremony_country)
+          cni_notary_public_countries.include?(calculator.ceremony_country)
         end
       end
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -260,9 +260,6 @@ module SmartAnswer
         precalculate :no_document_download_link_if_os_resident_of_uk_countries do
           Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
         end
-        precalculate :cni_posted_after_14_days_countries do
-          Calculators::MarriageAbroadDataQuery::CNI_POSTED_AFTER_14_DAYS_COUNTRIES
-        end
         precalculate :ceremony_and_residency_in_croatia do
           (calculator.ceremony_country == 'croatia' && calculator.resident_of_ceremony_country?)
         end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -267,7 +267,7 @@ module SmartAnswer
           Calculators::MarriageAbroadDataQuery::CNI_NOTARY_PUBLIC_COUNTRIES
         end
         precalculate :no_document_download_link_if_os_resident_of_uk_countries do
-          %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+          Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
         end
         precalculate :cni_posted_after_14_days_countries do
           %w(jordan qatar saudi-arabia united-arab-emirates yemen)

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -253,11 +253,7 @@ module SmartAnswer
 
       outcome :outcome_consular_cni_os_residing_in_third_country
 
-      outcome :outcome_os_consular_cni do
-        precalculate :no_document_download_link_if_os_resident_of_uk_countries do
-          Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
-        end
-      end
+      outcome :outcome_os_consular_cni
 
       outcome :outcome_os_france_or_fot
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -261,7 +261,7 @@ module SmartAnswer
           Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
         end
         precalculate :notary_public_inclusion do
-          cni_notary_public_countries.include?(calculator.ceremony_country) || %w(japan macedonia).include?(calculator.ceremony_country)
+          cni_notary_public_countries.include?(calculator.ceremony_country) || %w(macedonia).include?(calculator.ceremony_country)
         end
       end
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -276,9 +276,7 @@ module SmartAnswer
           (calculator.ceremony_country == 'croatia' && calculator.resident_of_ceremony_country?)
         end
         precalculate :birth_cert_inclusion do
-          if no_birth_cert_requirement.exclude?(calculator.ceremony_country)
-            '_incl_birth_cert'
-          end
+          no_birth_cert_requirement.exclude?(calculator.ceremony_country)
         end
         precalculate :notary_public_inclusion do
           if cni_notary_public_countries.include?(calculator.ceremony_country) || %w(japan macedonia).include?(calculator.ceremony_country)

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -254,9 +254,6 @@ module SmartAnswer
       outcome :outcome_consular_cni_os_residing_in_third_country
 
       outcome :outcome_os_consular_cni do
-        precalculate :three_day_residency_handled_by_exception do
-          Calculators::MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_HANDLED_BY_EXCEPTION
-        end
         precalculate :cni_notary_public_countries do
           Calculators::MarriageAbroadDataQuery::CNI_NOTARY_PUBLIC_COUNTRIES
         end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -254,14 +254,11 @@ module SmartAnswer
       outcome :outcome_consular_cni_os_residing_in_third_country
 
       outcome :outcome_os_consular_cni do
-        precalculate :cni_notary_public_countries do
-          Calculators::MarriageAbroadDataQuery::CNI_NOTARY_PUBLIC_COUNTRIES
-        end
         precalculate :no_document_download_link_if_os_resident_of_uk_countries do
           Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
         end
         precalculate :notary_public_inclusion do
-          cni_notary_public_countries.include?(calculator.ceremony_country)
+          Calculators::MarriageAbroadDataQuery::CNI_NOTARY_PUBLIC_COUNTRIES.include?(calculator.ceremony_country)
         end
       end
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -279,9 +279,7 @@ module SmartAnswer
           no_birth_cert_requirement.exclude?(calculator.ceremony_country)
         end
         precalculate :notary_public_inclusion do
-          if cni_notary_public_countries.include?(calculator.ceremony_country) || %w(japan macedonia).include?(calculator.ceremony_country)
-            '_notary_public'
-          end
+          cni_notary_public_countries.include?(calculator.ceremony_country) || %w(japan macedonia).include?(calculator.ceremony_country)
         end
       end
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -260,9 +260,6 @@ module SmartAnswer
         precalculate :no_document_download_link_if_os_resident_of_uk_countries do
           Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
         end
-        precalculate :birth_cert_inclusion do
-          Calculators::MarriageAbroadDataQuery::NO_BIRTH_CERT_REQUIREMENT.exclude?(calculator.ceremony_country)
-        end
         precalculate :notary_public_inclusion do
           cni_notary_public_countries.include?(calculator.ceremony_country) || %w(japan macedonia).include?(calculator.ceremony_country)
         end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -258,7 +258,7 @@ module SmartAnswer
           Calculators::MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES
         end
         precalculate :three_day_residency_handled_by_exception do
-          %w(croatia italy russia)
+          Calculators::MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_HANDLED_BY_EXCEPTION
         end
         precalculate :no_birth_cert_requirement do
           three_day_residency_requirement_applies - ['italy']

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -260,9 +260,6 @@ module SmartAnswer
         precalculate :no_document_download_link_if_os_resident_of_uk_countries do
           Calculators::MarriageAbroadDataQuery::NO_DOCUMENT_DOWNLOAD_LINK_IF_OS_RESIDENT_OF_UK_COUNTRIES
         end
-        precalculate :ceremony_and_residency_in_croatia do
-          (calculator.ceremony_country == 'croatia' && calculator.resident_of_ceremony_country?)
-        end
         precalculate :birth_cert_inclusion do
           Calculators::MarriageAbroadDataQuery::NO_BIRTH_CERT_REQUIREMENT.exclude?(calculator.ceremony_country)
         end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -261,7 +261,7 @@ module SmartAnswer
           Calculators::MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_HANDLED_BY_EXCEPTION
         end
         precalculate :no_birth_cert_requirement do
-          three_day_residency_requirement_applies - ['italy']
+          Calculators::MarriageAbroadDataQuery::NO_BIRTH_CERT_REQUIREMENT
         end
         precalculate :cni_notary_public_countries do
           %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland kazakhstan kuwait kyrgyzstan libya lithuania luxembourg mexico moldova montenegro russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -260,9 +260,6 @@ module SmartAnswer
         precalculate :three_day_residency_handled_by_exception do
           Calculators::MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_HANDLED_BY_EXCEPTION
         end
-        precalculate :no_birth_cert_requirement do
-          Calculators::MarriageAbroadDataQuery::NO_BIRTH_CERT_REQUIREMENT
-        end
         precalculate :cni_notary_public_countries do
           Calculators::MarriageAbroadDataQuery::CNI_NOTARY_PUBLIC_COUNTRIES
         end
@@ -276,7 +273,7 @@ module SmartAnswer
           (calculator.ceremony_country == 'croatia' && calculator.resident_of_ceremony_country?)
         end
         precalculate :birth_cert_inclusion do
-          no_birth_cert_requirement.exclude?(calculator.ceremony_country)
+          Calculators::MarriageAbroadDataQuery::NO_BIRTH_CERT_REQUIREMENT.exclude?(calculator.ceremony_country)
         end
         precalculate :notary_public_inclusion do
           cni_notary_public_countries.include?(calculator.ceremony_country) || %w(japan macedonia).include?(calculator.ceremony_country)

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -254,9 +254,6 @@ module SmartAnswer
       outcome :outcome_consular_cni_os_residing_in_third_country
 
       outcome :outcome_os_consular_cni do
-        precalculate :three_day_residency_requirement_applies do
-          Calculators::MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES
-        end
         precalculate :three_day_residency_handled_by_exception do
           Calculators::MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_HANDLED_BY_EXCEPTION
         end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -255,7 +255,7 @@ module SmartAnswer
 
       outcome :outcome_os_consular_cni do
         precalculate :three_day_residency_requirement_applies do
-          %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria chile croatia cuba democratic-republic-of-congo denmark dominican-republic el-salvador estonia ethiopia georgia greece guatemala honduras hungary iceland italy kazakhstan kosovo kuwait kyrgyzstan latvia lithuania luxembourg macedonia mexico moldova montenegro nepal panama romania russia serbia slovenia sudan sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+          Calculators::MarriageAbroadDataQuery::THREE_DAY_RESIDENCY_REQUIREMENT_COUNTRIES
         end
         precalculate :three_day_residency_handled_by_exception do
           %w(croatia italy russia)

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -263,7 +263,8 @@
     <% if calculator.partner_is_same_sex? ||
       (
         no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) &&
-        (cni_notary_public_countries + %w(macedonia) - %w(greece tunisia)).include?(calculator.ceremony_country)
+        (cni_notary_public_countries + %w(macedonia)).include?(calculator.ceremony_country) &&
+        %w(greece tunisia).exclude?(calculator.ceremony_country)
       ) %>
       <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -38,7 +38,7 @@
   <%= render partial: 'what_you_need_to_do.govspeak.erb',
       locals: { calculator: calculator } %>
 
-  <% if ceremony_and_residency_in_croatia %>
+  <% if calculator.ceremony_country == 'croatia' && calculator.resident_of_ceremony_country? %>
     You'll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
     The local registrar may also need a certificate of custom and law, which confirms the marriage is valid - the Embassy in Zagreb can provide this.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -136,7 +136,7 @@
 
     <% end %>
 
-    <% if three_day_residency_handled_by_exception.exclude?(calculator.ceremony_country) && three_day_residency_requirement_applies.include?(calculator.ceremony_country) %>
+    <% if three_day_residency_handled_by_exception.exclude?(calculator.ceremony_country) && calculator.three_day_residency_requirement_applies? %>
       <%= render partial: "three_day_residency_requirement.govspeak.erb",
                  locals: {
                    country_name_lowercase_prefix: calculator.country_name_lowercase_prefix

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -262,7 +262,7 @@
   <% else %>
     <% if calculator.partner_is_same_sex? ||
       (
-        no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) &&
+        calculator.document_download_link_if_opposite_sex_resident_of_uk_countries? &&
         (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country)) &&
         %w(greece tunisia).exclude?(calculator.ceremony_country)
       ) %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -263,7 +263,7 @@
     <% if calculator.partner_is_same_sex? ||
       (
         no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) &&
-        (cni_notary_public_countries + %w(macedonia)).include?(calculator.ceremony_country) &&
+        (notary_public_inclusion || %w(macedonia).include?(calculator.ceremony_country)) &&
         %w(greece tunisia).exclude?(calculator.ceremony_country)
       ) %>
       <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
@@ -319,7 +319,7 @@
 
       [Make an appointment to collect your CNI at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker).
 
-    <% elsif cni_notary_public_countries.include?(calculator.ceremony_country) %>
+    <% elsif notary_public_inclusion %>
       ###What happens next
 
       The embassy or notary public will charge a fee for taking the oath.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -204,7 +204,7 @@
   <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'macao' %>
     <%= render partial: 'required_supporting_documents_macao.govspeak.erb' %>
   <% elsif calculator.resident_of_ceremony_country? %>
-    <% if calculator.birth_certificate_required_as_supporting_document? && (notary_public_inclusion || %w(macedonia).include?(calculator.ceremony_country)) %>
+    <% if calculator.birth_certificate_required_as_supporting_document? && (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country)) %>
       You’ll need to provide supporting documents, including:
 
       - your passport
@@ -222,7 +222,7 @@
       - equivalent documents for your partner
 
 
-    <% elsif (notary_public_inclusion || %w(macedonia).include?(calculator.ceremony_country)) %>
+    <% elsif (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country)) %>
       You’ll need to provide supporting documents, including:
 
       - your passport
@@ -263,7 +263,7 @@
     <% if calculator.partner_is_same_sex? ||
       (
         no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) &&
-        (notary_public_inclusion || %w(macedonia).include?(calculator.ceremony_country)) &&
+        (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country)) &&
         %w(greece tunisia).exclude?(calculator.ceremony_country)
       ) %>
       <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
@@ -319,7 +319,7 @@
 
       [Make an appointment to collect your CNI at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker).
 
-    <% elsif notary_public_inclusion %>
+    <% elsif calculator.notary_public_ceremony_country? %>
       ###What happens next
 
       The embassy or notary public will charge a fee for taking the oath.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -260,7 +260,11 @@
 
     <% end %>
   <% else %>
-    <% if calculator.partner_is_same_sex? || (no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) && (cni_notary_public_countries + %w(macedonia) - %w(greece tunisia)).include?(calculator.ceremony_country)) %>
+    <% if calculator.partner_is_same_sex? ||
+      (
+        no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) &&
+        (cni_notary_public_countries + %w(macedonia) - %w(greece tunisia)).include?(calculator.ceremony_country)
+      ) %>
       <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
 
     <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -75,7 +75,7 @@
     <%= render partial: 'cni_at_local_register_office.govspeak.erb' %>
     <%= render partial: 'cni_issued_locally_validity.govspeak.erb',
                locals: { calculator: calculator } %>
-    <% if cni_posted_after_14_days_countries.include?(calculator.ceremony_country) %>
+    <% if calculator.cni_posted_after_14_days? %>
       They’ll post your notice, and as long as nobody has registered an objection after 14 days, they’ll issue your CNI.
 
     <% end -%>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -204,7 +204,7 @@
   <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'macao' %>
     <%= render partial: 'required_supporting_documents_macao.govspeak.erb' %>
   <% elsif calculator.resident_of_ceremony_country? %>
-    <% if calculator.birth_certificate_required_as_supporting_document? && notary_public_inclusion %>
+    <% if calculator.birth_certificate_required_as_supporting_document? && (notary_public_inclusion || %w(macedonia).include?(calculator.ceremony_country)) %>
       You’ll need to provide supporting documents, including:
 
       - your passport
@@ -222,7 +222,7 @@
       - equivalent documents for your partner
 
 
-    <% elsif notary_public_inclusion %>
+    <% elsif (notary_public_inclusion || %w(macedonia).include?(calculator.ceremony_country)) %>
       You’ll need to provide supporting documents, including:
 
       - your passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -136,7 +136,7 @@
 
     <% end %>
 
-    <% if three_day_residency_handled_by_exception.exclude?(calculator.ceremony_country) && calculator.three_day_residency_requirement_applies? %>
+    <% if %w(croatia italy russia).exclude?(calculator.ceremony_country) && calculator.three_day_residency_requirement_applies? %>
       <%= render partial: "three_day_residency_requirement.govspeak.erb",
                  locals: {
                    country_name_lowercase_prefix: calculator.country_name_lowercase_prefix

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -260,7 +260,7 @@
 
     <% end %>
   <% else %>
-    <% if calculator.partner_is_same_sex? || no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) && (cni_notary_public_countries + %w(macedonia) - %w(greece tunisia)).include?(calculator.ceremony_country) %>
+    <% if calculator.partner_is_same_sex? || (no_document_download_link_if_os_resident_of_uk_countries.exclude?(calculator.ceremony_country) && (cni_notary_public_countries + %w(macedonia) - %w(greece tunisia)).include?(calculator.ceremony_country)) %>
       <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
 
     <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb
@@ -204,7 +204,7 @@
   <% elsif calculator.resident_outside_of_uk? && calculator.ceremony_country == 'macao' %>
     <%= render partial: 'required_supporting_documents_macao.govspeak.erb' %>
   <% elsif calculator.resident_of_ceremony_country? %>
-    <% if birth_cert_inclusion && notary_public_inclusion %>
+    <% if calculator.birth_certificate_required_as_supporting_document? && notary_public_inclusion %>
       You’ll need to provide supporting documents, including:
 
       - your passport
@@ -213,7 +213,7 @@
       - equivalent documents for your partner
 
 
-    <% elsif birth_cert_inclusion %>
+    <% elsif calculator.birth_certificate_required_as_supporting_document? %>
       You’ll need to provide supporting documents, including:
 
       - your passport

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: 53f3fd0c409d6d5cb3980fbc7ecc3b1f
+lib/smart_answer_flows/marriage-abroad.rb: 533e06d2ce695e887bd2f780805c460b
 test/data/marriage-abroad-questions-and-responses.yml: 87f39a00d77fe0566a79e5cddbca765e
 test/data/marriage-abroad-responses-and-expected-results.yml: c388fc820b41309bb7594e9ef908a70e
 lib/smart_answer_flows/marriage-abroad/marriage_abroad.govspeak.erb: b4d0cfc1c7c4776d968c9b5b6df85027
@@ -105,7 +105,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_bot.govspeak.erb: f9c
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_cambodia.govspeak.erb: b693e25f4030a1d19c6acd7cf1b3debe
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_colombia.govspeak.erb: a0860f0581acfa1e5533f3114569301c
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_commonwealth.govspeak.erb: 7ed275a2c4647d85076d77ddf3eda685
-lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb: b72e4474a2f32571c9d94c79884b89f5
+lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_consular_cni.govspeak.erb: e14132cd9188901252d9561030453bf5
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_france_or_fot.govspeak.erb: 71d74db77499d680423d7586ba9e0e61
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_germany.govspeak.erb: e5e8a3e5209c68f513e9dbe145a5b671
 lib/smart_answer_flows/marriage-abroad/outcomes/outcome_os_hong_kong.govspeak.erb: 9c1686c0a3ba24dff0297e4e04f2fae6
@@ -133,8 +133,8 @@ lib/smart_answer_flows/marriage-abroad/questions/legal_residency.govspeak.erb: 7
 lib/smart_answer_flows/marriage-abroad/questions/marriage_or_pacs.govspeak.erb: a51aecfac697188f90ca9efefcb2e0ea
 lib/smart_answer_flows/marriage-abroad/questions/partner_opposite_or_same_sex.govspeak.erb: 40d0c99a5be50f0625c6562f06fe4afd
 lib/smart_answer_flows/marriage-abroad/questions/what_is_your_partners_nationality.govspeak.erb: 80e04f36c75c232bede1a244d621471e
-lib/smart_answer/calculators/marriage_abroad_calculator.rb: 96c48c4f5edd8bec13854adf2fdcd974
+lib/smart_answer/calculators/marriage_abroad_calculator.rb: 6329b517874ecf732cf3b48e0ce8601f
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 2f521bae99c2f48b49d07bcb283a8063
-lib/smart_answer/calculators/marriage_abroad_data_query.rb: 80043ce123ab86befc4def86361abb81
+lib/smart_answer/calculators/marriage_abroad_data_query.rb: 1d222b16a790bcf3f7b02c97b0e0b5b0
 lib/smart_answer/calculators/country_name_formatter.rb: 69a0726640385f42de50b80fdb144ff8
 lib/smart_answer/calculators/registrations_data_query.rb: 563c5db7d7272bc07bd636a92b40f3ce

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -760,6 +760,22 @@ module SmartAnswer
           assert_equal expected_path, calculator.outcome_path_when_resident_in_ceremony_country
         end
       end
+
+      context '#three_day_residency_requirement_applies?' do
+        should 'return true if ceremony country requires 3 day residency' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'albania'
+
+          assert calculator.three_day_residency_requirement_applies?
+        end
+
+        should 'return false if ceremony country does not require 3 days residency' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'country-not-requiring-three-day-residency'
+
+          refute calculator.three_day_residency_requirement_applies?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -824,6 +824,22 @@ module SmartAnswer
           refute calculator.notary_public_ceremony_country?
         end
       end
+
+      context '#document_download_link_if_opposite_sex_resident_of_uk_countries?' do
+        should 'return true if you can download forms' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'country-allowing-you-to-download-forms'
+
+          assert calculator.document_download_link_if_opposite_sex_resident_of_uk_countries?
+        end
+
+        should "return false if you can't download forms" do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'albania'
+
+          refute calculator.document_download_link_if_opposite_sex_resident_of_uk_countries?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -808,6 +808,22 @@ module SmartAnswer
           refute calculator.birth_certificate_required_as_supporting_document?
         end
       end
+
+      context '#notary_public_ceremony_country?' do
+        should 'return true if country has a notary public' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'albania'
+
+          assert calculator.notary_public_ceremony_country?
+        end
+
+        should 'return false if country has no notary public' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'country-without-notary-public'
+
+          refute calculator.notary_public_ceremony_country?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -792,6 +792,22 @@ module SmartAnswer
           refute calculator.cni_posted_after_14_days?
         end
       end
+
+      context '#birth_certificate_required_as_supporting_document?' do
+        should 'return true when a birth certificate is required' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'ceremony-country-requiring-birth-certificate'
+
+          assert calculator.birth_certificate_required_as_supporting_document?
+        end
+
+        should 'return false when no birth certificate is required' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'albania'
+
+          refute calculator.birth_certificate_required_as_supporting_document?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -776,6 +776,22 @@ module SmartAnswer
           refute calculator.three_day_residency_requirement_applies?
         end
       end
+
+      context '#cni_posted_after_14_days?' do
+        should 'return true if ceremony country will post notice after 14 days' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'jordan'
+
+          assert calculator.cni_posted_after_14_days?
+        end
+
+        should 'return false if ceremony country will not post notice after 14 days' do
+          calculator = MarriageAbroadCalculator.new
+          calculator.ceremony_country = 'ceremony-country-not-posting-notice-after-14-days'
+
+          refute calculator.cni_posted_after_14_days?
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I'm continuing to refactor marriage-abroad. This branch removes the `precalculate` blocks from outcome_os_consular_cni by adding logic to the `MarriageAbroadCalculator`.