### PR TITLE
Remove landing page bullet point item on maternity-paternity-calculator

### DIFF
--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
@@ -28,7 +28,6 @@
   You can’t use the calculator for:
 
   + births 15 weeks before the due date
-  + [Additional paternity Leave or Pay](/additional-paternity-leave-pay-employees)
   + paternity leave or pay for [overseas adoptions](/employers-paternity-pay-leave/adoption)
   + [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide)
 <% end %>

--- a/test/artefacts/maternity-paternity-calculator/maternity-paternity-calculator.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity-paternity-calculator.txt
@@ -19,7 +19,6 @@ You need:
 You can’t use the calculator for:
 
 + births 15 weeks before the due date
-+ [Additional paternity Leave or Pay](/additional-paternity-leave-pay-employees)
 + paternity leave or pay for [overseas adoptions](/employers-paternity-pay-leave/adoption)
 + [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide)
 

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/maternity-paternity-calculator.rb: 0f36ac59fd06f11925849319d7093e78
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 1bf0c803cd8e8a091417b0e1e19d2bd2
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: a59f6821dd5b949861ab6261840e58e4
-lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: c8c17c5f5e46a1b74cc8a6a2445486f7
+lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: c5bef53d847de83b21834222fbea4d58
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_must_be_on_payroll.govspeak.erb: e79accc3a0b6e9060fb3fbf9dd5848ad
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_must_earn_over_threshold.govspeak.erb: d2367c7b156a37e88a81061ce890503a
 lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_not_worked_long_enough.govspeak.erb: 08e6560e8927136f1f2899c4d0b1648f


### PR DESCRIPTION
Trello story: https://trello.com/c/HVcE1XFk/66-maternity-and-paternity-calculator-for-employers

## Factcheck

[Maternity and paternity calculator for employers](https://smart-answers-pr-2428.herokuapp.com/maternity-paternity-calculator)
## Expected changes

* [URL on GOV.UK](https://www.gov.uk/maternity-paternity-calculator)
    * Remove bullet point item from Maternity and paternity calculator for employers landing page

### Before

![screen shot 2016-04-01 at 13 50 01](https://cloud.githubusercontent.com/assets/5793815/14207220/a8683236-f810-11e5-9ebe-08e47475a782.png)

### After

![screen shot 2016-04-01 at 13 50 42](https://cloud.githubusercontent.com/assets/5793815/14207231/c181ac7a-f810-11e5-8b23-7805ae658280.png)
