### PR TITLE
Re-start A/B/C test on 'Start now' buttons

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -1,3 +1,5 @@
+//= require start-now-button-abc-tests
+
 function browserSupportsHtml5HistoryApi() {
   return !! (history && history.replaceState && history.pushState);
 }

--- a/app/assets/javascripts/start-now-button-abc-tests.js
+++ b/app/assets/javascripts/start-now-button-abc-tests.js
@@ -1,0 +1,45 @@
+//= require govuk/multivariate-test
+
+$(function(){
+  if(window.location.href.indexOf("/overseas-passports") > -1) {
+    new GOVUK.MultivariateTest({
+      el: '.get-started a',
+      name: 'startButton_osPassport_201602',
+      customDimensionIndex: 13,
+      contentExperimentId: 'egf8SiUzQJmsUuEIbxkCRw',
+      cohorts: {
+        original: { callback: function() {}, variantId: 0 },
+        getApplicationInfo: { html: 'Get application information', variantId: 1 },
+        next: { html: 'Next', variantId: 2 }
+      }
+    });
+  }
+
+  if(window.location.href.indexOf("/calculate-your-child-maintenance") > -1) {
+    new GOVUK.MultivariateTest({
+      el: '.get-started a',
+      name: 'startButton_calcChildM_201602',
+      customDimensionIndex: 13,
+      contentExperimentId: 'u0MzUmYRRzmb5mchoGp9Fw',
+      cohorts: {
+        original: { callback: function() {}, variantId: 0 },
+        calculate: { html: 'Calculate', variantId: 1 },
+        estimateChildMaintenance: { html: 'Estimate your child maintenance', variantId: 2 }
+      }
+    });
+  }
+
+  if(window.location.href.indexOf("/marriage-abroad") > -1) {
+    new GOVUK.MultivariateTest({
+      el: '.get-started a',
+      name: 'startButton_marriageAbroad_201602',
+      customDimensionIndex: 13,
+      contentExperimentId: 'Xk_FTKgiTwikoIH0fzPklw',
+      cohorts: {
+        original: { callback: function() {}, variantId: 0 },
+        findOutHow: { html: 'Find out how', variantId: 1 },
+        getMoreInfo: { html: 'Get more information', variantId: 2 }
+      }
+    });
+  }
+});


### PR DESCRIPTION
Reverts alphagov/smart-answers#2337

For https://trello.com/c/KbYQzkNV/351-run-start-now-button-test-again-1

We ran a multivariate test for 'start now' buttons on 3 start pages (https://trello.com/c/GYqg2EEj) which was merged March 8 2016.

We want to run the test again to increase our confidence that the improvement trends shown in the original test are valid, with the same options winning and with a similar scale if difference. The original test was our first experiment and some of the data seems odd, so a chance to cross check the results is valuable.

We want to run the test for at least 14 days so that we can easily compare the results with those from the original test.