### PR TITLE
Introduce on_response blocks to set attributes on calculator

### DIFF
--- a/lib/smart_answer/block.rb
+++ b/lib/smart_answer/block.rb
@@ -1,0 +1,14 @@
+module SmartAnswer
+  class Block
+    def initialize(&block)
+      @block = block
+    end
+
+    def evaluate(previous_state, response = nil)
+      args = [response].compact
+      previous_state.instance_exec(*args, &@block)
+      new_state = previous_state.dup
+      new_state.freeze
+    end
+  end
+end

--- a/lib/smart_answer/calculators/overseas_passports_calculator.rb
+++ b/lib/smart_answer/calculators/overseas_passports_calculator.rb
@@ -87,6 +87,10 @@ module SmartAnswer::Calculators
       world_location(location).name
     end
 
+    def valid_current_location?
+      world_location.present?
+    end
+
     def fco_organisation(location = current_location)
       world_location(location).fco_organisation
     end

--- a/lib/smart_answer/calculators/part_year_profit_tax_credits_calculator.rb
+++ b/lib/smart_answer/calculators/part_year_profit_tax_credits_calculator.rb
@@ -16,12 +16,12 @@ module SmartAnswer
       attr_accessor :started_trading_on
       attr_accessor :stopped_trading_on
 
-      def valid_stopped_trading_date?(date)
-        tax_year.include?(date)
+      def valid_stopped_trading_date?
+        tax_year.include?(stopped_trading_on)
       end
 
-      def valid_start_trading_date?(date)
-        date < award_period.ends_on
+      def valid_start_trading_date?
+        started_trading_on < award_period.ends_on
       end
 
       def tax_year

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -55,39 +55,39 @@ module SmartAnswer
         period.number_of_days
       end
 
-      def valid_last_sick_day?(value)
-        period = DateRange.new(begins_on: sick_start_date, ends_on: value)
+      def valid_last_sick_day?
+        period = DateRange.new(begins_on: sick_start_date, ends_on: sick_end_date)
         period.number_of_days >= 1
       end
 
-      def valid_linked_sickness_start_date?(value)
-        sick_start_date > value
+      def valid_linked_sickness_start_date?
+        sick_start_date > linked_sickness_start_date
       end
 
-      def within_eight_weeks_of_current_sickness_period?(previous_sickness_end_date)
+      def within_eight_weeks_of_current_sickness_period?
         earliest_allowed_date = sick_start_date - 8.weeks - 1.day
-        previous_sickness_end_date >= earliest_allowed_date
+        linked_sickness_end_date >= earliest_allowed_date
       end
 
-      def at_least_1_day_before_first_sick_day?(value)
-        value < sick_start_date - 1
+      def at_least_1_day_before_first_sick_day?
+        linked_sickness_end_date < sick_start_date - 1
       end
 
       def valid_period_of_incapacity_for_work?
         days_sick >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
       end
 
-      def valid_linked_period_of_incapacity_for_work?(value)
-        period = DateRange.new(begins_on: linked_sickness_start_date, ends_on: value)
+      def valid_linked_period_of_incapacity_for_work?
+        period = DateRange.new(begins_on: linked_sickness_start_date, ends_on: linked_sickness_end_date)
         period.number_of_days >= MINIMUM_NUMBER_OF_DAYS_IN_PERIOD_OF_INCAPACITY_TO_WORK
       end
 
-      def valid_last_payday_before_sickness?(value)
-        value < sick_start_date
+      def valid_last_payday_before_sickness?
+        relevant_period_to < sick_start_date
       end
 
-      def valid_last_payday_before_offset?(value)
-        value <= pay_day_offset
+      def valid_last_payday_before_offset?
+        relevant_period_from <= pay_day_offset + 1.day
       end
 
       def sick_start_date_for_awe

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -4,7 +4,7 @@ module SmartAnswer
   class Node
     attr_reader :name, :calculations, :next_node_calculations, :precalculations
 
-    def initialize(flow, name, options = {}, &block)
+    def initialize(flow, name, _options = {}, &block)
       @flow = flow
       @name = name
       @on_response_blocks = []

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -7,6 +7,7 @@ module SmartAnswer
     def initialize(flow, name, options = {}, &block)
       @flow = flow
       @name = name
+      @on_response_blocks = []
       @calculations = []
       @next_node_calculations = []
       @precalculations = []
@@ -23,6 +24,10 @@ module SmartAnswer
 
     def filesystem_friendly_name
       to_s.sub(/\?$/, '')
+    end
+
+    def on_response(&block)
+      @on_response_blocks << Block.new(&block)
     end
 
     def calculate(variable_name, &block)

--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -52,8 +52,11 @@ module SmartAnswer
 
       def transition(current_state, raw_input)
         input = parse_input(raw_input)
-        new_state = @next_node_calculations.inject(current_state.dup) do |new_state, calculation|
-          calculation.evaluate(new_state, input)
+        state_after_on_response_blocks = @on_response_blocks.inject(current_state.dup) do |state, block|
+          block.evaluate(state, input)
+        end
+        new_state = @next_node_calculations.inject(state_after_on_response_blocks.dup) do |state, calculation|
+          calculation.evaluate(state, input)
         end
         next_node = next_node_for(new_state, input)
         new_state = new_state.transition_to(next_node, input) do |state|

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -89,8 +89,8 @@ module SmartAnswer
 
         validate_in_range
 
-        validate do |response|
-          calculator.valid_last_sick_day?(response)
+        validate do
+          calculator.valid_last_sick_day?
         end
 
         next_node do
