### PR TITLE
Introduce on_response blocks to allow setting of attributes on calculator in new-style flows

### DIFF
--- a/lib/smart_answer/block.rb
+++ b/lib/smart_answer/block.rb
@@ -1,0 +1,14 @@
+module SmartAnswer
+  class Block
+    def initialize(&block)
+      @block = block
+    end
+
+    def evaluate(previous_state, response = nil)
+      args = [response].compact
+      previous_state.instance_exec(*args, &@block)
+      new_state = previous_state.dup
+      new_state.freeze
+    end
+  end
+end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -55,39 +55,39 @@ module SmartAnswer
         period.number_of_days
       end
 
-      def valid_last_sick_day?(value)
-        period = DateRange.new(begins_on: sick_start_date, ends_on: value)
+      def valid_last_sick_day?
+        period = DateRange.new(begins_on: sick_start_date, ends_on: sick_end_date)
         period.number_of_days >= 1
       end
 
-      def valid_linked_sickness_start_date?(value)
-        sick_start_date > value
+      def valid_linked_sickness_start_date?
+        sick_start_date > linked_sickness_start_date
       end
 
-      def within_eight_weeks_of_current_sickness_period?(previous_sickness_end_date)
+      def within_eight_weeks_of_current_sickness_period?
         earliest_allowed_date = sick_start_date - 8.weeks - 1.day
-        previous_sickness_end_date >= earliest_allowed_date
+        linked_sickness_end_date >= earliest_allowed_date
       end
 
-      def at_least_1_day_before_first_sick_day?(value)
-        value < sick_start_date - 1
+      def at_least_1_day_before_first_sick_day?
+        linked_sickness_end_date < sick_start_date - 1
       end
 
       def valid_period_of_incapacity_for_work?
         days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
       end
 
-      def valid_linked_period_of_incapacity_for_work?(value)
-        period = DateRange.new(begins_on: linked_sickness_start_date, ends_on: value)
+      def valid_linked_period_of_incapacity_for_work?
+        period = DateRange.new(begins_on: linked_sickness_start_date, ends_on: linked_sickness_end_date)
         period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
       end
 
-      def valid_last_payday_before_sickness?(value)
-        value < sick_start_date
+      def valid_last_payday_before_sickness?
+        relevant_period_to < sick_start_date
       end
 
-      def valid_last_payday_before_offset?(value)
-        value <= pay_day_offset
+      def valid_last_payday_before_offset?
+        relevant_period_from <= pay_day_offset + 1.day
       end
 
       def sick_start_date_for_awe

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -4,7 +4,7 @@ module SmartAnswer
   class Node
     attr_reader :name, :calculations, :next_node_calculations, :precalculations
 
-    def initialize(flow, name, options = {}, &block)
+    def initialize(flow, name, _options = {}, &block)
       @flow = flow
       @name = name
       @on_response_blocks = []

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -7,6 +7,7 @@ module SmartAnswer
     def initialize(flow, name, options = {}, &block)
       @flow = flow
       @name = name
+      @on_response_blocks = []
       @calculations = []
       @next_node_calculations = []
       @precalculations = []
@@ -31,6 +32,10 @@ module SmartAnswer
 
     def next_node_calculation(variable_name, &block)
       @next_node_calculations << Calculation.new(variable_name, &block)
+    end
+
+    def on_response(&block)
+      @on_response_blocks << Block.new(&block)
     end
 
     def precalculate(variable_name, &block)

--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -52,8 +52,11 @@ module SmartAnswer
 
       def transition(current_state, raw_input)
         input = parse_input(raw_input)
-        new_state = @next_node_calculations.inject(current_state.dup) do |new_state, calculation|
-          calculation.evaluate(new_state, input)
+        state_after_next_node_calculatations = @next_node_calculations.inject(current_state.dup) do |state, calculation|
+          calculation.evaluate(state, input)
+        end
+        new_state = @on_response_blocks.inject(state_after_next_node_calculatations.dup) do |state, block|
+          block.evaluate(state, input)
         end
         next_node = next_node_for(new_state, input)
         new_state = new_state.transition_to(next_node, input) do |state|

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -92,8 +92,8 @@ module SmartAnswer
 
         validate_in_range
 
-        validate do |response|
-          calculator.valid_last_sick_day?(response)
+        validate do
+          calculator.valid_last_sick_day?
         end
 
         next_node do
@@ -139,8 +139,8 @@ module SmartAnswer
 
         validate_in_range
 
