### PR TITLE
Remove blank line at top of value_question_test.rb

### DIFF
--- a/test/unit/value_question_test.rb
+++ b/test/unit/value_question_test.rb
@@ -1,4 +1,3 @@
-
 require_relative '../test_helper'
 require 'ostruct'
 


### PR DESCRIPTION
This PR aims to address intermittent lint failures in smart answers.

CI has flagged two Style/TrailingWhitespace instances in file `value_question_test.rb` and whilst these spaces don't seem to appear in the source file any longer, this commit removes the leading blank line which may be related
```
bundle exec govuk-lint-ruby --diff --cached --format clang
test/unit/value_question_test.rb:70:1: C: Style/TrailingWhitespace: Trailing whitespace detected.  (https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace)
test/unit/value_question_test.rb:96:1: C: Style/TrailingWhitespace: Trailing whitespace detected.  (https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace)
```