@@ -136,8 +136,8 @@ module SmartAnswer
 
         validate_in_range
 
-        validate :linked_sickness_must_be_before do |response|
-          calculator.valid_linked_sickness_start_date?(response)
+        validate :linked_sickness_must_be_before do
+          calculator.valid_linked_sickness_start_date?
         end
 
         next_node do
@@ -156,16 +156,16 @@ module SmartAnswer
 
         validate_in_range
 
-        validate :must_be_within_eight_weeks do |response|
-          calculator.within_eight_weeks_of_current_sickness_period?(response)
+        validate :must_be_within_eight_weeks do
+          calculator.within_eight_weeks_of_current_sickness_period?
         end
 
-        validate :must_be_at_least_1_day_before_first_sick_day do |response|
-          calculator.at_least_1_day_before_first_sick_day?(response)
+        validate :must_be_at_least_1_day_before_first_sick_day do
+          calculator.at_least_1_day_before_first_sick_day?
         end
 
-        validate :must_be_valid_period_of_incapacity_for_work do |response|
-          calculator.valid_linked_period_of_incapacity_for_work?(response)
+        validate :must_be_valid_period_of_incapacity_for_work do
+          calculator.valid_linked_period_of_incapacity_for_work?
         end
 
         next_node do
@@ -233,8 +233,8 @@ module SmartAnswer
           calculator.relevant_period_to = response
         end
 
-        validate do |response|
-          calculator.valid_last_payday_before_sickness?(response)
+        validate do
+          calculator.valid_last_payday_before_sickness?
         end
 
         next_node do
@@ -256,8 +256,8 @@ module SmartAnswer
           calculator.relevant_period_from = response + 1.day
         end
 
-        validate do |response|
-          calculator.valid_last_payday_before_offset?(response)
+        validate do
+          calculator.valid_last_payday_before_offset?
         end
 
         next_node do

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -15,12 +15,12 @@ module SmartAnswer
         option :statutory_adoption_pay
         option :additional_statutory_paternity_pay
 
-        next_node_calculation :calculator do
-          Calculators::StatutorySickPayCalculator.new
+        on_response do |response|
+          self.calculator = Calculators::StatutorySickPayCalculator.new
+          calculator.other_pay_types_received = response.split(",")
         end
 
-        next_node do |response|
-          calculator.other_pay_types_received = response.split(",")
+        next_node do
           if calculator.already_getting_maternity_pay?
             outcome :already_getting_maternity
           else
@@ -34,12 +34,15 @@ module SmartAnswer
         option :yes
         option :no
 
-        next_node do |response|
+        on_response do |response|
           if response == 'yes'
             calculator.enough_notice_of_absence = true
           else
             calculator.enough_notice_of_absence = false
           end
+        end
+
+        next_node do
           question :employee_work_different_days?
         end
       end
@@ -63,10 +66,14 @@ module SmartAnswer
       date_question :first_sick_day? do
         from { Date.new(2011, 1, 1) }
         to { Date.today.end_of_year }
+
+        on_response do |response|
+          calculator.sick_start_date = response
+        end
+
         validate_in_range
 
-        next_node do |response|
-          calculator.sick_start_date = response
+        next_node do
           question :last_sick_day?
         end
       end
@@ -75,14 +82,18 @@ module SmartAnswer
       date_question :last_sick_day? do
         from { Date.new(2011, 1, 1) }
         to { Date.today.end_of_year }
+
+        on_response do |response|
+          calculator.sick_end_date = response
+        end
+
         validate_in_range
 
         validate do |response|
           calculator.valid_last_sick_day?(response)
         end
 
-        next_node do |response|
-          calculator.sick_end_date = response
+        next_node do
           if calculator.valid_period_of_incapacity_for_work?
             question :has_linked_sickness?
           else
@@ -96,13 +107,19 @@ module SmartAnswer
         option :yes
         option :no
 
-        next_node do |response|
+        on_response do |response|
           case response
           when 'yes'
             calculator.has_linked_sickness = true
-            question :linked_sickness_start_date?
           when 'no'
             calculator.has_linked_sickness = false
+          end
+        end
+
+        next_node do
+          if calculator.has_linked_sickness
+            question :linked_sickness_start_date?
+          else
             question :paid_at_least_8_weeks?
           end
         end
@@ -112,14 +129,18 @@ module SmartAnswer
       date_question :linked_sickness_start_date? do
         from { Date.new(2010, 1, 1) }
         to { Date.today.end_of_year }
+
+        on_response do |response|
+          calculator.linked_sickness_start_date = response
+        end
+
         validate_in_range
 
         validate :linked_sickness_must_be_before do |response|
           calculator.valid_linked_sickness_start_date?(response)
         end
 
-        next_node do |response|
-          calculator.linked_sickness_start_date = response
+        next_node do
           question :linked_sickness_end_date?
         end
       end
@@ -128,6 +149,11 @@ module SmartAnswer
       date_question :linked_sickness_end_date? do
         from { Date.new(2010, 1, 1) }
         to { Date.today.end_of_year }
+
+        on_response do |response|
+          calculator.linked_sickness_end_date = response
+        end
+
         validate_in_range
 
         validate :must_be_within_eight_weeks do |response|
@@ -142,8 +168,7 @@ module SmartAnswer
           calculator.valid_linked_period_of_incapacity_for_work?(response)
         end
 
-        next_node do |response|
-          calculator.linked_sickness_end_date = response
+        next_node do
           question :paid_at_least_8_weeks?
         end
       end
