### PR TITLE
Fix RatesQuery#rates method to respect relevant_date argument

### DIFF
--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -5,13 +5,12 @@ module SmartAnswer::Calculators
     end
 
     def rates(relevant_date = Date.today)
-      return @rates if @rates
       relevant_rates = data.find do |rates_hash|
         rates_hash[:start_date] <= relevant_date && rates_hash[:end_date] >= relevant_date
       end
       relevant_rates ||= data.last
 
-      @rates = OpenStruct.new(relevant_rates)
+      OpenStruct.new(relevant_rates)
     end
 
   private

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -6,12 +6,12 @@ module SmartAnswer::Calculators
 
     def rates(relevant_date = Date.today)
       return @rates if @rates
-      rates = data.find do |rates_hash|
+      relevant_rates = data.find do |rates_hash|
         rates_hash[:start_date] <= relevant_date && rates_hash[:end_date] >= relevant_date
       end
-      rates ||= data.last
+      relevant_rates ||= data.last
 
-      @rates = OpenStruct.new(rates)
+      @rates = OpenStruct.new(relevant_rates)
     end
 
   private

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -30,5 +30,4 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_bef
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.govspeak.erb: 77831bed05434968d38648a40d3ce6e9
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/usual_work_days.govspeak.erb: 5570b649de33ac95bf274bcae70895a9
 lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 721d60e221806043c9e4acacc39409c9
-lib/smart_answer/calculators/rates_query.rb: c9568eac2742cad26f93458ed2276876
 lib/data/rates/statutory_sick_pay.yml: de2d34118e3016d1137c394745d33280

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -21,6 +21,18 @@ module SmartAnswer::Calculators
           test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
           assert_equal 2, test_rate.rates(Date.parse('2113-03-12')).rate
         end
+
+        context 'given a rate has been loaded for one date' do
+          setup do
+            @test_rate = SmartAnswer::Calculators::RatesQuery.new('exact_date_rates')
+            @test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
+            @test_rate.rates(Date.parse('2013-01-31')).rate
+          end
+
+          should 'return the correct rate for a different date' do
+            assert_equal 2, @test_rate.rates(Date.parse("2013-02-01")).rate
+          end
+        end
       end
 
       context "Married couples allowance" do


### PR DESCRIPTION
There seems to be a subtle bug in this code, in that the query class saves the results of invoking #rates the first time in a @rates instance variable.

But on subsequent invocations, it returns the previously calculated value, regardless if it is invoked with a different `relevant_date` argument.