### PR TITLE
Remove sentence on outcome page for calculate-statutory-sick-pay

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
@@ -27,7 +27,5 @@
 
   There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-  You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
   *[SSP]: Statutory Sick Pay
 <% end %>

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -15,8 +15,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -16,8 +16,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -29,8 +29,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -28,8 +28,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -23,8 +23,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -24,8 +24,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -19,8 +19,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -20,8 +20,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -33,8 +33,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -32,8 +32,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -21,8 +21,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -22,8 +22,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -17,8 +17,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2012-09-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -18,8 +18,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -31,8 +31,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/statutory_adoption_pay,statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-30/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -30,8 +30,6 @@ SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this 
 
 There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
 
-You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
 *[SSP]: Statutory Sick Pay
 
 

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -5,7 +5,7 @@ test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: b4251
 lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: f91dc1d321c164a06271889100875600
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/_esa.govspeak.erb: 660031398fda690ed7b3e2186ba64060
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/already_getting_maternity.govspeak.erb: 258fd4422c4ae665c83d5ee1e061bbff
-lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb: 9d83bb00f206964e9f493ea6657d2cba
+lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb: 8436f42c580dd7a7c2d22cfa9261c1a7
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/maximum_entitlement_reached.govspeak.erb: eb12d5290c873df20fd23ff9eb06c273
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/must_be_sick_for_4_days.govspeak.erb: 17b34a7463bcbbf7e2a5c417ec5452f9
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_earned_enough.govspeak.erb: 1e5cd1c6d99b6bd3145578416d62e7c5


### PR DESCRIPTION
Trello story: https://trello.com/c/MT3ZFvtQ/64-calculate-your-employee-s-statutory-sick-pay

## Factcheck

[Calculate your employee's statutory sick pay](https://smart-answers-pr-2427.herokuapp.com/calculate-statutory-sick-pay/y/none/yes/no/2016-03-03/2016-03-16/yes/2016-01-01/2016-02-07/eight_weeks_more/monthly/2015-12-30/2015-10-30/2000.0/1,2,3,4,5)

## Expected changes

* [URL on GOV.UK](https://www.gov.uk/calculate-statutory-sick-pay/y/none/yes/no/2016-03-03/2016-03-16/yes/2016-01-01/2016-02-07/eight_weeks_more/monthly/2015-12-30/2015-10-30/2000.0/1,2,3,4,5)
    * Remove line about claiming back sick pay from outcome page

### Before

![screen shot 2016-04-01 at 12 03 49](https://cloud.githubusercontent.com/assets/5793815/14205272/d6544e32-f801-11e5-970a-0f6c230c3db6.png)

### After

![screen shot 2016-04-01 at 12 04 47](https://cloud.githubusercontent.com/assets/5793815/14205292/f5a674a4-f801-11e5-8e23-9def3986aad7.png)