@@ -158,8 +183,11 @@ module SmartAnswer
           calculator.sick_start_date_for_awe
         end
 
-        next_node do |response|
+        on_response do |response|
           calculator.eight_weeks_earnings = response
+        end
+
+        next_node do
           if calculator.paid_at_least_8_weeks_of_earnings?
             question :how_often_pay_employee_pay_patterns? # Question 7.2
           elsif calculator.paid_less_than_8_weeks_of_earnings?
@@ -178,8 +206,11 @@ module SmartAnswer
         option :monthly
         option :irregularly
 
-        next_node do |response|
+        on_response do |response|
           calculator.pay_pattern = response
+        end
+
+        next_node do
           if calculator.paid_at_least_8_weeks_of_earnings?
             question :last_payday_before_sickness? # Question 8
           else
@@ -198,12 +229,15 @@ module SmartAnswer
           calculator.sick_start_date_for_awe
         end
 
+        on_response do |response|
+          calculator.relevant_period_to = response
+        end
+
         validate do |response|
           calculator.valid_last_payday_before_sickness?(response)
         end
 
-        next_node do |response|
-          calculator.relevant_period_to = response
+        next_node do
           question :last_payday_before_offset?
         end
       end
@@ -218,12 +252,15 @@ module SmartAnswer
           calculator.pay_day_offset
         end
 
+        on_response do |response|
+          calculator.relevant_period_from = response + 1.day
+        end
+
         validate do |response|
           calculator.valid_last_payday_before_offset?(response)
         end
 
-        next_node do |response|
-          calculator.relevant_period_from = response + 1.day
+        next_node do
           question :total_employee_earnings?
         end
       end
@@ -238,8 +275,11 @@ module SmartAnswer
           calculator.relevant_period_to
         end
 
-        next_node do |response|
+        on_response do |response|
           calculator.total_employee_earnings = response
+        end
+
+        next_node do
           question :usual_work_days?
         end
       end
@@ -250,32 +290,44 @@ module SmartAnswer
           calculator.sick_start_date_for_awe
         end
 
-        next_node do |response|
+        on_response do |response|
           calculator.relevant_contractual_pay = response
+        end
+
+        next_node do
           question :contractual_days_covered_by_earnings?
         end
       end
 
       # Question 9.1
       value_question :contractual_days_covered_by_earnings? do
-        next_node do |response|
+        on_response do |response|
           calculator.contractual_days_covered_by_earnings = response
+        end
+
+        next_node do
           question :usual_work_days?
         end
       end
 
       # Question 10
       money_question :total_earnings_before_sick_period? do
-        next_node do |response|
+        on_response do |response|
           calculator.total_earnings_before_sick_period = response
+        end
+
+        next_node do
           question :days_covered_by_earnings?
         end
       end
 
       # Question 10.1
       value_question :days_covered_by_earnings? do
-        next_node do |response|
+        on_response do |response|
           calculator.days_covered_by_earnings = response.to_i
+        end
+
+        next_node do
           question :usual_work_days?
         end
       end
@@ -284,8 +336,11 @@ module SmartAnswer
       checkbox_question :usual_work_days? do
         %w{1 2 3 4 5 6 0}.each { |n| option n.to_s }
 
-        next_node do |response|
+        on_response do |response|
           calculator.days_of_the_week_worked = response.split(",")
+        end
+
+        next_node do
           if calculator.not_earned_enough?
             outcome :not_earned_enough
           elsif calculator.maximum_entitlement_reached?

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -10,16 +10,16 @@ module SmartAnswer
 
       # Q1
       country_select :what_passport_do_you_have?, additional_countries: additional_countries, exclude_countries: Calculators::UkVisaCalculator::EXCLUDE_COUNTRIES do
-        next_node_calculation :calculator do
-          Calculators::UkVisaCalculator.new
+        on_response do |response|
+          self.calculator = Calculators::UkVisaCalculator.new
+          calculator.passport_country = response
         end
 
         calculate :purpose_of_visit_answer do
           nil
         end
 
-        next_node do |response|
-          calculator.passport_country = response
+        next_node do
           if calculator.passport_country_is_israel?
             question :israeli_document_type?
           elsif calculator.passport_country_in_eea?
@@ -35,8 +35,11 @@ module SmartAnswer
         option :"full-passport"
         option :"provisional-passport"
 
-        next_node do |response|
+        on_response do |response|
           calculator.passport_country = 'israel-provisional-passport' if response == 'provisional-passport'
+        end
+
+        next_node do
           question :purpose_of_visit?
         end
       end
@@ -53,9 +56,11 @@ module SmartAnswer
         option :medical
         option :diplomatic
 
-        next_node do |response|
+        on_response do |response|
           calculator.purpose_of_visit_answer = response
+        end
 
+        next_node do
           if calculator.study_visit? || calculator.work_visit?
             next question(:staying_for_how_long?)
           end
@@ -130,9 +135,11 @@ module SmartAnswer
         option :yes
         option :no
 
-        next_node do |response|
+        on_response do |response|
           calculator.passing_through_uk_border_control_answer = response
+        end
 
+        next_node do
           if calculator.passing_through_uk_border_control?
             if calculator.passport_country_is_taiwan?
               outcome :outcome_transit_taiwan_through_border_control

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -19,12 +19,12 @@ module SmartAnswer
 
       # Q1
       country_select :country_of_ceremony?, exclude_countries: exclude_countries do
