### PR TITLE
Allow `RatesQuery` date to be set using environment variable

### DIFF
--- a/doc/factcheck.md
+++ b/doc/factcheck.md
@@ -20,6 +20,16 @@ Once deployed you'll need to use the standard `git push` mechanism to deploy you
 ./startup_heroku.sh
 ```
 
+### Displaying rates for a specific date
+
+The `RatesQuery` object is responsible for looking up the correct rates (in lib/data/rates) to display. By default, it'll lookup the rates for today but that can be overridden by setting the `RATES_QUERY_DATE` environment variable.
+
+This is useful for previewing future rates on Heroku, e.g. when rates are being changed in the new tax year.
+
+```bash
+$ heroku config:set RATES_QUERY_DATE=<yyyy-mm-dd>
+```
+
 ## Historical v2 workflow
 
 __This is for reference only. This method is no longer used.__

--- a/lib/smart_answer/calculators/married_couples_allowance_calculator.rb
+++ b/lib/smart_answer/calculators/married_couples_allowance_calculator.rb
@@ -62,7 +62,7 @@ module SmartAnswer::Calculators
     end
 
     def rates
-      @rates ||= SmartAnswer::Calculators::RatesQuery.new('married_couples_allowance').rates
+      @rates ||= SmartAnswer::Calculators::RatesQuery.from_file('married_couples_allowance').rates
     end
   end
 end

--- a/lib/smart_answer/calculators/maternity_paternity_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator.rb
@@ -93,11 +93,11 @@ module SmartAnswer::Calculators
 
 
     def lower_earning_limit_birth
-      RatesQuery.new('maternity_paternity_birth').rates(@qualifying_week.last).lower_earning_limit_rate
+      RatesQuery.from_file('maternity_paternity_birth').rates(@qualifying_week.last).lower_earning_limit_rate
     end
 
     def lower_earning_limit_adoption
-      RatesQuery.new('maternity_paternity_adoption').rates(@qualifying_week.last).lower_earning_limit_rate
+      RatesQuery.from_file('maternity_paternity_adoption').rates(@qualifying_week.last).lower_earning_limit_rate
     end
 
     def lower_earning_limit

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -14,13 +14,20 @@ module SmartAnswer::Calculators
     end
 
     def rates(date = nil)
-      date = date || Date.today
+      date = date || date_from_environment_variable || Date.today
       relevant_rates = data.find do |rates_hash|
         rates_hash[:start_date] <= date && rates_hash[:end_date] >= date
       end
       relevant_rates ||= data.last
 
       OpenStruct.new(relevant_rates)
+    end
+
+  private
+
+    def date_from_environment_variable
+      return nil if ENV['RATES_QUERY_DATE'].blank?
+      Date.parse(ENV['RATES_QUERY_DATE'])
     end
   end
 end

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -1,6 +1,9 @@
 module SmartAnswer::Calculators
   class RatesQuery
-    def initialize(rates_filename)
+    attr_reader :load_path
+
+    def initialize(rates_filename, load_path: nil)
+      @load_path = load_path || File.join("lib", "data", "rates")
       @rates_filename = rates_filename
     end
 
@@ -14,10 +17,6 @@ module SmartAnswer::Calculators
     end
 
   private
-
-    def load_path
-      @load_path ||= File.join("lib", "data", "rates")
-    end
 
     def data
       @data ||= YAML.load_file(Rails.root.join(load_path, "#{@rates_filename}.yml")).map(&:with_indifferent_access)

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -1,14 +1,16 @@
 module SmartAnswer::Calculators
   class RatesQuery
     def self.from_file(rates_filename, load_path: nil)
-      new(rates_filename, load_path: load_path)
+      load_path ||= File.join("lib", "data", "rates")
+      rates_data_path = Rails.root.join(load_path, "#{rates_filename}.yml")
+      rates_data = YAML.load_file(rates_data_path).map(&:with_indifferent_access)
+      new(rates_data)
     end
 
-    attr_reader :load_path
+    attr_reader :data
 
-    def initialize(rates_filename, load_path: nil)
-      @load_path = load_path || File.join("lib", "data", "rates")
-      @rates_filename = rates_filename
+    def initialize(rates_data)
+      @data = rates_data
     end
 
     def rates(relevant_date = Date.today)
@@ -18,12 +20,6 @@ module SmartAnswer::Calculators
       relevant_rates ||= data.last
 
       OpenStruct.new(relevant_rates)
-    end
-
-  private
-
-    def data
-      @data ||= YAML.load_file(Rails.root.join(load_path, "#{@rates_filename}.yml")).map(&:with_indifferent_access)
     end
   end
 end

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -13,9 +13,9 @@ module SmartAnswer::Calculators
       @data = rates_data
     end
 
-    def rates(relevant_date = Date.today)
+    def rates(date = Date.today)
       relevant_rates = data.find do |rates_hash|
-        rates_hash[:start_date] <= relevant_date && rates_hash[:end_date] >= relevant_date
+        rates_hash[:start_date] <= date && rates_hash[:end_date] >= date
       end
       relevant_rates ||= data.last
 

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -13,7 +13,8 @@ module SmartAnswer::Calculators
       @data = rates_data
     end
 
-    def rates(date = Date.today)
+    def rates(date = nil)
+      date = date || Date.today
       relevant_rates = data.find do |rates_hash|
         rates_hash[:start_date] <= date && rates_hash[:end_date] >= date
       end

--- a/lib/smart_answer/calculators/rates_query.rb
+++ b/lib/smart_answer/calculators/rates_query.rb
@@ -1,5 +1,9 @@
 module SmartAnswer::Calculators
   class RatesQuery
+    def self.from_file(rates_filename, load_path: nil)
+      new(rates_filename, load_path: load_path)
+    end
+
     attr_reader :load_path
 
     def initialize(rates_filename, load_path: nil)

--- a/lib/smart_answer/calculators/redundancy_calculator.rb
+++ b/lib/smart_answer/calculators/redundancy_calculator.rb
@@ -33,11 +33,11 @@ module SmartAnswer::Calculators
     end
 
     def self.redundancy_rates(date)
-      RatesQuery.new('redundancy_pay').rates(date)
+      RatesQuery.from_file('redundancy_pay').rates(date)
     end
 
     def self.northern_ireland_redundancy_rates(date)
-      RatesQuery.new('redundancy_pay_northern_ireland').rates(date)
+      RatesQuery.from_file('redundancy_pay_northern_ireland').rates(date)
     end
   end
 end

--- a/lib/smart_answer/calculators/registrations_data_query.rb
+++ b/lib/smart_answer/calculators/registrations_data_query.rb
@@ -81,7 +81,7 @@ module SmartAnswer::Calculators
     end
 
     def document_return_fees
-      SmartAnswer::Calculators::RatesQuery.new('births_and_deaths_document_return_fees').rates
+      SmartAnswer::Calculators::RatesQuery.from_file('births_and_deaths_document_return_fees').rates
     end
 
     def self.registration_data

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -160,7 +160,7 @@ module SmartAnswer
 
       # define as static so we don't have to instantiate the calculator too early in the flow
       def self.lower_earning_limit_on(date)
-        SmartAnswer::Calculators::RatesQuery.new('statutory_sick_pay').rates(date).lower_earning_limit_rate
+        SmartAnswer::Calculators::RatesQuery.from_file('statutory_sick_pay').rates(date).lower_earning_limit_rate
       end
 
       def self.months_between(start_date, end_date)
@@ -256,7 +256,7 @@ module SmartAnswer
     private
 
       def weekly_rate_on(date)
-        SmartAnswer::Calculators::RatesQuery.new('statutory_sick_pay').rates(date).ssp_weekly_rate
+        SmartAnswer::Calculators::RatesQuery.from_file('statutory_sick_pay').rates(date).ssp_weekly_rate
       end
 
       def max_days_that_can_be_paid

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -21,7 +21,7 @@ module SmartAnswer
         end
 
         calculate :age_related_allowance_chooser do
-          rates = SmartAnswer::Calculators::RatesQuery.new('married_couples_allowance').rates
+          rates = SmartAnswer::Calculators::RatesQuery.from_file('married_couples_allowance').rates
           AgeRelatedAllowanceChooser.new(
             personal_allowance: rates.personal_allowance,
             over_65_allowance: rates.over_65_allowance,

--- a/lib/smart_answer_flows/state-pension-through-partner.rb
+++ b/lib/smart_answer_flows/state-pension-through-partner.rb
@@ -30,11 +30,11 @@ module SmartAnswer
         end
 
         calculate :lower_basic_state_pension_rate do
-          rate = SmartAnswer::Calculators::RatesQuery.new('state_pension').rates.lower_weekly_rate
+          rate = SmartAnswer::Calculators::RatesQuery.from_file('state_pension').rates.lower_weekly_rate
           "£#{rate}"
         end
         calculate :higher_basic_state_pension_rate do
-          rate = SmartAnswer::Calculators::RatesQuery.new('state_pension').rates.weekly_rate
+          rate = SmartAnswer::Calculators::RatesQuery.from_file('state_pension').rates.weekly_rate
           "£#{rate}"
         end
 

--- a/test/data/calculate-employee-redundancy-pay-files.yml
+++ b/test/data/calculate-employee-redundancy-pay-files.yml
@@ -10,6 +10,6 @@ lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/date_of_redun
 lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/weekly_pay_before_tax.govspeak.erb: 805f2283eecf730779d648b2998db59f
 lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/years_employed.govspeak.erb: 6840413403d9331d79e3b60f04d244a9
 lib/smart_answer_flows/shared_logic/redundancy_pay.rb: 04f4009e5e4bf1620356825f67cdb7e0
-lib/smart_answer/calculators/redundancy_calculator.rb: 6f97d315c840f829670f64e2fabce6dd
+lib/smart_answer/calculators/redundancy_calculator.rb: 1fe3bafe5d283d97f1f3406e0bf56b4e
 lib/data/rates/redundancy_pay.yml: 270b43298e223b28ba7ad3f81f5e0a08
 lib/data/rates/redundancy_pay_northern_ireland.yml: 01a56e2760328e0213318050689f2556

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-married-couples-allowance.rb: 1fc12bbf0b4779a063ad26974cc041d5
+lib/smart_answer_flows/calculate-married-couples-allowance.rb: f9bf8da3b4b9e2966fabf91f6f2142cd
 test/data/calculate-married-couples-allowance-questions-and-responses.yml: 3cdcbf373de49fa6383b7dcb1967eb80
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3a6d219be3fceda5e5e091520ab5227f
 lib/smart_answer_flows/calculate-married-couples-allowance/calculate_married_couples_allowance.govspeak.erb: 2a107c5f5eccf492a1bbb055fb87ee2c
@@ -22,4 +22,4 @@ lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_h
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_husbands_date_of_birth.govspeak.erb: e4fc026bed0343ef3a2727da6c8ed30a
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/whats_the_husbands_income.govspeak.erb: dd71c9678c1f2b9eba3471151b2ba839
 lib/data/rates/married_couples_allowance.yml: 2a981979d28576078696119ea1938315
-lib/smart_answer/calculators/married_couples_allowance_calculator.rb: e1e66b360f09a5f3282348151e7ffdfd
+lib/smart_answer/calculators/married_couples_allowance_calculator.rb: 5933b68549cee3305ea4c9c589b37f29

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -29,5 +29,5 @@ lib/smart_answer_flows/calculate-statutory-sick-pay/questions/pay_amount_if_not_
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_before_sick_period.govspeak.erb: 46ce81328d55d2bef88bb1047cf047cd
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.govspeak.erb: 77831bed05434968d38648a40d3ce6e9
 lib/smart_answer_flows/calculate-statutory-sick-pay/questions/usual_work_days.govspeak.erb: 5570b649de33ac95bf274bcae70895a9
-lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: 721d60e221806043c9e4acacc39409c9
+lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: e9d02e8ed9aea95c76b2d477af9c78f7
 lib/data/rates/statutory_sick_pay.yml: de2d34118e3016d1137c394745d33280

--- a/test/data/calculate-your-redundancy-pay-files.yml
+++ b/test/data/calculate-your-redundancy-pay-files.yml
@@ -10,6 +10,6 @@ lib/smart_answer_flows/calculate-your-redundancy-pay/questions/date_of_redundanc
 lib/smart_answer_flows/calculate-your-redundancy-pay/questions/weekly_pay_before_tax.govspeak.erb: 9662fd7b09d3722850ede311bf27b844
 lib/smart_answer_flows/calculate-your-redundancy-pay/questions/years_employed.govspeak.erb: 6bf4ef75048732fab207104b21cdc6e6
 lib/smart_answer_flows/shared_logic/redundancy_pay.rb: 04f4009e5e4bf1620356825f67cdb7e0
-lib/smart_answer/calculators/redundancy_calculator.rb: 6f97d315c840f829670f64e2fabce6dd
+lib/smart_answer/calculators/redundancy_calculator.rb: 1fe3bafe5d283d97f1f3406e0bf56b4e
 lib/data/rates/redundancy_pay.yml: 270b43298e223b28ba7ad3f81f5e0a08
 lib/data/rates/redundancy_pay_northern_ireland.yml: 01a56e2760328e0213318050689f2556

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -145,4 +145,4 @@ lib/smart_answer/calculators/marriage_abroad_calculator.rb: 6329b517874ecf732cf3
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: e224243b2aa50c3c89d68515b16106f7
 lib/smart_answer/calculators/country_name_formatter.rb: c11e2762e225f0800e770728fb6ad474
-lib/smart_answer/calculators/registrations_data_query.rb: 563c5db7d7272bc07bd636a92b40f3ce
+lib/smart_answer/calculators/registrations_data_query.rb: 9c45bdaf4080cef1b8326db428119bfb

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -73,6 +73,6 @@ lib/smart_answer_flows/maternity-paternity-calculator/questions/which_week_in_mo
 lib/smart_answer_flows/shared_logic/adoption-calculator.rb: 022dbc4053c89002b652506378fdcdf3
 lib/smart_answer_flows/shared_logic/maternity-calculator.rb: 0c248c921668eb519524fb3dbfb24b77
 lib/smart_answer_flows/shared_logic/paternity-calculator.rb: 42fddc7f33ee8aadbc0eca4bd56f774b
-lib/smart_answer/calculators/maternity_paternity_calculator.rb: 24de99189c23e9a7cc048871a817bb3c
+lib/smart_answer/calculators/maternity_paternity_calculator.rb: def054503513f72d77a21fc12bf2bfc6
 lib/data/rates/maternity_paternity_birth.yml: 3eef956f1020576a9343647fec34dd01
 lib/data/rates/maternity_paternity_adoption.yml: 453c4d90b6fd9ffe1556782665f313fc

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -23,7 +23,7 @@ lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b5
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/data/registrations.yml: 2eb5c61678f21bd9cc06af67c230279f
 lib/smart_answer/calculators/country_name_formatter.rb: c11e2762e225f0800e770728fb6ad474
-lib/smart_answer/calculators/registrations_data_query.rb: 563c5db7d7272bc07bd636a92b40f3ce
+lib/smart_answer/calculators/registrations_data_query.rb: 9c45bdaf4080cef1b8326db428119bfb
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029
 test/fixtures/worldwide/afghanistan_organisations.json: 1fd89b60eb079c7b3fddcab985f37366

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -20,7 +20,7 @@ lib/smart_answer_flows/shared/births_and_deaths_registration/_button.govspeak.er
 lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 test/fixtures/worldwide/italy_organisations.json: dc5feb424edeeb12835be916605caf46
-lib/smart_answer/calculators/registrations_data_query.rb: 563c5db7d7272bc07bd636a92b40f3ce
+lib/smart_answer/calculators/registrations_data_query.rb: 9c45bdaf4080cef1b8326db428119bfb
 lib/smart_answer/calculators/country_name_formatter.rb: c11e2762e225f0800e770728fb6ad474
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029

--- a/test/data/state-pension-through-partner-files.yml
+++ b/test/data/state-pension-through-partner-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/state-pension-through-partner.rb: 7bbbf44609e203688f3e81cebab2f7c7
+lib/smart_answer_flows/state-pension-through-partner.rb: cd439166832bc37012cfff424f012810
 test/data/state-pension-through-partner-questions-and-responses.yml: 256f0f1136d388a674a0732173da6c1a
 test/data/state-pension-through-partner-responses-and-expected-results.yml: fcf56e5687c592c8693f62f529bc939e
 lib/smart_answer_flows/state-pension-through-partner/outcomes/_increase_retirement_income.govspeak.erb: 2391bf6e80d1aa4d0d4258030b4f4e00

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -29,10 +29,10 @@ module SmartAnswer::Calculators
           setup do
             load_path = File.join("test", "fixtures", "rates")
             @test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
-            @test_rate.rates(Date.parse('2013-01-31')).rate
           end
 
           should 'return the correct rate for a different date' do
+            assert_equal 1, @test_rate.rates(Date.parse('2013-01-31')).rate
             assert_equal 2, @test_rate.rates(Date.parse("2013-02-01")).rate
           end
         end

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -4,33 +4,24 @@ module SmartAnswer::Calculators
   class RatesQueryTest < ActiveSupport::TestCase
     context RatesQuery do
       context "#rates" do
-        should "be 1 for 2013-01-31" do
+        setup do
           load_path = File.join("test", "fixtures", "rates")
-          test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
+          @test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
+        end
 
-          assert_equal 1, test_rate.rates(Date.parse('2013-01-31')).rate
+        should "be 1 for 2013-01-31" do
+          assert_equal 1, @test_rate.rates(Date.parse('2013-01-31')).rate
         end
 
         should "be 2 for 2013-02-01" do
-          load_path = File.join("test", "fixtures", "rates")
-          test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
-
-          assert_equal 2, test_rate.rates(Date.parse('2013-02-01')).rate
+          assert_equal 2, @test_rate.rates(Date.parse('2013-02-01')).rate
         end
 
         should "be the latest known rate (2) for uncovered future dates" do
-          load_path = File.join("test", "fixtures", "rates")
-          test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
-
-          assert_equal 2, test_rate.rates(Date.parse('2113-03-12')).rate
+          assert_equal 2, @test_rate.rates(Date.parse('2113-03-12')).rate
         end
 
         context 'given a rate has been loaded for one date' do
-          setup do
-            load_path = File.join("test", "fixtures", "rates")
-            @test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
-          end
-
           should 'return the correct rate for a different date' do
             assert_equal 1, @test_rate.rates(Date.parse('2013-01-31')).rate
             assert_equal 2, @test_rate.rates(Date.parse("2013-02-01")).rate

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -32,7 +32,7 @@ module SmartAnswer::Calculators
           setup do
             today = Date.today
             @yesterday = today - 1.day
-            tomorrow = today + 1.day
+            @tomorrow = today + 1.day
 
             yesterdays_rates = {
               start_date: @yesterday,
@@ -45,8 +45,8 @@ module SmartAnswer::Calculators
               rate: 2
             }
             tomorrows_rates = {
-              start_date: tomorrow,
-              end_date: tomorrow,
+              start_date: @tomorrow,
+              end_date: @tomorrow,
               rate: 1
             }
             rates = [yesterdays_rates, todays_rates, tomorrows_rates]
@@ -55,6 +55,16 @@ module SmartAnswer::Calculators
 
           should "return rate for date specified when calling the method" do
             assert_equal 3, @rates_query.rates(@yesterday).rate
+          end
+
+          should "return rate for date specified in RATES_QUERY_DATE environment variable if set" do
+            begin
+              ENV['RATES_QUERY_DATE'] = @tomorrow.to_s
+
+              assert_equal 1, @rates_query.rates.rate
+            ensure
+              ENV['RATES_QUERY_DATE'] = nil
+            end
           end
 
           should "return rate for today when no date is specified" do

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -5,27 +5,30 @@ module SmartAnswer::Calculators
     context RatesQuery do
       context "#rates" do
         should "be 1 for 2013-01-31" do
-          test_rate = RatesQuery.new('exact_date_rates')
-          test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
+          load_path = File.join("test", "fixtures", "rates")
+          test_rate = RatesQuery.new('exact_date_rates', load_path: load_path)
+
           assert_equal 1, test_rate.rates(Date.parse('2013-01-31')).rate
         end
 
         should "be 2 for 2013-02-01" do
-          test_rate = RatesQuery.new('exact_date_rates')
-          test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
+          load_path = File.join("test", "fixtures", "rates")
+          test_rate = RatesQuery.new('exact_date_rates', load_path: load_path)
+
           assert_equal 2, test_rate.rates(Date.parse('2013-02-01')).rate
         end
 
         should "be the latest known rate (2) for uncovered future dates" do
-          test_rate = RatesQuery.new('exact_date_rates')
-          test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
+          load_path = File.join("test", "fixtures", "rates")
+          test_rate = RatesQuery.new('exact_date_rates', load_path: load_path)
+
           assert_equal 2, test_rate.rates(Date.parse('2113-03-12')).rate
         end
 
         context 'given a rate has been loaded for one date' do
           setup do
-            @test_rate = RatesQuery.new('exact_date_rates')
-            @test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
+            load_path = File.join("test", "fixtures", "rates")
+            @test_rate = RatesQuery.new('exact_date_rates', load_path: load_path)
             @test_rate.rates(Date.parse('2013-01-31')).rate
           end
 

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -2,29 +2,29 @@ require_relative "../../test_helper"
 
 module SmartAnswer::Calculators
   class RatesQueryTest < ActiveSupport::TestCase
-    context SmartAnswer::Calculators::RatesQuery do
+    context RatesQuery do
       context "#rates" do
         should "be 1 for 2013-01-31" do
-          test_rate = SmartAnswer::Calculators::RatesQuery.new('exact_date_rates')
+          test_rate = RatesQuery.new('exact_date_rates')
           test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
           assert_equal 1, test_rate.rates(Date.parse('2013-01-31')).rate
         end
 
         should "be 2 for 2013-02-01" do
-          test_rate = SmartAnswer::Calculators::RatesQuery.new('exact_date_rates')
+          test_rate = RatesQuery.new('exact_date_rates')
           test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
           assert_equal 2, test_rate.rates(Date.parse('2013-02-01')).rate
         end
 
         should "be the latest known rate (2) for uncovered future dates" do
-          test_rate = SmartAnswer::Calculators::RatesQuery.new('exact_date_rates')
+          test_rate = RatesQuery.new('exact_date_rates')
           test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
           assert_equal 2, test_rate.rates(Date.parse('2113-03-12')).rate
         end
 
         context 'given a rate has been loaded for one date' do
           setup do
-            @test_rate = SmartAnswer::Calculators::RatesQuery.new('exact_date_rates')
+            @test_rate = RatesQuery.new('exact_date_rates')
             @test_rate.stubs(:load_path).returns(File.join("test", "fixtures", "rates"))
             @test_rate.rates(Date.parse('2013-01-31')).rate
           end
@@ -37,7 +37,7 @@ module SmartAnswer::Calculators
 
       context "Married couples allowance" do
         setup do
-          @query = SmartAnswer::Calculators::RatesQuery.new('married_couples_allowance')
+          @query = RatesQuery.new('married_couples_allowance')
         end
 
         should "have all required rates defined for the current fiscal year" do

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -27,6 +27,40 @@ module SmartAnswer::Calculators
             assert_equal 2, @test_rate.rates(Date.parse("2013-02-01")).rate
           end
         end
+
+        context 'with various dates' do
+          setup do
+            today = Date.today
+            @yesterday = today - 1.day
+            tomorrow = today + 1.day
+
+            yesterdays_rates = {
+              start_date: @yesterday,
+              end_date: @yesterday,
+              rate: 3
+            }
+            todays_rates = {
+              start_date: today,
+              end_date: today,
+              rate: 2
+            }
+            tomorrows_rates = {
+              start_date: tomorrow,
+              end_date: tomorrow,
+              rate: 1
+            }
+            rates = [yesterdays_rates, todays_rates, tomorrows_rates]
+            @rates_query = RatesQuery.new(rates)
+          end
+
+          should "return rate for date specified when calling the method" do
+            assert_equal 3, @rates_query.rates(@yesterday).rate
+          end
+
+          should "return rate for today when no date is specified" do
+            assert_equal 2, @rates_query.rates.rate
+          end
+        end
       end
 
       context "Married couples allowance" do

--- a/test/unit/calculators/rates_query_test.rb
+++ b/test/unit/calculators/rates_query_test.rb
@@ -6,21 +6,21 @@ module SmartAnswer::Calculators
       context "#rates" do
         should "be 1 for 2013-01-31" do
           load_path = File.join("test", "fixtures", "rates")
-          test_rate = RatesQuery.new('exact_date_rates', load_path: load_path)
+          test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
 
           assert_equal 1, test_rate.rates(Date.parse('2013-01-31')).rate
         end
 
         should "be 2 for 2013-02-01" do
           load_path = File.join("test", "fixtures", "rates")
-          test_rate = RatesQuery.new('exact_date_rates', load_path: load_path)
+          test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
 
           assert_equal 2, test_rate.rates(Date.parse('2013-02-01')).rate
         end
 
         should "be the latest known rate (2) for uncovered future dates" do
           load_path = File.join("test", "fixtures", "rates")
-          test_rate = RatesQuery.new('exact_date_rates', load_path: load_path)
+          test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
 
           assert_equal 2, test_rate.rates(Date.parse('2113-03-12')).rate
         end
@@ -28,7 +28,7 @@ module SmartAnswer::Calculators
         context 'given a rate has been loaded for one date' do
           setup do
             load_path = File.join("test", "fixtures", "rates")
-            @test_rate = RatesQuery.new('exact_date_rates', load_path: load_path)
+            @test_rate = RatesQuery.from_file('exact_date_rates', load_path: load_path)
             @test_rate.rates(Date.parse('2013-01-31')).rate
           end
 
@@ -40,7 +40,7 @@ module SmartAnswer::Calculators
 
       context "Married couples allowance" do
         setup do
-          @query = RatesQuery.new('married_couples_allowance')
+          @query = RatesQuery.from_file('married_couples_allowance')
         end
 
         should "have all required rates defined for the current fiscal year" do


### PR DESCRIPTION
This will allow us to deploy rates changes to Heroku and ask someone from the content team/department to factcheck the changes. This was previously hard because the `RatesQuery` defaulted to today's date.

This was [suggested by @floehopper in a comment on the Trello card about updating the rates for register-a-birth][trello-comment].

I tested that this was working as expected by setting the `RATES_QUERY_DATE` environment variable and viewing an outcome for the register-a-birth Smart Answer.

## Before

    $ rails s
    $ open http://localhost:3000/register-a-birth/y/afghanistan/mother/yes/same_country#pay

![pr-2412-before](https://cloud.githubusercontent.com/assets/6556/14137089/a928920a-f6c2-11e5-9ddb-76b768f2495d.png)

Observe that it's displaying the latest rates available in [births_and_deaths_document_return_fees.yml][births-and-deaths-rates].

## After

    $ RATES_QUERY_DATE=2015-07-30 rails s
    $ open http://localhost:3000/register-a-birth/y/afghanistan/mother/yes/same_country#pay

![pr-2412-after](https://cloud.githubusercontent.com/assets/6556/14137095/ad56a6aa-f6c2-11e5-9705-5371f88823d3.png)

Observe that it's displaying the earlier rates available in [births_and_deaths_document_return_fees.yml][births-and-deaths-rates].

[births-and-deaths-rates]: https://github.com/alphagov/smart-answers/blob/master/lib/data/rates/births_and_deaths_document_return_fees.yml
[trello-comment]: https://trello.com/c/NNHVAmHF/72-register-a-birth-abroad-update-to-fees-on-6-april-2016-content-change-request#comment-56fa5dc838521db45b367f6f