### PR TITLE
Replace standard visitor with short-term study (Content and Link) For Taiwan

### DIFF
--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_taiwan_exception.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_taiwan_exception.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :body do %>
-  However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
+  However, you should bring the [same documents](/study-visit-visa/documents-you-must-provide) you'd need to apply for a visa, to show to officers at the UK border.
 
-  ^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a Standard Visitor visa](/standard-visitor-visa).^
+  ^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a short-term study visa](/study-visit-visa).^
 <% end %>

--- a/test/artefacts/check-uk-visa/taiwan/medical.txt
+++ b/test/artefacts/check-uk-visa/taiwan/medical.txt
@@ -1,6 +1,6 @@
 You won't need a visa if your passport has a personal ID number on the bio data page.
 
-However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
+However, you should bring the [same documents](/study-visit-visa/documents-you-must-provide) you'd need to apply for a visa, to show to officers at the UK border.
 
-^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a Standard Visitor visa](/standard-visitor-visa).^
+^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a short-term study visa](/study-visit-visa).^
 

--- a/test/artefacts/check-uk-visa/taiwan/school.txt
+++ b/test/artefacts/check-uk-visa/taiwan/school.txt
@@ -1,6 +1,6 @@
 You won't need a visa if your passport has a personal ID number on the bio data page.
 
-However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
+However, you should bring the [same documents](/study-visit-visa/documents-you-must-provide) you'd need to apply for a visa, to show to officers at the UK border.
 
-^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a Standard Visitor visa](/standard-visitor-visa).^
+^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a short-term study visa](/study-visit-visa).^
 

--- a/test/artefacts/check-uk-visa/taiwan/study/six_months_or_less.txt
+++ b/test/artefacts/check-uk-visa/taiwan/study/six_months_or_less.txt
@@ -1,6 +1,6 @@
 You won't need a visa if your passport has a personal ID number on the bio data page.
 
-However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
+However, you should bring the [same documents](/study-visit-visa/documents-you-must-provide) you'd need to apply for a visa, to show to officers at the UK border.
 
-^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a Standard Visitor visa](/standard-visitor-visa).^
+^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a short-term study visa](/study-visit-visa).^
 

--- a/test/artefacts/check-uk-visa/taiwan/tourism.txt
+++ b/test/artefacts/check-uk-visa/taiwan/tourism.txt
@@ -1,6 +1,6 @@
 You won't need a visa if your passport has a personal ID number on the bio data page.
 
-However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
+However, you should bring the [same documents](/study-visit-visa/documents-you-must-provide) you'd need to apply for a visa, to show to officers at the UK border.
 
-^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a Standard Visitor visa](/standard-visitor-visa).^
+^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a short-term study visa](/study-visit-visa).^
 

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -20,7 +20,7 @@ lib/smart_answer_flows/check-uk-visa/outcomes/outcome_standard_visit.govspeak.er
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_m.govspeak.erb: 3fc2c54633e28cac546673d1a7d605c2
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_waiver.govspeak.erb: dd0351a3dcde033fd5e66a791fa13a7b
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_y.govspeak.erb: b268016aaa0e7c6c50149b24fed15557
-lib/smart_answer_flows/check-uk-visa/outcomes/outcome_taiwan_exception.govspeak.erb: a571306467b1bfac12fb4088fae8f3c8
+lib/smart_answer_flows/check-uk-visa/outcomes/outcome_taiwan_exception.govspeak.erb: efbcf67df0d639cb48d102b0b036b8c1
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_leaving_airport.govspeak.erb: 5ab6a0a0e197780eee24c4259a9a247c
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_leaving_airport_datv.govspeak.erb: 1d0ce7899e540d7a21023613cfab48e7
 lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_not_leaving_airport.govspeak.erb: 3ea6330e57bb70c6fa07ef0c949f24ab


### PR DESCRIPTION
Zenddesk Story:  https://govuk.zendesk.com/agent/tickets/1287220
Trello Story:  https://trello.com/c/2NNNCDPL/67-change-study-visa-link

* Changed visa needed from standard visitor to short-term study.

## Factchecks
https://smart-answers-pr-2398.herokuapp.com/check-uk-visa/y/taiwan/school 
https://smart-answers-pr-2398.herokuapp.com/check-uk-visa/y/taiwan/schootourism
https://smart-answers-pr-2398.herokuapp.com/check-uk-visa/y/taiwan/medical
https://smart-answers-pr-2398.herokuapp.com/check-uk-visa/y/taiwan/study/six_months_or_less

### Expected changes
* [GOV.UK](//gov.uk/check-uk-visa/y/taiwan/school)
*  Replace visa standard visitor with short-term study.

### Before
![screen shot 2016-03-22 at 17 04 09](https://cloud.githubusercontent.com/assets/84896/13960412/2e19f6f8-f050-11e5-8586-091fa05ebbb6.png)



### After
![screen shot 2016-03-22 at 17 04 27](https://cloud.githubusercontent.com/assets/84896/13960410/2a13c9ee-f050-11e5-9aed-776f10ba804b.png)