-        next_node_calculation :calculator do
-          Calculators::MarriageAbroadCalculator.new
+        on_response do |response|
+          self.calculator = Calculators::MarriageAbroadCalculator.new
+          calculator.ceremony_country = response
         end
 
-        next_node do |response|
-          calculator.ceremony_country = response
+        next_node do
           if calculator.ceremony_country == 'ireland'
             question :partner_opposite_or_same_sex?
           elsif %w(france monaco new-caledonia wallis-and-futuna).include?(calculator.ceremony_country)
@@ -43,8 +43,11 @@ module SmartAnswer
         option :ceremony_country
         option :third_country
 
-        next_node do |response|
+        on_response do |response|
           calculator.resident_of = response
+        end
+
+        next_node do
           if calculator.ceremony_country == 'switzerland'
             question :partner_opposite_or_same_sex?
           else
@@ -58,8 +61,11 @@ module SmartAnswer
         option :marriage
         option :pacs
 
-        next_node do |response|
+        on_response do |response|
           calculator.marriage_or_pacs = response
+        end
+
+        next_node do
           if calculator.ceremony_country == 'monaco'
             outcome :outcome_ceremonies_in_monaco
           elsif calculator.want_to_get_married?
@@ -76,8 +82,11 @@ module SmartAnswer
         option :partner_local
         option :partner_other
 
-        next_node do |response|
+        on_response do |response|
           calculator.partner_nationality = response
+        end
+
+        next_node do
           question :partner_opposite_or_same_sex?
         end
       end
@@ -87,8 +96,11 @@ module SmartAnswer
         option :opposite_sex
         option :same_sex
 
-        next_node do |response|
+        on_response do |response|
           calculator.sex_of_your_partner = response
+        end
+
+        next_node do
           if calculator.ceremony_country == 'brazil' && calculator.resident_outside_of_uk?
             outcome :outcome_marriage_in_brazil_when_residing_in_brazil_or_third_country
           elsif calculator.ceremony_country == "netherlands"

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -13,8 +13,8 @@ module SmartAnswer
           calculator.current_location = response
         end
 
-        validate do |response|
-          calculator.world_location(response)
+        validate do
+          calculator.valid_current_location?
         end
 
         calculate :overseas_passports_embassies do |response|

--- a/lib/smart_answer_flows/part-year-profit-tax-credits.rb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits.rb
@@ -11,12 +11,12 @@ module SmartAnswer
         from { Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE }
         to   { Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_LATEST_DATE }
 
-        next_node_calculation :calculator do
-          Calculators::PartYearProfitTaxCreditsCalculator.new
+        on_response do |response|
+          self.calculator = Calculators::PartYearProfitTaxCreditsCalculator.new
+          calculator.tax_credits_award_ends_on = response
         end
 
-        next_node do |response|
-          calculator.tax_credits_award_ends_on = response
+        next_node do
           question :what_date_do_your_accounts_go_up_to?
         end
       end
@@ -24,8 +24,11 @@ module SmartAnswer
       date_question :what_date_do_your_accounts_go_up_to? do
         default_year { 0 }
 
-        next_node do |response|
+        on_response do |response|
           calculator.accounts_end_month_and_day = response
+        end
+
+        next_node do
           question :have_you_stopped_trading?
         end
       end
@@ -34,12 +37,18 @@ module SmartAnswer
         option "yes"
         option "no"
 
-        next_node do |response|
+        on_response do |response|
           if response == 'yes'
             calculator.stopped_trading = true
-            question :did_you_start_trading_before_the_relevant_accounting_year?
           elsif response == 'no'
             calculator.stopped_trading = false
+          end
+        end
+
+        next_node do
+          if calculator.stopped_trading
+            question :did_you_start_trading_before_the_relevant_accounting_year?
+          else
             question :do_your_accounts_cover_a_12_month_period?
           end
         end
@@ -67,12 +76,15 @@ module SmartAnswer
         precalculate(:tax_year_begins_on) { calculator.tax_year.begins_on }
         precalculate(:tax_year_ends_on)   { calculator.tax_year.ends_on }
 
+        on_response do |response|
+          calculator.stopped_trading_on = response
+        end
+
         validate(:not_in_tax_year_error) do |response|
           calculator.valid_stopped_trading_date?(response)
         end
 
-        next_node do |response|
-          calculator.stopped_trading_on = response
+        next_node do
           question :what_is_your_taxable_profit?
         end
       end
@@ -98,12 +110,15 @@ module SmartAnswer
 
         precalculate(:award_period_ends_on) { calculator.award_period.ends_on }
 
+        on_response do |response|
+          calculator.started_trading_on = response
+        end
+
         validate(:invalid_start_trading_date) do |response|
           calculator.valid_start_trading_date?(response)
         end
 
-        next_node do |response|
-          calculator.started_trading_on = response
+        next_node do
           if calculator.stopped_trading
             question :when_did_you_stop_trading?
           else
@@ -116,8 +131,11 @@ module SmartAnswer
         precalculate(:basis_period_begins_on) { calculator.basis_period.begins_on }
         precalculate(:basis_period_ends_on)   { calculator.basis_period.ends_on }
 
-        next_node do |response|
+        on_response do |response|
           calculator.taxable_profit = response
+        end
+
+        next_node do
           outcome :result
         end
       end

--- a/lib/smart_answer_flows/part-year-profit-tax-credits.rb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits.rb
@@ -80,8 +80,8 @@ module SmartAnswer
           calculator.stopped_trading_on = response
         end
 
-        validate(:not_in_tax_year_error) do |response|
-          calculator.valid_stopped_trading_date?(response)
+        validate(:not_in_tax_year_error) do
+          calculator.valid_stopped_trading_date?
         end
 
         next_node do
