### PR TITLE
Add 2016/17 rates for register-a-birth

### DIFF
--- a/lib/data/rates/register_a_birth.yml
+++ b/lib/data/rates/register_a_birth.yml
@@ -3,3 +3,7 @@
   end_date: 2016-04-05
   register_a_birth: 105.00
   copy_of_birth_registration_certificate: 65.00
+- start_date: 2016-04-06
+  end_date: 2017-04-05
+  register_a_birth: 150.00
+  copy_of_birth_registration_certificate: 50.00

--- a/lib/data/rates/register_a_birth.yml
+++ b/lib/data/rates/register_a_birth.yml
@@ -1,0 +1,5 @@
+---
+- start_date: 2015-04-06
+  end_date: 2016-04-05
+  register_a_birth: 105.00
+  copy_of_birth_registration_certificate: 65.00

--- a/lib/smart_answer/calculators/registrations_data_query.rb
+++ b/lib/smart_answer/calculators/registrations_data_query.rb
@@ -84,6 +84,10 @@ module SmartAnswer::Calculators
       SmartAnswer::Calculators::RatesQuery.new('births_and_deaths_document_return_fees').rates
     end
 
+    def register_a_birth_fees
+      RatesQuery.new('register_a_birth').rates
+    end
+
     def self.registration_data
       @embassy_data ||= YAML.load_file(Rails.root.join("lib", "data", "registrations.yml"))
     end

--- a/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb
@@ -32,8 +32,8 @@
 
   Service | Fee
   -|-
-  Register a birth | £105
-  Copy of a birth registration certificate | £65
+  Register a birth | <%= format_money(reg_data_query.register_a_birth_fees.register_a_birth) %>
+  Copy of a birth registration certificate | <%= format_money(reg_data_query.register_a_birth_fees.copy_of_birth_registration_certificate) %>
 
   You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
 

--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb
@@ -203,8 +203,8 @@
 
   Service | Fee
   -|-
-  Register a birth | £105
-  Copy of a birth registration certificate | £65
+  Register a birth | <%= format_money(reg_data_query.register_a_birth_fees.register_a_birth) %>
+  Copy of a birth registration certificate | <%= format_money(reg_data_query.register_a_birth_fees.copy_of_birth_registration_certificate) %>
 
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: document_return_fees } %>
   <%= render partial: 'shared/births_and_deaths_registration/button.govspeak.erb', locals: { button_data: button_data } %>

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -138,4 +138,4 @@ lib/smart_answer/calculators/marriage_abroad_calculator.rb: 6329b517874ecf732cf3
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 1d222b16a790bcf3f7b02c97b0e0b5b0
 lib/smart_answer/calculators/country_name_formatter.rb: 69a0726640385f42de50b80fdb144ff8
-lib/smart_answer/calculators/registrations_data_query.rb: 563c5db7d7272bc07bd636a92b40f3ce
+lib/smart_answer/calculators/registrations_data_query.rb: 1acf8d5cb091afd13cc510bbe99f4973

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -7,8 +7,8 @@ lib/smart_answer_flows/register-a-birth/outcomes/homeoffice_result.govspeak.erb:
 lib/smart_answer_flows/register-a-birth/outcomes/no_birth_certificate_result.govspeak.erb: 174d68aa0d7cf3922a9e6a1867676359
 lib/smart_answer_flows/register-a-birth/outcomes/no_embassy_result.govspeak.erb: ed56d500311fbe441649c92193f0e631
 lib/smart_answer_flows/register-a-birth/outcomes/no_registration_result.govspeak.erb: 7b60252b078e6aec6f5759e894ce4ffb
-lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb: 61f902aceeebe0c90fb42a998916e0b7
-lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb: eeed695325359da6001774feaa070704
+lib/smart_answer_flows/register-a-birth/outcomes/north_korea_result.govspeak.erb: da2a2e2601d5509d4fd3f647fc9d9951
+lib/smart_answer_flows/register-a-birth/outcomes/oru_result.govspeak.erb: 18ed9f2d7ba14070bfb1630dafb45565
 lib/smart_answer_flows/register-a-birth/questions/childs_date_of_birth.govspeak.erb: e911daf1dc69ce85db372dc4ea3bdd50
 lib/smart_answer_flows/register-a-birth/questions/country_of_birth.govspeak.erb: 31c306c928e71eee86c60352f51ccf83
 lib/smart_answer_flows/register-a-birth/questions/have_you_adopted_the_child.govspeak.erb: 3a9d66656446a508c7232b26778dfa23
@@ -17,13 +17,14 @@ lib/smart_answer_flows/register-a-birth/questions/where_are_you_now.govspeak.erb
 lib/smart_answer_flows/register-a-birth/questions/which_country.govspeak.erb: 913b5637a2814cbd529affffc55b1f72
 lib/smart_answer_flows/register-a-birth/questions/who_has_british_nationality.govspeak.erb: 9a1a1acec4abc5a3f5199ab2eae0cd1c
 lib/smart_answer_flows/register-a-birth/register_a_birth.govspeak.erb: 05cf2d9426fc91f395fc524fdfdac800