-        validate :linked_sickness_must_be_before do |response|
-          calculator.valid_linked_sickness_start_date?(response)
+        validate :linked_sickness_must_be_before do
+          calculator.valid_linked_sickness_start_date?
         end
 
         next_node do
@@ -159,16 +159,16 @@ module SmartAnswer
 
         validate_in_range
 
-        validate :must_be_within_eight_weeks do |response|
-          calculator.within_eight_weeks_of_current_sickness_period?(response)
+        validate :must_be_within_eight_weeks do
+          calculator.within_eight_weeks_of_current_sickness_period?
         end
 
-        validate :must_be_at_least_1_day_before_first_sick_day do |response|
-          calculator.at_least_1_day_before_first_sick_day?(response)
+        validate :must_be_at_least_1_day_before_first_sick_day do
+          calculator.at_least_1_day_before_first_sick_day?
         end
 
-        validate :must_be_valid_period_of_incapacity_for_work do |response|
-          calculator.valid_linked_period_of_incapacity_for_work?(response)
+        validate :must_be_valid_period_of_incapacity_for_work do
+          calculator.valid_linked_period_of_incapacity_for_work?
         end
 
         next_node do
@@ -236,8 +236,8 @@ module SmartAnswer
           calculator.relevant_period_to = response
         end
 
-        validate do |response|
-          calculator.valid_last_payday_before_sickness?(response)
+        validate do
+          calculator.valid_last_payday_before_sickness?
         end
 
         next_node do
@@ -259,8 +259,8 @@ module SmartAnswer
           calculator.relevant_period_from = response + 1.day
         end
 
-        validate do |response|
-          calculator.valid_last_payday_before_offset?(response)
+        validate do
+          calculator.valid_last_payday_before_offset?
         end
 
         next_node do

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -19,8 +19,11 @@ module SmartAnswer
           Calculators::StatutorySickPayCalculator.new
         end
 
-        next_node do |response|
+        on_response do |response|
           calculator.other_pay_types_received = response.split(",")
+        end
+
+        next_node do
           if calculator.already_getting_maternity_pay?
             outcome :already_getting_maternity
           else
@@ -34,12 +37,15 @@ module SmartAnswer
         option :yes
         option :no
 
-        next_node do |response|
+        on_response do |response|
           if response == 'yes'
             calculator.enough_notice_of_absence = true
           else
             calculator.enough_notice_of_absence = false
           end
+        end
+
+        next_node do
           question :employee_work_different_days?
         end
       end
@@ -63,10 +69,14 @@ module SmartAnswer
       date_question :first_sick_day? do
         from { Date.new(2011, 1, 1) }
         to { Date.today.end_of_year }
+
+        on_response do |response|
+          calculator.sick_start_date = response
+        end
+
         validate_in_range
 
-        next_node do |response|
-          calculator.sick_start_date = response
+        next_node do
           question :last_sick_day?
         end
       end
@@ -75,14 +85,18 @@ module SmartAnswer
       date_question :last_sick_day? do
         from { Date.new(2011, 1, 1) }
         to { Date.today.end_of_year }
+
+        on_response do |response|
+          calculator.sick_end_date = response
+        end
+
         validate_in_range
 
         validate do |response|
           calculator.valid_last_sick_day?(response)
         end
 
-        next_node do |response|
-          calculator.sick_end_date = response
+        next_node do
           if calculator.valid_period_of_incapacity_for_work?
             question :has_linked_sickness?
           else
@@ -96,13 +110,19 @@ module SmartAnswer
         option :yes
         option :no
 
-        next_node do |response|
+        on_response do |response|
           case response
           when 'yes'
             calculator.has_linked_sickness = true
-            question :linked_sickness_start_date?
           when 'no'
             calculator.has_linked_sickness = false
+          end
+        end
+
+        next_node do
+          if calculator.has_linked_sickness
+            question :linked_sickness_start_date?
+          else
             question :paid_at_least_8_weeks?
           end
         end
@@ -112,14 +132,18 @@ module SmartAnswer
       date_question :linked_sickness_start_date? do
         from { Date.new(2010, 1, 1) }
         to { Date.today.end_of_year }
+
+        on_response do |response|
+          calculator.linked_sickness_start_date = response
+        end
+
         validate_in_range
 
         validate :linked_sickness_must_be_before do |response|
           calculator.valid_linked_sickness_start_date?(response)
         end
 