@@ -114,8 +114,8 @@ module SmartAnswer
           calculator.started_trading_on = response
         end
 
-        validate(:invalid_start_trading_date) do |response|
-          calculator.valid_start_trading_date?(response)
+        validate(:invalid_start_trading_date) do
+          calculator.valid_start_trading_date?
         end
 
         next_node do

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-statutory-sick-pay.rb: d2c0aae4754ffe424ec0cdbe5e1c73c5
+lib/smart_answer_flows/calculate-statutory-sick-pay.rb: b01febd3a3febdcbba3c908ffbe5a348
 test/data/calculate-statutory-sick-pay-questions-and-responses.yml: dfd8baf65a8c26430cf17958e8908202
 test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: b42519fbb030e7eaf0912d1de0b8ff47
 lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: f91dc1d321c164a06271889100875600
@@ -29,5 +29,5 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/questions/pay_amount_if_not_
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_before_sick_period.govspeak.erb: 46ce81328d55d2bef88bb1047cf047cd
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.govspeak.erb: 77831bed05434968d38648a40d3ce6e9
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/usual_work_days.govspeak.erb: 5570b649de33ac95bf274bcae70895a9
-lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: e9d02e8ed9aea95c76b2d477af9c78f7
+lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 90c89eabd2e47837ffe538ae27706552
 lib/data/rates/statutory_sick_pay.yml: b275311f2ec89fc707e6b9cfefec1179

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/check-uk-visa.rb: 9846edf0584404b1433d5f200ba9b660
+lib/smart_answer_flows/check-uk-visa.rb: 18ff6d2173bdb8d0e10ad4c986d03c96
 test/data/check-uk-visa-questions-and-responses.yml: db3081a2a7162f108baa5ff00706c9fd
 test/data/check-uk-visa-responses-and-expected-results.yml: 60d4090bdf290693442b66d5ab86102e
 lib/smart_answer_flows/check-uk-visa/check_uk_visa.govspeak.erb: a442b4ddd169b26a401c70d145e5b44e

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: 5f58f1ff2e3e5c4852565a8eeccd4b52
+lib/smart_answer_flows/marriage-abroad.rb: 9395e453c566da3c506d4ccf9b27df87
 test/data/marriage-abroad-questions-and-responses.yml: 2debf4d9c0e525b5fe3b44ca701e36e0
 test/data/marriage-abroad-responses-and-expected-results.yml: b1415318b0ecdba069d2fb6e601d4da1
 lib/smart_answer_flows/marriage-abroad/marriage_abroad.govspeak.erb: b4d0cfc1c7c4776d968c9b5b6df85027

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/overseas-passports.rb: bcefe18e039544b984cc13eb158f4922
+lib/smart_answer_flows/overseas-passports.rb: 76b05a5d6301934e46bd13247a8abf01
 test/data/overseas-passports-questions-and-responses.yml: 4c6749fcf0a37deb135fc8c94fa52bc7
 test/data/overseas-passports-responses-and-expected-results.yml: aca0c7e72dfbf84606a47cb7d6d7f758
 lib/smart_answer_flows/overseas-passports/outcomes/_cost.govspeak.erb: 548eee239b4195e500d106f6b72f26ce
@@ -42,7 +42,7 @@ lib/smart_answer_flows/overseas-passports/questions/which_best_describes_you_adu
 lib/smart_answer_flows/overseas-passports/questions/which_best_describes_you_child.govspeak.erb: 61c9f0f7d1960caacc77fad1544cfa26
 lib/smart_answer_flows/overseas-passports/questions/which_country_are_you_in.govspeak.erb: dc6f1404e792f12c110ce248286c167f
 lib/smart_answer_flows/overseas-passports/questions/which_opt.govspeak.erb: 0f629592f57a5ec972f23bf170d37714
-lib/smart_answer/calculators/overseas_passports_calculator.rb: 37714b3c979b3af92b6d6d6b017bc5ae
+lib/smart_answer/calculators/overseas_passports_calculator.rb: 38bcdc2df765fd89b47391bdcaeb0792
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1d83fae34e0ee72ce1c1554bdb766d21
 lib/smart_answer/overseas_passports_helper.rb: 07df4cd921e62464c2dc9534b4d8cdf8
 lib/smart_answer/calculators/passport_and_embassy_data_query.rb: 21c2a74b8496d437ffd204d70ad5b366

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -1,0 +1,67 @@
+require_relative '../test_helper'
+
+module SmartAnswer
+  class BlockTest < ActiveSupport::TestCase
+    context '#evaluate' do
+      setup do
+        @state = State.new(:node_key)
+      end
+
+      should 'make response available to block' do
+        saved_response = nil
+        block = Block.new do |response|
+          saved_response = response
+        end
+        block.evaluate(@state, :answer)
+        assert_equal :answer, saved_response
+      end
+
+      should 'default response to nil' do
+        saved_response = nil
+        block = Block.new do |response|
+          saved_response = response
+        end
+        block.evaluate(@state, nil)
+        assert_nil saved_response
+      end
+
+      should 'allow block to read state variables' do
+        @state.foo = :initial_value
+        saved_value = nil
+        block = Block.new do
+          saved_value = foo
+        end
+        block.evaluate(@state)
+        assert_equal :initial_value, saved_value
+      end
+
+      should 'allow block to make changes to state variables' do
+        @state.foo = :initial_value
+        block = Block.new do
+          self.foo = :new_value
+        end
+        new_state = block.evaluate(@state)
+        assert_equal :new_value, new_state.foo
+      end
+
+      should 'return a new state instance' do
+        block = Block.new {}
+        new_state = block.evaluate(@state)
+        refute_same @state, new_state
+      end
+
+      should 'freeze new state' do
+        block = Block.new {}
+        new_state = block.evaluate(@state)
+        assert new_state.frozen?
+      end
+
+      should 'copy initial state variables into new state' do
+        @state.foo = :initial_value
+        block = Block.new {}
+        block.evaluate(@state)
+        assert_equal :initial_value, @state.foo
+      end
+    end
+  end
+end

