### PR TITLE
Add a missing link to a referenced commit

### DIFF
--- a/doc/creating-a-new-smart-answer.md
+++ b/doc/creating-a-new-smart-answer.md
@@ -21,7 +21,7 @@ module SmartAnswer
       value_question :question_1? do
         next_node do
           outcome :outcome_1
-        end:
+        end
       end
 
       outcome :outcome_1

--- a/doc/refactoring.md
+++ b/doc/refactoring.md
@@ -6,7 +6,7 @@ These concerns should really be split. Routing belongs in the flow, policy/calcu
 
 We've refactored a small number of these Smart Answers and have a rough set of steps that we follow:
 
-* Remove unused code from the flow, e.g. unused `save_input_as`, `precalculate` or `calculate` blocks. See commit fe4014d7c007108f3daa07f1c5dd749f5de683a0 for an example.
+* Remove unused code from the flow, e.g. unused `save_input_as`, `precalculate` or `calculate` blocks. See commit [fe4014d7c007108f3daa07f1c5dd749f5de683a0](https://github.com/alphagov/smart-answers/commit/fe4014d7c007108f3daa07f1c5dd749f5de683a0) for an example.
 
 * Include `ActiveModel::Model` in the calculator so that it's easy to instantiate it with a number of attributes set. See commit [f78671a062339ae97abb5cb267b55536233316c9](https://github.com/alphagov/smart-answers/commit/f78671a062339ae97abb5cb267b55536233316c9) for an example.
 


### PR DESCRIPTION
PR [2416](https://github.com/alphagov/smart-answers/pull/2416) added links to all of the commits referenced in the instructions. One link was missed.

Also fix a syntax error in the example code in the "Creating a new flow" instructions.