-        next_node do |response|
-          calculator.linked_sickness_start_date = response
+        next_node do
           question :linked_sickness_end_date?
         end
       end
@@ -128,6 +152,11 @@ module SmartAnswer
       date_question :linked_sickness_end_date? do
         from { Date.new(2010, 1, 1) }
         to { Date.today.end_of_year }
+
+        on_response do |response|
+          calculator.linked_sickness_end_date = response
+        end
+
         validate_in_range
 
         validate :must_be_within_eight_weeks do |response|
@@ -142,8 +171,7 @@ module SmartAnswer
           calculator.valid_linked_period_of_incapacity_for_work?(response)
         end
 
-        next_node do |response|
-          calculator.linked_sickness_end_date = response
+        next_node do
           question :paid_at_least_8_weeks?
         end
       end
@@ -158,8 +186,11 @@ module SmartAnswer
           calculator.sick_start_date_for_awe
         end
 
-        next_node do |response|
+        on_response do |response|
           calculator.eight_weeks_earnings = response
+        end
+
+        next_node do
           if calculator.paid_at_least_8_weeks_of_earnings?
             question :how_often_pay_employee_pay_patterns? # Question 7.2
           elsif calculator.paid_less_than_8_weeks_of_earnings?
@@ -178,8 +209,11 @@ module SmartAnswer
         option :monthly
         option :irregularly
 
-        next_node do |response|
+        on_response do |response|
           calculator.pay_pattern = response
+        end
+
+        next_node do
           if calculator.paid_at_least_8_weeks_of_earnings?
             question :last_payday_before_sickness? # Question 8
           else
@@ -198,12 +232,15 @@ module SmartAnswer
           calculator.sick_start_date_for_awe
         end
 
+        on_response do |response|
+          calculator.relevant_period_to = response
+        end
+
         validate do |response|
           calculator.valid_last_payday_before_sickness?(response)
         end
 
-        next_node do |response|
-          calculator.relevant_period_to = response
+        next_node do
           question :last_payday_before_offset?
         end
       end
@@ -218,12 +255,15 @@ module SmartAnswer
           calculator.pay_day_offset
         end
 
+        on_response do |response|
+          calculator.relevant_period_from = response + 1.day
+        end
+
         validate do |response|
           calculator.valid_last_payday_before_offset?(response)
         end
 
-        next_node do |response|
-          calculator.relevant_period_from = response + 1.day
+        next_node do
           question :total_employee_earnings?
         end
       end
@@ -238,8 +278,11 @@ module SmartAnswer
           calculator.relevant_period_to
         end
 
-        next_node do |response|
+        on_response do |response|
           calculator.total_employee_earnings = response
+        end
+
+        next_node do
           question :usual_work_days?
         end
       end
@@ -250,32 +293,44 @@ module SmartAnswer
           calculator.sick_start_date_for_awe
         end
 
-        next_node do |response|
+        on_response do |response|
           calculator.relevant_contractual_pay = response
+        end
+
+        next_node do
           question :contractual_days_covered_by_earnings?
         end
       end
 
       # Question 9.1
       value_question :contractual_days_covered_by_earnings? do
-        next_node do |response|
+        on_response do |response|
           calculator.contractual_days_covered_by_earnings = response
+        end
+
+        next_node do
           question :usual_work_days?
         end
       end
 
       # Question 10
       money_question :total_earnings_before_sick_period? do
-        next_node do |response|
+        on_response do |response|
           calculator.total_earnings_before_sick_period = response
+        end
+
+        next_node do
           question :days_covered_by_earnings?
         end
       end
 
       # Question 10.1
       value_question :days_covered_by_earnings? do
-        next_node do |response|
+        on_response do |response|
           calculator.days_covered_by_earnings = response.to_i
+        end
+
+        next_node do
           question :usual_work_days?
         end
       end
@@ -284,8 +339,11 @@ module SmartAnswer
       checkbox_question :usual_work_days? do
         %w{1 2 3 4 5 6 0}.each { |n| option n.to_s }
 
-        next_node do |response|
+        on_response do |response|
           calculator.days_of_the_week_worked = response.split(",")