--- a/test/unit/calculation_test.rb
+++ b/test/unit/calculation_test.rb
@@ -1,0 +1,75 @@
+require_relative '../test_helper'
+
+module SmartAnswer
+  class CalculationTest < ActiveSupport::TestCase
+    context '#evaluate' do
+      setup do
+        @state = State.new(:node_key)
+      end
+
+      should 'make response available to calculation' do
+        saved_response = nil
+        calculation = Calculation.new(:bar) do |response|
+          saved_response = response
+        end
+        calculation.evaluate(@state, :answer)
+        assert_equal :answer, saved_response
+      end
+
+      should 'default response to nil' do
+        saved_response = nil
+        calculation = Calculation.new(:bar) do |response|
+          saved_response = response
+        end
+        calculation.evaluate(@state, nil)
+        assert_nil saved_response
+      end
+
+      should 'allow calculation to read state variables' do
+        @state.foo = :initial_value
+        saved_value = nil
+        calculation = Calculation.new(:bar) do
+          saved_value = foo
+        end
+        calculation.evaluate(@state)
+        assert_equal :initial_value, saved_value
+      end
+
+      should 'allow calculation to make changes to state variables' do
+        @state.foo = :initial_value
+        calculation = Calculation.new(:bar) do
+          self.foo = :new_value
+        end
+        new_state = calculation.evaluate(@state)
+        assert_equal :new_value, new_state.foo
+      end
+
+      should 'assign block return value to state variable' do
+        calculation = Calculation.new(:bar) do
+          :new_value
+        end
+        new_state = calculation.evaluate(@state)
+        assert_equal :new_value, new_state.bar
+      end
+
+      should 'return a new state instance' do
+        calculation = Calculation.new(:bar) {}
+        new_state = calculation.evaluate(@state)
+        refute_same @state, new_state
+      end
+
+      should 'freeze new state' do
+        calculation = Calculation.new(:bar) {}
+        new_state = calculation.evaluate(@state)
+        assert new_state.frozen?
+      end
+
+      should 'copy initial state variables into new state' do
+        @state.foo = :initial_value
+        calculation = Calculation.new(:bar) {}
+        calculation.evaluate(@state)
+        assert_equal :initial_value, @state.foo
+      end
+    end
+  end
+end

--- a/test/unit/calculators/overseas_passports_calculator_test.rb
+++ b/test/unit/calculators/overseas_passports_calculator_test.rb
@@ -629,6 +629,22 @@ module SmartAnswer
           end
         end
       end
+
+      context '#valid_current_location?' do
+        setup do
+          @calculator = OverseasPassportsCalculator.new
+        end
+
+        should 'be truthy if world_location is present?' do
+          @calculator.stubs(:world_location).returns(stub('world-location'))
+          assert @calculator.valid_current_location?
+        end
+
+        should 'be falsey if world_location is not present?' do
+          @calculator.stubs(:world_location).returns(nil)
+          refute @calculator.valid_current_location?
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/part_year_profit_calculator_test.rb
+++ b/test/unit/calculators/part_year_profit_calculator_test.rb
@@ -10,16 +10,20 @@ module SmartAnswer
         end
 
         should 'be valid if the stopped trading date is in the tax year that the tax credits award ended' do
-          assert @calculator.valid_stopped_trading_date?(Date.parse('2015-04-06'))
-          assert @calculator.valid_stopped_trading_date?(Date.parse('2016-04-05'))
+          @calculator.stopped_trading_on = Date.parse('2015-04-06')
+          assert @calculator.valid_stopped_trading_date?
+          @calculator.stopped_trading_on = Date.parse('2016-04-05')
+          assert @calculator.valid_stopped_trading_date?
         end
 
         should 'be invalid if the stopped trading date is before the tax year that the tax credits award ended' do
-          refute @calculator.valid_stopped_trading_date?(Date.parse('2015-04-05'))
+          @calculator.stopped_trading_on = Date.parse('2015-04-05')
+          refute @calculator.valid_stopped_trading_date?
         end
 
         should 'be invalid if the stopped trading date is after the tax year that the tax credits award ended' do
-          refute @calculator.valid_stopped_trading_date?(Date.parse('2016-04-06'))
+          @calculator.stopped_trading_on = Date.parse('2016-04-06')
+          refute @calculator.valid_stopped_trading_date?
         end
       end
 
@@ -34,12 +38,15 @@ module SmartAnswer
           end
 
           should 'be valid if the date is before the date the tax credits award ends' do
-            assert @calculator.valid_start_trading_date?(Date.parse('2015-07-31'))
+            @calculator.started_trading_on = Date.parse('2015-07-31')
+            assert @calculator.valid_start_trading_date?
           end
 
           should 'be invalid if the date is on or after the date the tax credits award ends' do
