### PR TITLE
Avoid double render error if exception raised after render

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,8 +26,8 @@ protected
 
     # handle cases where exception occured during render
     if performed?
-      response.status = status_code
-      response_body = error_message
+      self.status = status_code
+      self.response_body = error_message
     else
       render status: status_code, text: error_message
     end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -103,13 +103,6 @@ class SmartAnswersControllerTest < ActionController::TestCase
       assert_equal 503, response.status
     end
 
-    should 'cope with 503 exception during rendering' do
-      @controller.view_context_class.any_instance.stubs(:content_for).raises(GdsApi::TimedOutException)
-
-      get :show, id: 'smart-answers-controller-sample'
-      assert_equal 503, response.status
-    end
-
     should "404 Not Found if request is for an unknown format" do
       @controller.stubs(:respond_to).raises(ActionController::UnknownFormat)
 

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -1,0 +1,97 @@
+require_relative '../integration_test_helper'
+
+class ErrorHandlingTest < ActionDispatch::IntegrationTest
+  class ExampleController < ApplicationController
+    class << self
+      attr_accessor :exception_to_raise_before_render
+      attr_accessor :exception_to_raise_after_render
+    end
+
+    def test
+      set_slimmer_headers(skip: true)
+      if self.class.exception_to_raise_before_render
+        raise self.class.exception_to_raise_before_render
+      end
+      render text: 'rendered-from-test-action'
+      if self.class.exception_to_raise_after_render
+        raise self.class.exception_to_raise_after_render
+      end
+    end
+  end
+
+  setup do
+    Rails.application.routes.draw do
+      get '/test' => 'error_handling_test/example#test'
+    end
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+    ExampleController.exception_to_raise_before_render = nil
+    ExampleController.exception_to_raise_after_render = nil
+  end
+
+  context 'when GdsApi::TimedOutException raised before render' do
+    setup do
+      ExampleController.exception_to_raise_before_render = GdsApi::TimedOutException
+    end
+
+    should 'set response status code to 503' do
+      get '/test'
+      assert_response 503
+    end
+
+    should 'render error message as response body' do
+      get '/test'
+      assert_equal '503 error', response.body
+    end
+  end
+
+  context 'when ActionController::UnknownFormat raised before render' do
+    setup do
+      ExampleController.exception_to_raise_before_render = ActionController::UnknownFormat
+    end
+
+    should 'set response status code to 404' do
+      get '/test'
+      assert_response 404
+    end
+
+    should 'render error message as response body' do
+      get '/test'
+      assert_equal '404 error', response.body
+    end
+  end
+
+  context 'when GdsApi::TimedOutException raised after render' do
+    setup do
+      ExampleController.exception_to_raise_after_render = GdsApi::TimedOutException
+    end
+
+    should 'set response status code to 503' do
+      get '/test'
+      assert_response 503
+    end
+
+    should 'replace response body with error message' do
+      get '/test'
+      assert_equal '503 error', response.body
+    end
+  end
+
+  context 'when ActionController::UnknownFormat raised after render' do
+    setup do
+      ExampleController.exception_to_raise_after_render = ActionController::UnknownFormat
+    end
+
+    should 'set response status code to 404' do
+      get '/test'
+      assert_response 404
+    end
+
+    should 'replace response body with error message' do
+      get '/test'
+      assert_equal '404 error', response.body
+    end
+  end
+end


### PR DESCRIPTION
The `if performed?` conditional in `ApplicationController#error` was introduced in 168b69edf25c2a816be2b947c93c4d6630b3f6a6 in order to avoid a `DoubleRenderError` if the relevant exception was raised after rendering had completed. However, the change was made along with a test that didn't test what it was meant to test - I think the test is triggering an exception *in the middle of* rendering and not *after* rendering.

To remedy this, I replaced the originally added controller test and added a new Rails integration test, `ErrorHandlingTest`. This gives coverage of both branches of the `if/else` statement and a failure of one of these tests surfaced the fact that the line, `response_body = error_message` is not doing anything useful - it's just assigning the value in `error_message` to a local variable, `response_body` which is not then used for anything.

In fact I first came across this because this method was causing a `Lint/UselessAssignment` Rubocop violation where a `response_body` local variable was being assigned, but not used. I _think_ the intention was probably to use the `ActionController::Metal#response_body=` writer method.

I fixed the failing test by changing `response_body = error_message` to `self.response_body = error_message`.

I also decided to change `response.status = status_code` so that it too uses a writer method on `ActionController::Metal` rather than accessing the `response`. The latter is only made available by `ActionController::RackDelegation` i.e. it may not be available in all requests. Doing this felt more consistent and more robust.

I had to use `set_slimmer_headers(skip: true)` in the test controller action, because Slimmer ignores the body content of an error page and so we'd never see what it's being set to. The body content is ignored because `Slimmer::Skin#error` does not include `Slimmer::Processors::BodyInserter` in the list of processors for the request.

Thus with Slimmer enabled the relevant ERB error template (e.g. [404.html.erb][1] and its [related partial [2]) from the static app is the main source of the error page, albeit with a few things changed e.g. the page title.

[1]: https://github.com/alphagov/static/blob/master/app/views/root/404.html.erb
[2]: https://github.com/alphagov/static/blob/master/app/views/root/_error_page.html.erb