+        end
+
+        next_node do
           if calculator.not_earned_enough?
             outcome :not_earned_enough
           elsif calculator.maximum_entitlement_reached?

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-statutory-sick-pay.rb: d2c0aae4754ffe424ec0cdbe5e1c73c5
+lib/smart_answer_flows/calculate-statutory-sick-pay.rb: f8166c1b3e7ae0480ac12bb14d50ad95
 test/data/calculate-statutory-sick-pay-questions-and-responses.yml: dfd8baf65a8c26430cf17958e8908202
 test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: b42519fbb030e7eaf0912d1de0b8ff47
 lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: f91dc1d321c164a06271889100875600
@@ -29,6 +29,6 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/questions/pay_amount_if_not_
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_before_sick_period.govspeak.erb: 46ce81328d55d2bef88bb1047cf047cd
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.govspeak.erb: 77831bed05434968d38648a40d3ce6e9
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/usual_work_days.govspeak.erb: 5570b649de33ac95bf274bcae70895a9
-lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 721d60e221806043c9e4acacc39409c9
+lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 1b4fe3d8e643f7c451b0ba69a26c2561
 lib/smart_answer/calculators/rates_query.rb: c9568eac2742cad26f93458ed2276876
 lib/data/rates/statutory_sick_pay.yml: de2d34118e3016d1137c394745d33280

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -51,7 +51,7 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-07',
               initial_state: {
-                calculator: stub('calculator', {
+                calculator: stub_everything('calculator', {
                   linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: false,
@@ -70,7 +70,7 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-31',
               initial_state: {
-                calculator: stub('calculator', {
+                calculator: stub_everything('calculator', {
                   linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: true,
@@ -89,7 +89,7 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-03',
               initial_state: {
-                calculator: stub('calculator', {
+                calculator: stub_everything('calculator', {
                   sick_start_date: Date.parse('2015-02-01'),
                   linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5),

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -51,13 +51,13 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-07',
               initial_state: {
-                calculator: stub_everything('calculator', {
+                calculator: stub_everything('calculator',
                   linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: false,
                   at_least_1_day_before_first_sick_day?: true,
                   valid_linked_period_of_incapacity_for_work?: true
-                }),
+                ),
               })
           end
           assert_equal 'must_be_within_eight_weeks', exception.message
@@ -70,13 +70,13 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-31',
               initial_state: {
-                calculator: stub_everything('calculator', {
+                calculator: stub_everything('calculator',
                   linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: true,
                   at_least_1_day_before_first_sick_day?: false,
                   valid_linked_period_of_incapacity_for_work?: true
-                }),
+                ),
               })
           end
           assert_equal 'must_be_at_least_1_day_before_first_sick_day', exception.message
@@ -89,14 +89,14 @@ module SmartAnswer
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-03',
               initial_state: {
-                calculator: stub_everything('calculator', {
+                calculator: stub_everything('calculator',
                   sick_start_date: Date.parse('2015-02-01'),
                   linked_sickness_start_date: Date.parse('2015-01-01'),
                   days_of_the_week_worked: %w(1 2 3 4 5),
                   within_eight_weeks_of_current_sickness_period?: true,
                   at_least_1_day_before_first_sick_day?: true,
                   valid_linked_period_of_incapacity_for_work?: false
-                }),
+                ),
               })
           end
           assert_equal 'must_be_valid_period_of_incapacity_for_work', exception.message


### PR DESCRIPTION
This is a spike to explore the ideas in this [Trello card][1].

The idea is that we'll use these `on_response` blocks in a question block to set attributes on the calculator/policy object instead of doing that in `next_node` blocks which is the current "new-style" approach.

One advantage of doing this is to separate out the attribute-setting code which should make it easier to do automatically in future.

Another advantage is that we can avoid having to pass the response into any validation-related methods on the calculator which should make them more ActiveModel-like.

The new `on_response` blocks are run after `next_node_calculation` blocks, but before `validate` blocks. Ideally I would've preferred to have them run *before* `next_node_calculation` blocks too, but since the `calculator` is currently usually instantiated in a `next_node_calculation` bloc, this seemed like the simplest solution.

An alternative would be to use a `precalculate` block to instantiate the `calculator`, however, currently these don't get executed for the first question.

Although I have some reservations about this approach in the longer term (see Trello card comments), I think this is a step forward.

I'd love feedback, especially from @erikse & @chrisroos who were involved in the [original comment thread][2]. If this makes sense, I would open a new PR to do it properly and to use `on_response` blocks in all new-style flows.

[1]: https://trello.com/c/V6nqIWcJ
[2]: https://github.com/alphagov/smart-answers/commit/211734a881a56edeb0d73ecd88c57e7d9a040f67#commitcomment-16645397