+lib/data/rates/register_a_birth.yml: 48884c301d6ca983a38879c70464f0c5
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/data/registrations.yml: 2eb5c61678f21bd9cc06af67c230279f
 lib/smart_answer/calculators/country_name_formatter.rb: 69a0726640385f42de50b80fdb144ff8
-lib/smart_answer/calculators/registrations_data_query.rb: 563c5db7d7272bc07bd636a92b40f3ce
+lib/smart_answer/calculators/registrations_data_query.rb: 1acf8d5cb091afd13cc510bbe99f4973
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029
 test/fixtures/worldwide/afghanistan_organisations.json: 1fd89b60eb079c7b3fddcab985f37366

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -20,7 +20,7 @@ lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.er
 lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 test/fixtures/worldwide/italy_organisations.json: dc5feb424edeeb12835be916605caf46
-lib/smart_answer/calculators/registrations_data_query.rb: 563c5db7d7272bc07bd636a92b40f3ce
+lib/smart_answer/calculators/registrations_data_query.rb: 1acf8d5cb091afd13cc510bbe99f4973
 lib/smart_answer/calculators/country_name_formatter.rb: 69a0726640385f42de50b80fdb144ff8
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -52,6 +52,22 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context 'register a birth fees' do
+        context 'for 2015/16' do
+          should 'be £105 for registering a birth' do
+            rates_query = SmartAnswer::Calculators::RatesQuery.new('register_a_birth')
+            sixth_april_2015 = Date.parse('2015-04-06')
+            assert_equal 105, rates_query.rates(sixth_april_2015).register_a_birth
+          end
+
+          should 'be £65 for a copy of the birth registration certificate' do
+            rates_query = SmartAnswer::Calculators::RatesQuery.new('register_a_birth')
+            sixth_april_2015 = Date.parse('2015-04-06')
+            assert_equal 65, rates_query.rates(sixth_april_2015).copy_of_birth_registration_certificate
+          end
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -67,6 +67,20 @@ module SmartAnswer::Calculators
             assert_equal 65, rates_query.rates(sixth_april_2015).copy_of_birth_registration_certificate
           end
         end
+
+        context 'for 2016/17' do
+          should 'be £150 for registering a birth' do
+            rates_query = SmartAnswer::Calculators::RatesQuery.new('register_a_birth')
+            sixth_april_2015 = Date.parse('2016-04-06')
+            assert_equal 150, rates_query.rates(sixth_april_2015).register_a_birth
+          end
+
+          should 'be £50 for a copy of the birth registration certificate' do
+            rates_query = SmartAnswer::Calculators::RatesQuery.new('register_a_birth')
+            sixth_april_2015 = Date.parse('2016-04-06')
+            assert_equal 50, rates_query.rates(sixth_april_2015).copy_of_birth_registration_certificate
+          end
+        end
       end
     end
   end

--- a/test/unit/calculators/registrations_data_query_test.rb
+++ b/test/unit/calculators/registrations_data_query_test.rb
@@ -68,6 +68,15 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context '#register_a_birth_fees' do
+        should 'instantiate RatesQuery using register_a_birth data' do
+          rates_query = stub(rates: 'register-a-birth-rates')
+          RatesQuery.stubs(:new).with('register_a_birth').returns(rates_query)
+
+          assert_equal 'register-a-birth-rates', RegistrationsDataQuery.new.register_a_birth_fees
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/NNHVAmHF

I've extracted the hardcoded costs from the north_korea_result and oru_result outcome templates and moved them to the new register_a_birth.yml rates file.

I've added the 2016/17 rates and checked that they'll be displayed from 6 April 2016 by changing the date on my local server.

## Expected changes

### URLs to check

* [Afghanistan](https://www.gov.uk/register-a-birth/y/afghanistan/mother/yes/same_country#pay)
* [North Korea](https://www.gov.uk/register-a-birth/y/north-korea/mother/yes/same_country#cost)

### Before 6 April 2016

![register-a-birth-afghanistan-2015-16](https://cloud.githubusercontent.com/assets/6556/14038903/6c10c654-f2bb-11e5-83a9-b2d6a71e8d45.png)
![register-a-birth-north-korea-2015-16](https://cloud.githubusercontent.com/assets/6556/14038904/6c534380-f2bb-11e5-9d9d-96017ff8a315.png)

### After 6 April 2016

![register-a-birth-afghanistan-2016-17](https://cloud.githubusercontent.com/assets/6556/14038906/71fe9cb2-f2bb-11e5-8f08-bce16a30ad9c.png)
![register-a-birth-north-korea-2016-17](https://cloud.githubusercontent.com/assets/6556/14038907/7215f042-f2bb-11e5-9ab0-74f2bfadef51.png)