### PR TITLE
Update links to Jenkins and add links to github repos in READMEs

### DIFF
--- a/doc/archiving.md
+++ b/doc/archiving.md
@@ -9,8 +9,9 @@ If a flow needs to be removed urgently then it be can archived quickly by changi
 Once a flow has been removed the artefact will no longer register itself when the Smart Answers application is released.
 
 You will then need to:
-1. Archive the artefact in Panopticon (same process as other types of content)
-2. Add a redirect `router-data` for the artefact slub. This should be a `prefix` route, so all parts of the Smart Answer URL are matched and preserved. ([This is a good example](https://github.gds/gds/router-data/blob/master/data/slug-changes.csv#L623))
+
+1. Archive the artefact in [Panopticon](https://github.com/alphagov/panopticon) (same process as other types of content)
+2. Add a redirect in [router-data](https://github.gds/gds/router-data) for the artefact slug. This should be a `prefix` route, so all parts of the Smart Answer URL are matched and preserved. ([This is a good example](https://github.gds/gds/router-data/blob/master/data/slug-changes.csv#L623))
 
 ## Flow file naming convention
 

--- a/doc/continuous-integration.md
+++ b/doc/continuous-integration.md
@@ -2,7 +2,7 @@
 
 ## Main
 
-The [govuk_smart_answers CI instance](https://ci-new.alphagov.co.uk/job/govuk_smart_answers/) is triggered by new commits on the `master` branch of the [GitHub repo](https://github.com/alphagov/smart-answers). It runs the [`jenkins.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins.sh) script with the `RUN_REGRESSION_TESTS` not set. This script does the following:
+The [govuk_smart_answers CI instance](https://ci.dev.publishing.service.gov.uk/job/govuk_smart_answers/) is triggered by new commits on the `master` branch of the [GitHub repo](https://github.com/alphagov/smart-answers). It runs the [`jenkins.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins.sh) script with the `RUN_REGRESSION_TESTS` not set. This script does the following:
 
 * Attempts to merge the current branch (`master`) into `master` - this should always succeed and is effectively a no-op
 * Checks out the latest [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas) which are used in a few of the tests
@@ -15,7 +15,7 @@ If any of these steps fails, the build fails-fast.
 
 ## Branches
 
-The [govuk_smartanswers_branches CI instance](https://ci-new.alphagov.co.uk/job/govuk_smartanswers_branches/) is triggered by new commits on other branches of the [GitHub repo](https://github.com/alphagov/smart-answers). It runs the [`jenkins_branches.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins_branches.sh) script with the `RUN_REGRESSION_TESTS` not set.
+The [govuk_smartanswers_branches CI instance](https://ci.dev.publishing.service.gov.uk/job/govuk_smartanswers_branches/) is triggered by new commits on other branches of the [GitHub repo](https://github.com/alphagov/smart-answers). It runs the [`jenkins_branches.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins_branches.sh) script with the `RUN_REGRESSION_TESTS` not set.
 
 This script calls the [`jenkins.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins.sh) script wrapping it in code which sends notifications to GitHub, so that the build status is displayed on [pull request pages](https://github.com/alphagov/smart-answers/pulls).
 
@@ -25,7 +25,7 @@ If the merge succeeds then the script continues as for the main CI instance.
 
 ## Regression
 
-The [govuk_smart_answers_regressions CI instance](https://ci-new.alphagov.co.uk/job/govuk_smart_answers_regressions/) is triggered periodically (currently every 2 hours). It runs the [`jenkins.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins.sh) script with the `RUN_REGRESSION_TESTS` set. This script does the following:
+The [govuk_smart_answers_regressions CI instance](https://ci.dev.publishing.service.gov.uk/job/govuk_smart_answers_regressions/) is triggered periodically (currently every 2 hours). It runs the [`jenkins.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins.sh) script with the `RUN_REGRESSION_TESTS` set. This script does the following:
 
 * Checks out the lastest [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas) which are used in a few of the tests
 * Installs the bundled gems

--- a/doc/deploying.md
+++ b/doc/deploying.md
@@ -2,13 +2,13 @@
 
 ## Integration
 
-This happens automatically as a post build action when the govuk_smart_answers build passes on CI.
+This happens automatically as a post build action when the [govuk_smart_answers](https://ci.dev.publishing.service.gov.uk/job/govuk_smart_answers/) build passes on CI.
 
 ### Manually
 
 If you have sufficient permissions, you can use the [Integration Deploy App](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/). Click the "Build with Parameters" link and enter "release" as the "TAG".
 
-If you do not have sufficient permissions, you can either kick the main CI build in Jenkins or commit & push something to the `master` branch.
+If you do not have sufficient permissions, you can either kick the [main CI build](continuous-integration.md#main) in Jenkins or commit & push something to the `master` branch.
 
 ## Production
 


### PR DESCRIPTION
Add links in the documentation to make it easier to find things referenced in documentation (e.g. Jenkins job and an application repositories).