-            refute @calculator.valid_start_trading_date?(Date.parse('2015-08-01'))
-            refute @calculator.valid_start_trading_date?(Date.parse('2016-01-01'))
+            @calculator.started_trading_on = Date.parse('2015-08-01')
+            refute @calculator.valid_start_trading_date?
+            @calculator.started_trading_on = Date.parse('2016-01-01')
+            refute @calculator.valid_start_trading_date?
           end
         end
 
@@ -50,12 +57,15 @@ module SmartAnswer
           end
 
           should 'be valid if the date is before the date the business stopped trading' do
-            assert @calculator.valid_start_trading_date?(Date.parse('2015-06-30'))
+            @calculator.started_trading_on = Date.parse('2015-06-30')
+            assert @calculator.valid_start_trading_date?
           end
 
           should 'be invalid if the date is on or after the date the business stopped trading' do
-            refute @calculator.valid_start_trading_date?(Date.parse('2015-07-01'))
-            refute @calculator.valid_start_trading_date?(Date.parse('2016-01-01'))
+            @calculator.started_trading_on = Date.parse('2015-07-01')
+            refute @calculator.valid_start_trading_date?
+            @calculator.started_trading_on = Date.parse('2016-01-01')
+            refute @calculator.valid_start_trading_date?
           end
         end
       end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -288,6 +288,21 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal ['red', Date.parse('2011-02-01')], flow.process(['red', { year: 2011, month: 2, day: 1 }]).responses
   end
 
+  should "evaluate on_response block" do
+    flow = SmartAnswer::Flow.new do
+      money_question :how_much? do
+        on_response do |response|
+          self.price = response
+        end
+        next_node { outcome :done }
+      end
+      outcome :done
+    end
+
+    state = flow.process(["1"])
+    assert_equal SmartAnswer::Money.new('1'), state.price
+  end
+
   should "perform calculations on saved inputs" do
     flow = SmartAnswer::Flow.new do
       money_question :how_much? do

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -46,58 +46,67 @@ module SmartAnswer
 
     context 'when answering linked_sickness_end_date? question' do
       context 'and linked sickness ends more than 8 weeks before sickness starts' do
+        setup do
+          @calculator.linked_sickness_start_date = Date.parse('2015-01-01')
+          @calculator.days_of_the_week_worked = %w(1 2 3 4 5)
+          @calculator.stubs(
+            within_eight_weeks_of_current_sickness_period?: false,
+            at_least_1_day_before_first_sick_day?: true,
+            valid_linked_period_of_incapacity_for_work?: true
+          )
+        end
+
         should 'raise an exception' do
           exception = assert_raise(SmartAnswer::InvalidResponse) do
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-07',
-              initial_state: {
-                calculator: stub('calculator', {
-                  linked_sickness_start_date: Date.parse('2015-01-01'),
-                  days_of_the_week_worked: %w(1 2 3 4 5),
-                  within_eight_weeks_of_current_sickness_period?: false,
-                  at_least_1_day_before_first_sick_day?: true,
-                  valid_linked_period_of_incapacity_for_work?: true
-                }),
-              })
+              initial_state: { calculator: @calculator }
+            )
           end
           assert_equal 'must_be_within_eight_weeks', exception.message
         end
       end
 
       context 'and linked sickness ends the day before sickness starts' do
+        setup do
+          @calculator.linked_sickness_start_date = Date.parse('2015-01-01')
+          @calculator.days_of_the_week_worked = %w(1 2 3 4 5)
+          @calculator.stubs(
+            within_eight_weeks_of_current_sickness_period?: true,
+            at_least_1_day_before_first_sick_day?: false,
+            valid_linked_period_of_incapacity_for_work?: true
+          )
+        end
+
         should 'raise an exception' do
           exception = assert_raise(SmartAnswer::InvalidResponse) do
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-31',
-              initial_state: {
-                calculator: stub('calculator', {
-                  linked_sickness_start_date: Date.parse('2015-01-01'),
-                  days_of_the_week_worked: %w(1 2 3 4 5),
-                  within_eight_weeks_of_current_sickness_period?: true,
-                  at_least_1_day_before_first_sick_day?: false,
-                  valid_linked_period_of_incapacity_for_work?: true
-                }),
-              })
+              initial_state: { calculator: @calculator }
+            )
           end
           assert_equal 'must_be_at_least_1_day_before_first_sick_day', exception.message
         end
       end
 
       context 'and linked sickness period is less than 4 calendar days long' do
