### PR TITLE
Remove first sentence on the landing page for state-pension-through-partner

### DIFF
--- a/lib/smart_answer_flows/state-pension-through-partner/state_pension_through_partner.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/state_pension_through_partner.govspeak.erb
@@ -7,8 +7,6 @@
 <% end %>
 
 <% content_for :body do %>
-  The new State Pension will replace the current State Pension system (which includes [basic State Pension](/state-pension) and [Additional State Pension](/additional-state-pension)).
-
   The rules for how you can increase your State Pension and what you can inherit will be different depending on when you and your spouse or civil partner reach [State Pension age](/state-pension-age).
 
 

--- a/test/artefacts/state-pension-through-partner/state-pension-through-partner.txt
+++ b/test/artefacts/state-pension-through-partner/state-pension-through-partner.txt
@@ -1,7 +1,5 @@
 Your partner’s National Insurance record and your State Pension
 
-The new State Pension will replace the current State Pension system (which includes [basic State Pension](/state-pension) and [Additional State Pension](/additional-state-pension)).
-
 The rules for how you can increase your State Pension and what you can inherit will be different depending on when you and your spouse or civil partner reach [State Pension age](/state-pension-age).
 
 You’ll need to know when both you and your spouse or civil partner reach State Pension age to use this tool.

--- a/test/data/state-pension-through-partner-files.yml
+++ b/test/data/state-pension-through-partner-files.yml
@@ -16,5 +16,5 @@ lib/smart_answer_flows/state-pension-through-partner/questions/what_is_your_gend
 lib/smart_answer_flows/state-pension-through-partner/questions/what_is_your_marital_status.govspeak.erb: 86b0f4cdedffd735114360c21248ff05
 lib/smart_answer_flows/state-pension-through-partner/questions/when_will_you_reach_pension_age.govspeak.erb: 91c30ae0ee8202f5725fcf71f476babf
 lib/smart_answer_flows/state-pension-through-partner/questions/when_will_your_partner_reach_pension_age.govspeak.erb: d2f06f49adaa0f29f0c3ae9438dd55c7
-lib/smart_answer_flows/state-pension-through-partner/state_pension_through_partner.govspeak.erb: 41e4a83090d6e6626d0ec1042ea9fbbd
+lib/smart_answer_flows/state-pension-through-partner/state_pension_through_partner.govspeak.erb: e2cf8de591cf0cf42f296640eb1fe819
 lib/data/rates/state_pension.yml: 7e97e88500fb698038c49332b48b82bf


### PR DESCRIPTION
Trello story: https://trello.com/c/zlSaZmkf/73-6-april-text-change-only-your-partner-s-national-insurance-record-and-your-state-pension

## Factcheck
[Your partner’s National Insurance record and your State Pension](https://smart-answers-pr-2422.herokuapp.com/state-pension-through-partner)

## Expected Changes
* [URL on GOV.UK](https://www.gov.uk/state-pension-through-partner)
    * Delete the first sentence on Your partner’s National Insurance record and your State Pension landing page

### Before

![screen shot 2016-03-31 at 16 35 21](https://cloud.githubusercontent.com/assets/5793815/14181382/972478f2-f75e-11e5-8588-b8c830cfcae5.png)

### After

![screen shot 2016-03-31 at 16 36 02](https://cloud.githubusercontent.com/assets/5793815/14181412/b2e28e8a-f75e-11e5-82f0-2e4082bfdc00.png)