+        setup do
+          @calculator.sick_start_date = Date.parse('2015-02-01')
+          @calculator.linked_sickness_start_date = Date.parse('2015-01-01')
+          @calculator.days_of_the_week_worked = %w(1 2 3 4 5)
+          @calculator.stubs(
+            within_eight_weeks_of_current_sickness_period?: true,
+            at_least_1_day_before_first_sick_day?: true,
+            valid_linked_period_of_incapacity_for_work?: false
+          )
+        end
+
         should 'raise an exception' do
           exception = assert_raise(SmartAnswer::InvalidResponse) do
             setup_states_for_question(:linked_sickness_end_date?,
               responding_with: '2015-01-03',
-              initial_state: {
-                calculator: stub('calculator', {
-                  sick_start_date: Date.parse('2015-02-01'),
-                  linked_sickness_start_date: Date.parse('2015-01-01'),
-                  days_of_the_week_worked: %w(1 2 3 4 5),
-                  within_eight_weeks_of_current_sickness_period?: true,
-                  at_least_1_day_before_first_sick_day?: true,
-                  valid_linked_period_of_incapacity_for_work?: false
-                }),
-              })
+              initial_state: { calculator: @calculator }
+            )
           end
           assert_equal 'must_be_valid_period_of_incapacity_for_work', exception.message
         end

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -60,7 +60,8 @@ module SmartAnswer
 
         should 'raise an exception' do
           exception = assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(:linked_sickness_end_date?,
+            setup_states_for_question(
+              :linked_sickness_end_date?,
               responding_with: '2015-01-07',
               initial_state: { calculator: @calculator }
             )
@@ -76,7 +77,8 @@ module SmartAnswer
 
         should 'raise an exception' do
           exception = assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(:linked_sickness_end_date?,
+            setup_states_for_question(
+              :linked_sickness_end_date?,
               responding_with: '2015-01-31',
               initial_state: { calculator: @calculator }
             )
@@ -92,7 +94,8 @@ module SmartAnswer
 
         should 'raise an exception' do
           exception = assert_raise(SmartAnswer::InvalidResponse) do
-            setup_states_for_question(:linked_sickness_end_date?,
+            setup_states_for_question(
+              :linked_sickness_end_date?,
               responding_with: '2015-01-03',
               initial_state: { calculator: @calculator }
             )

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -46,8 +46,6 @@ module SmartAnswer
 
     context 'when answering linked_sickness_end_date? question' do
       setup do
-        @calculator.linked_sickness_start_date = Date.parse('2015-01-01')
-        @calculator.days_of_the_week_worked = %w(1 2 3 4 5)
         @calculator.stubs(
           within_eight_weeks_of_current_sickness_period?: true,
           at_least_1_day_before_first_sick_day?: true,
@@ -89,7 +87,6 @@ module SmartAnswer
 
       context 'and linked sickness period is less than 4 calendar days long' do
         setup do
-          @calculator.sick_start_date = Date.parse('2015-02-01')
           @calculator.stubs(valid_linked_period_of_incapacity_for_work?: false)
         end
 

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -45,15 +45,19 @@ module SmartAnswer
     end
 
     context 'when answering linked_sickness_end_date? question' do
+      setup do
+        @calculator.linked_sickness_start_date = Date.parse('2015-01-01')
+        @calculator.days_of_the_week_worked = %w(1 2 3 4 5)
+        @calculator.stubs(
+          within_eight_weeks_of_current_sickness_period?: true,
+          at_least_1_day_before_first_sick_day?: true,
+          valid_linked_period_of_incapacity_for_work?: true
+        )
+      end
+
       context 'and linked sickness ends more than 8 weeks before sickness starts' do
         setup do
-          @calculator.linked_sickness_start_date = Date.parse('2015-01-01')
-          @calculator.days_of_the_week_worked = %w(1 2 3 4 5)
-          @calculator.stubs(
-            within_eight_weeks_of_current_sickness_period?: false,
-            at_least_1_day_before_first_sick_day?: true,
-            valid_linked_period_of_incapacity_for_work?: true
-          )
+          @calculator.stubs(within_eight_weeks_of_current_sickness_period?: false)
         end
 
         should 'raise an exception' do
@@ -69,13 +73,7 @@ module SmartAnswer
 
       context 'and linked sickness ends the day before sickness starts' do
         setup do
-          @calculator.linked_sickness_start_date = Date.parse('2015-01-01')
-          @calculator.days_of_the_week_worked = %w(1 2 3 4 5)
-          @calculator.stubs(
-            within_eight_weeks_of_current_sickness_period?: true,
-            at_least_1_day_before_first_sick_day?: false,
-            valid_linked_period_of_incapacity_for_work?: true
-          )
+          @calculator.stubs(at_least_1_day_before_first_sick_day?: false)
         end
 
         should 'raise an exception' do
@@ -92,13 +90,7 @@ module SmartAnswer
       context 'and linked sickness period is less than 4 calendar days long' do
         setup do
           @calculator.sick_start_date = Date.parse('2015-02-01')
-          @calculator.linked_sickness_start_date = Date.parse('2015-01-01')
-          @calculator.days_of_the_week_worked = %w(1 2 3 4 5)
-          @calculator.stubs(
-            within_eight_weeks_of_current_sickness_period?: true,
-            at_least_1_day_before_first_sick_day?: true,
-            valid_linked_period_of_incapacity_for_work?: false
-          )
+          @calculator.stubs(valid_linked_period_of_incapacity_for_work?: false)
         end
 
         should 'raise an exception' do


### PR DESCRIPTION
## Description

Supersedes #2405.

Trello card: https://trello.com/c/V6nqIWcJ

The idea is that we'll use these `on_response` blocks in a question block to set attributes on the calculator/policy object instead of doing that in `next_node` blocks which is the current "new-style" approach.

I've updated the following flows to use the new `on_response` blocks:

* calculate-statutory-sick-pay
* check-uk-visa
* marriage-abroad
* overseas-passports
* part-year-profit-tax-credits

These are the only flows which use the new-style pattern of instantiating a calculator object in the first question, setting each response as an attribute on the calculator, and encapsulating all the policy logic in the calculator. I don't think it makes sense to apply the same approach to any of the other flows until they have been converted closer to the new-style.

## Motivation

One advantage of doing this is to separate out the attribute-setting code which should make it easier to do automatically in future. Theoretically the `next_node` block will only need access to the calculator and not to the response.

Another advantage is that we can avoid having to pass the response into any validation-related methods on the calculator which should make them more ActiveModel-like.

The new `on_response` blocks are run before both `next_node_calculation` and `validate` blocks.

## External changes

None. This is just a refactoring.
